### PR TITLE
feat(log): detailed interface-call logging via spdlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive   # spdlog lives in third_party/spdlog as a git submodule
 
       - name: Configure (CMake, VS 2022 x64)
         run: cmake --preset vs2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          submodules: recursive   # spdlog lives in third_party/spdlog as a git submodule
 
       - name: Configure (CMake, VS 2022 x64)
         run: cmake --preset vs2022

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/spdlog"]
+	path = third_party/spdlog
+	url = git@github.com:gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/spdlog"]
 	path = third_party/spdlog
-	url = git@github.com:gabime/spdlog.git
+	url = https://github.com/gabime/spdlog.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 WinAudio 是一个小巧的 Windows 音频测试工具，用于对系统音频设备做采集、播放等测试。
 
 **Phase 3 已完成。** 当前代码库包含 4 个项目：
-- **WinAudioCore**（`src/core`）：纯 C++ 静态库，零外部依赖（仅 Win32 + STL）；提供后端抽象（`IAudioBackend`）、设备枚举（`DeviceEnumerator`）、WASAPI-Shared/Exclusive 采集/播放、WAV 读写、环形缓冲区（RingBuffer）、引擎（Engine）、双流延迟监听（MonitorEngine、DelayFifo）、FFT 分析（Fft、SampleConvert、ScopeBuffer、Analysis）。
-- **WinAudioCli**（`src/cli`）：最小化命令行前端，支持 `list` / `capture` / `play` / `probe` / `monitor` 子命令。
+- **WinAudioCore**（`src/core`）：纯 C++ 静态库（外部依赖仅 spdlog header-only submodule + Win32 + STL）；提供后端抽象（`IAudioBackend`）、设备枚举（`DeviceEnumerator`）、WASAPI-Shared/Exclusive 采集/播放、WAV 读写、环形缓冲区（RingBuffer）、引擎（Engine）、双流延迟监听（MonitorEngine、DelayFifo）、FFT 分析（Fft、SampleConvert、ScopeBuffer、Analysis）、详细接口调用日志（`wa::log`，spdlog 封装）。
+- **WinAudioCli**（`src/cli`）：最小化命令行前端，支持 `list` / `capture` / `play` / `probe` / `monitor` 子命令；均支持 `--log-level <trace|debug|info|warn|err>` / `--log-file <path>`（日志走 stderr，默认 info）。
 - **WinAudioGui**（`src/gui`）：Dear ImGui + DX11 GUI 前端，为首选交互方式；**恒监听**（monitor-only），两列布局（左列：设备/控制/状态/日志；右列：采集/播放各一个"波形+声谱图"合并单元，共享时间轴、可拖拽重排），"同步播放" checkbox 实时控制 render 流。
 - **WinAudioTests**（`src/tests`）：gtest 单元测试套件，覆盖核心模块（RingBuffer、AudioFormat、WAV、FormatSpec、WasapiStream 辅助函数、Fft、SampleConvert、ScopeBuffer、DelayFifo、Analysis、MonitorEngine、Spectrogram）。
 
@@ -50,7 +50,7 @@ Phase 1 实现了 **WASAPI-Shared 采集/播放**；Phase 2 新增了 **WASAPI-E
 .\build.bat Release
 .\build.bat Release --clean
 
-# 运行测试（ctest，73 个）
+# 运行测试（ctest，78 个）
 .\test.bat Debug          # 或 .\test.bat Release
 # 也可直接跑测试 exe：
 .\build\bin\Debug\WinAudioTests.exe
@@ -153,6 +153,15 @@ cmake --build build --config Release -j
 - **COM 与线程安全**：`CoInitializeEx` 包装（RAII）；WASAPI 线程模型约定；原子操作与互斥锁。
 - **错误处理**：`Result` 类型，HRESULT 到 string 映射，用户友好报错。
 
+## 日志（详细接口调用日志）
+
+core 通过 `wa::log`（`src/core/Log.{h,cpp}`）——对 **spdlog**（`third_party/spdlog`，git submodule 固定 v1.15.3，header-only）的薄封装——记录**一切 WASAPI/COM/Win32 接口调用的参数与返回值**。`Result.h` 的「never prints」精神保留：core 不选输出目的地，由上层注册 sink；未注册 sink 时零输出。
+
+- **级别**：`Error / Warn / Info / Debug / Trace`，**默认 Info**，运行时可切。Info=生命周期（open/close/start/stop、选中设备、最终格式）；Debug=**所有控制路径调用**的参数+返回值（HRESULT 经 `hrName` 译成符号名，如 `AUDCLNT_E_DEVICE_INVALIDATED`）；Trace=音频热路径逐帧（`GetBuffer`/`ReleaseBuffer`/`GetCurrentPadding` 等）；Warn=可容忍异常 + 补齐现状被忽略的返回值。
+- **双路径 / 实时性**：控制路径同步记录；音频热路径经 spdlog async logger（`overrun_oldest` 非阻塞、队满丢最旧）。`emitTrace` 在音频线程**无堆分配**（inline stack buffer），但 spdlog async 队列 enqueue 会取一个**极短的 mpmc mutex 锁**——Trace 是诊断用途，开启时可能对被测音频有轻微扰动。
+- **输出（sink，可并存）**：`rotating_file_sink`（文件轮转）、stderr、自定义 callback（GUI 面板）。行格式 `时间戳 级别 [线程] Module::Call args:… ret:…`，线程短名 main/pump/capW/renW/cap/play。
+- **前端**：CLI `--log-level`/`--log-file`（日志走 stderr，与状态行 stdout 分离）；GUI 默认写 exe 目录 `winaudio.log` + 左栏日志面板（级别下拉运行时切、清空、自动滚动、5000 行环形上限）。
+- **插桩纯观测**：只读现有变量/HRESULT 记录，不改任何控制流/返回值/时序。
 ## 约定
 
 - 回答默认用中文；代码、命令、API 标识符等保持英文原文。

--- a/docs/superpowers/specs/2026-07-06-winaudio-verbose-logging-design.md
+++ b/docs/superpowers/specs/2026-07-06-winaudio-verbose-logging-design.md
@@ -1,0 +1,192 @@
+# WinAudio 详细接口调用日志设计
+
+**日期**: 2026-07-06
+**状态**: 待实现（brainstorming 定稿）
+
+## 目标
+
+为 WinAudio 增加**详细的接口调用日志**能力,让用户能通过日志看到一切接口调用(尤其 core 内部的 WASAPI/COM/Win32 API 调用)的**参数与返回值(HRESULT)**,并统一优化日志输出格式。核心理念 **"默认安静,一键详细"**:平时只记生命周期关键事件(info),需要排障时把级别切到 debug 即可看到所有控制路径接口调用的完整参数+返回值,再切到 trace 可逐帧审计音频热路径——而这一切**不破坏被测音频的实时性**。
+
+日志实现基于 **spdlog**(以 git submodule 固定版本引入),不自建日志后端。
+
+## 背景与现状痛点
+
+现状扫描结论(见附录 A 的调用点地图):
+
+- `src/core` 是一个**刻意"从不打印"的纯库**(`Result.h:7` 契约),约 **68 处** WASAPI/COM 调用点全部只把结果压进 `Result` 往上抛,其中 **~15 处连返回值都被直接忽略**(`GetBufferSize`/`GetDevicePeriod`/`Stop`/`ReleaseBuffer` 等)。
+- **没有 `hrToString`**:HRESULT 现在只显示成 `0x88890004` 裸十六进制,无可读符号名/描述(全代码库无 `FormatMessage`)。
+- **没有 `AudioFormat::toString()`**:格式参数在 4+ 处被手写重复格式化。
+- **没有任何日志级别/开关**。GUI 日志面板 `logLines_` 只有 3 处写入(`invalid format` / `monitor started` / `monitor stopped`)、只增不删、无时间戳;CLI 全靠 `printf`。
+
+即"想看接口调用细节根本无从看起"。本设计基于 spdlog 搭一套薄封装 + 全面插桩。
+
+## 为什么用 spdlog(选型依据)
+
+- **原生 async logger**:内置无锁 mpmc 队列 + 后台线程池。设 `overrun_oldest` 溢出策略后,日志调用**非阻塞**(队满丢最旧,不等待),音频线程可安全调用,不引发 xrun——直接替代自建的双路径前端队列。
+- **原生 `trace` 级别**:`trace/debug/info/warn/err/critical`,与本设计级别一一对应(log4cpp 无 trace)。
+- **现代 C++ / CMake 原生 / MSVC 友好**:`add_subdirectory` 即集成,可继承本项目 `CMAKE_MSVC_RUNTIME_LIBRARY`(`/MT`);作为 SYSTEM include 抑制第三方 `/W4` 告警。
+- **sink 生态**:`rotating_file_sink`(文件大小轮转,免自写)、自定义 sink 只需继承 `spdlog::sinks::base_sink<Mutex>`(GUI 面板用)。
+- **格式**:`set_pattern` 定制前缀 + fmt 格式化 payload。
+
+## 架构总览
+
+在 `src/core` 新增一层**基于 spdlog 的薄封装 `wa::log`**。它保留 `Result.h` "never prints" 的**精神**:core 不直接选择输出目的地,由上层通过 `wa::log` 注册 sink;未初始化/未加 sink 时不产生输出。`Result` 语义完全不变——日志是旁路的观测通道,不替代返回值。
+
+- **单一 async logger**(spdlog),挂多个 sink;**溢出策略 `overrun_oldest`(非阻塞)**。
+- **控制路径**(枚举/格式协商/`Initialize`/`Start`/`open`,低频):经 `wa::log` 同步入队 async logger。
+- **热路径**(音频线程 `GetBuffer`/`ReleaseBuffer`/`GetCurrentPadding`,trace 级):同样调 async logger,但因 `overrun_oldest` + 调用前 `should_log(trace)` 短路,**关 trace 时零开销、开 trace 时非阻塞无堆分配**(spdlog 用 stack buffer 格式化,payload < 250B 不堆分配)。后台线程池做实际 sink 写。
+- **不再自建 `RingBuffer` 日志队列**:spdlog async 队列即前端。
+
+## 范围
+
+### 目标(本次交付)
+
+- `third_party/spdlog` 作为 git submodule(固定版本);CMake 集成、`/MT` 继承、SYSTEM include。
+- core `wa::log` 封装:init async logger(`overrun_oldest`)、级别 get/set、sink 注册、`emit`/`emitTrace` 转发、`hrName`。
+- 三个 sink:`rotating_file_sink`(文件)、stderr sink(CLI)、自定义 GUI 面板 sink(继承 `base_sink`)。
+- `AudioFormat::toString()`。
+- 在 core 全部控制路径 WASAPI/COM 调用点插桩(debug)、音频热路径插桩(trace)、生命周期事件(info)、失败与被忽略返回值(err/warn)。
+- GUI:升级日志面板 + 级别下拉 + 默认写 `winaudio.log`。
+- CLI:`--log-level` / `--log-file` + 日志走 stderr。
+
+### 非目标(YAGNI)
+
+- 不自建日志后端/队列(交给 spdlog);不再考虑 log4cpp。
+- 不做**每 sink 独立级别**——全局单一 logger 级别,运行时可切。
+- 不做结构化 JSON 日志(已选对齐分栏文本格式)。
+- 不做日志的网络/远程传输、不做日志压缩。
+- 不改变现有 CLI stdout 行为(状态行、`caps` 表、设备列表照旧);日志是新增的 stderr 通道。
+
+## 日志级别与覆盖映射
+
+直接用 spdlog `level::{trace,debug,info,warn,err,critical}`,全局 logger 级别 **默认 `info`**。级别 X 生效时输出 ≥X 严重度。
+
+| 级别 | 记什么 | 典型调用点 |
+|---|---|---|
+| **err** | 调用失败(`FAILED(hr)`)、`Result::Fail` 的产生点 | `Initialize`/`Activate`/`Start`/`GetService` 失败 |
+| **warn** | 可容忍的异常与**现状被忽略的返回值** | `IsFormatSupported` 返回不支持、xrun 发生、`Stop`/`ReleaseBuffer`/`GetBufferSize`/`GetDevicePeriod` 非 S_OK、async 队列丢弃计数 |
+| **info** | 生命周期关键事件(普通用户看得懂的主线) | open/close、start/stop、选中设备(名字+id)、最终协商格式、后端模式 |
+| **debug** | **所有控制路径 WASAPI/COM 调用**的参数 + 返回值 | 附录 A 中 ~50 处非热路径调用点(枚举、`GetMixFormat`、`IsFormatSupported`、`Initialize` 各分支、`GetService`、`SetClientProperties`、`SetEventHandle`、`GetBufferSize`…) |
+| **trace** | 音频线程热路径逐帧 | `GetBuffer`/`ReleaseBuffer`/`GetCurrentPadding`/`GetNextPacketSize`/`WaitForSingleObject`(capture/render 循环) |
+
+**默认 info** = 面板/文件开箱只有关键事件,安静;把级别切到 debug 立刻看到一切接口调用参数+返回值(核心诉求);trace 再逐帧。
+
+## 日志行格式(对齐分栏)
+
+目标呈现(缩进即代码块):
+
+    12:34:56.789 INFO  [pump] WasapiStream::Initialize   args: mode=exclusive fmt=48000/16/2 buf=10.0ms flags=0x60000   ret: S_OK
+    12:34:56.792 ERROR [main] DeviceEnum::GetMixFormat                                                                   ret: 0x88890004 AUDCLNT_E_DEVICE_INVALIDATED
+    12:34:57.010 TRACE [capW] IAudioCaptureClient::GetBuffer                                                             ret: frames=480 flags=0x0
+
+- 前缀(时间戳/级别/线程)交给 spdlog `set_pattern`,例如 `%H:%M:%S.%e %^%-5l%$ [%t] %v`(`%e`=毫秒、`%-5l`=定宽级别、`%t`=线程、`%v`=payload;`%^%$` 让 GUI/console sink 上色)。
+- **线程标签**:spdlog `%t` 默认是数字线程 id;本设计给每线程注册**短名**(`main`/`pump`/`capW`/`renW`/`enum`),用自定义 flag 或在 payload 内呈现。各线程入口设置一次(漏设显示 `?`)。
+- **payload(`%v`)= `Module::Call` + 左对齐填充 + `args: …` + `ret: …`**,由调用点用 `AudioFormat::toString()` 等拼好(对齐由 payload 内固定列宽处理)。
+- **ret**:HRESULT 经 `hrName` → `S_OK` 或 `0x88890004 AUDCLNT_E_DEVICE_INVALIDATED`;输出型参数(如 `GetBuffer` 的 frames/flags)拼成 `frames=480 flags=0x0`。
+
+## core 日志层组件(新增 `src/core/Log.h` / `Log.cpp`)
+
+`wa::log` facade 草案(缩进即代码块):
+
+    namespace wa::log {
+
+    enum class Level { Trace, Debug, Info, Warn, Err };   // 映射 spdlog::level
+
+    // 初始化:建 async logger(overrun_oldest),挂已注册 sink;进程启动调用一次
+    void init();
+    void shutdown();                       // drain + spdlog::shutdown()
+
+    void  setLevel(Level lvl);             // 转 logger->set_level
+    Level level();
+    bool  shouldLog(Level lvl);            // 转 logger->should_log,热路径短路
+
+    // sink 注册(内部转 logger->sinks().push_back)
+    void addFileSink(const std::string& path, size_t maxBytes, size_t maxFiles);
+    void addStderrSink();
+    void addSink(spdlog::sink_ptr sink);   // GUI 自定义 sink
+
+    // 控制路径:同步记录(经宏 WA_LOG 短路级别后再拼 args/ret)
+    void emit(Level lvl, const char* module, const char* call,
+              std::string args, std::string ret);
+
+    // 热路径:音频线程调用;内部 should_log(trace) 短路 + 非阻塞入队
+    void emitTrace(const char* module, const char* call,
+                   unsigned frames, unsigned flags, long hr);
+
+    const char* hrName(long hr);           // HRESULT to 符号名
+
+    } // namespace wa::log
+
+- **payload 组装**:`emit`/`emitTrace` 内把 `Module::Call args ret` 拼成一行 payload,交 spdlog logger 按级别输出;前缀由 pattern 加。
+- **宏短路**:`WA_LOG(lvl, module, call, argsExpr, retExpr)` 先 `if (wa::log::shouldLog(lvl))` 再求值 `argsExpr`/`retExpr`,关级别不做无谓格式化。
+- **async 溢出**:logger 用 `spdlog::async_overflow_policy::overrun_oldest`,队满丢最旧且不阻塞;spdlog 自身统计丢弃,必要时周期性补一条 warn。
+- **时间戳**:spdlog `%e` 提供毫秒墙钟,无需自管。
+- **shutdown**:进程退出前 `wa::log::shutdown()` → drain 队列 + `spdlog::shutdown()`,避免丢尾部日志。
+
+### `hrName`(HRESULT to 可读)
+
+手写一张 WinAudio 会遇到的**常见码表**(硬编码,零依赖):`S_OK`、`S_FALSE`、`E_INVALIDARG`、`E_POINTER`、`E_NOINTERFACE`、`E_OUTOFMEMORY`、`RPC_E_CHANGED_MODE`、`AUDCLNT_E_*`(DEVICE_INVALIDATED / UNSUPPORTED_FORMAT / DEVICE_IN_USE / BUFFER_SIZE_NOT_ALIGNED / EXCLUSIVE_MODE_ONLY / NOT_INITIALIZED 等)、`AUDCLNT_S_*`。命中即返回符号名;未命中 fallback `FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM)` 取系统描述;再不行返回空(只留裸 hex)。
+
+### `AudioFormat::toString()`(新增)
+
+返回 `"48000/16/2"`(float 时 `"48000/32f/2"`),消除现状 CLI(`main.cpp:160/169`)、GUI(`AppUi.cpp:139-145/676-683/715-718/121-124`)4+ 处重复手写格式化,并供日志 args 统一使用。
+
+## 三个 sink 与前端集成
+
+- **文件 sink**:直接用 spdlog `rotating_file_sink_mt`(**大小轮转**,默认如 10 MB × 3 份)。GUI 默认 `winaudio.log`(exe 同目录,`GetModuleFileNameW` 定位)。
+- **GUI 面板 sink**:**自定义 `spdlog::sinks::base_sink<std::mutex>`**,`sink_it_` 里把 spdlog 格式化后的行推入 GUI 侧一个**加锁 pending 缓冲**,`AppUi::draw()` 每帧取出追加到 `logLines_`(**环形行数上限**、自动滚动、清空按钮、**级别下拉运行时切**);**绝不在音频线程碰 ImGui**(sink 运行在 spdlog 后台线程)。
+- **CLI stderr sink**:spdlog `stderr_color_sink_mt`(或普通 stderr sink),与现有 `\r` 状态行/表格(stdout)分离,便于 `2> log.txt`。参数 `--log-level <trace|debug|info|warn|err>`(默认 info)、`--log-file <path>`(给了才加 file sink)。
+- **GUI 默认**:启动 `wa::log::init()` 后 `addFileSink("winaudio.log", ...)` + GUI 面板 sink。
+
+## 全局约束(Global Constraints)
+
+- **依赖 spdlog(submodule 固定版本)**:`third_party/spdlog` 作 git submodule,pin 到指定 release tag 的 commit;CMake `add_subdirectory` 链 `spdlog::spdlog`;作为 SYSTEM include 抑制其 `/W4` 告警;继承本项目 `CMAKE_MSVC_RUNTIME_LIBRARY`(`/MT`)。除 spdlog 外 core 不引其它第三方。
+- **core 默认零输出**:未 `init`/未加 sink 时不产生 I/O;`Result` 语义与既有返回值行为**字节级不变**,日志纯旁路。
+- **插桩纯观测**:所有日志插桩只读取现有变量/参数/HRESULT 来记录,**不得改变任何现有控制流、返回值或时序**;"补齐被忽略的返回值"仅指捕获 hr 用于记录一条 warn,原有的继续/跳过/break 行为保持不变。
+- **音频线程绝不阻塞**:热路径经 async logger `overrun_oldest`(队满丢弃)+ `should_log` 短路;不加自定义锁、不在实时线程做 I/O。
+- **现有 CLI stdout 行为不变**:状态行、`caps` 表、设备列表照旧;日志只走 stderr。
+- **构建/质量**:C++17、静态 CRT(`/MT`)、本项目代码 `/W4` 零告警、Debug+Release 双配置;`build.bat`/`test.bat` 驱动;gtest 无硬件;GUI 存活验证。
+- **回答用中文**,代码/命令/API 标识符保持英文。
+
+## 错误处理与线程安全
+
+- 线程安全交给 spdlog(logger/sink 内部线程安全);`wa::log` 级别用 spdlog 原子级别。
+- GUI 面板 sink 的 pending 缓冲用一把轻锁,后台线程写、主线程读。
+- 文件 sink I/O 失败由 spdlog 处理(默认抛 spdlog 异常);`wa::log` 在 init/注册处捕获并降级为静默,**不得把日志错误反抛进 core 的 `Result`**。
+- 关闭顺序:停止音频流 → `wa::log::shutdown()`(drain + spdlog shutdown)。
+
+## 测试策略(gtest,无硬件)
+
+- 级别过滤:`setLevel` 后挂一个 fake sink(继承 `base_sink`),断言 `shouldLog()` 与实际收到的行级别集合正确。
+- `hrName`:常见码映射正确;未知码走 fallback 不崩。
+- `AudioFormat::toString`:int/float、单/双声道、各采样率的字符串正确;与旧手写输出等价。
+- payload 组装:给定 module/call/args/ret 产出对齐 payload(列宽正确)。
+- 非阻塞语义:async logger 设小队列 + `overrun_oldest`,高频写不阻塞、丢弃计数可观测(用 fake sink 计数)。
+- 多 sink 分发:挂 N 个 fake sink,一条 `emit` 每个都收到。
+- 沿用 `build.bat`/`test.bat` 双配置 + `/W4` 零告警(本项目代码)+ GUI 存活验证。
+
+## 风险与待定
+
+- **spdlog `/W4` 告警**:必须作为 SYSTEM include,否则本项目 `/W4` 零告警门槛会被第三方头污染。
+- **async 溢出丢日志**:`overrun_oldest` 下极高频 trace 可能丢最旧行(含偶发控制路径行);队列容量取足够大(如 8192),并让 spdlog 统计丢弃。可接受(trace 本就诊断用途)。
+- **线程短名**:spdlog `%t` 默认数字 id;需自定义 flag/registration 给 `main/pump/capW/renW` 短名,漏设显示 `?`。
+- **submodule 版本**:pin 到 spdlog 最新稳定 release tag(实现时确定确切版本号与 commit)。
+- **插桩工作量大**:~50 debug + ~15 warn 补齐 + 热路径 trace,分布在 `DeviceEnumerator.cpp`/`Engine.cpp`/`WasapiStream.cpp`/`MonitorEngine.cpp`。writing-plans 阶段按文件/子系统拆多任务。
+
+## 附录 A:现状调用点地图(供 writing-plans 拆任务)
+
+> core 里仅 4 个 .cpp 触及 COM/WASAPI:`DeviceEnumerator.cpp`、`Engine.cpp`、`WasapiStream.cpp`(重头)、`MonitorEngine.cpp`(仅 Win32 事件,设备调用全走 `IAudioBackend`)。`WavFile.cpp` 用 C stdio(非 COM)。现有错误处理两模式:(A) `if (FAILED(hr)) return HrToResult(hr,"where")`;(B) 包在 `SUCCEEDED(...)` 里,失败静默跳过——(B) 及"返回值忽略"处是 warn 补齐重点。
+
+- **`DeviceEnumerator.cpp`**(~29 处): `CoCreateInstance`、`GetDefaultAudioEndpoint`/`GetDevice`、`IMMDevice::GetId`/`OpenPropertyStore`/`Activate`、`IPropertyStore::GetValue`(FriendlyName/DeviceFormat/OEMFormat)、`GetMixFormat`、`EnumAudioEndpoints`、`IMMDeviceCollection::GetCount`(忽略)/`Item`、`IsFormatSupported`(能力矩阵探测)。
+- **`Engine.cpp`**(~6 处,`probeFormat`): `CoCreateInstance`、`GetDefaultAudioEndpoint`/`GetDevice`、`Activate`、`IsFormatSupported`(分类 S_OK/S_FALSE/失败)。
+- **`WasapiStream.cpp`**(~33 处,**重头**): `QueryInterface(IAudioClient2)`、`IsOffloadCapable`、`SetClientProperties`、`GetService(IAudioSessionControl/2)`、`SetDuckingPreference`、`Initialize`(shared-requested / shared-mix / exclusive / 重对齐)、`GetMixFormat`、`IsFormatSupported(EXCLUSIVE)`、`GetDevicePeriod`(忽略)、`GetBufferSize`(部分忽略)、`Activate`、`SetEventHandle`、`Start`、`Stop`(忽略)、`GetService(Capture/Render Client)`、`GetNextPacketSize`、`GetBuffer`/`ReleaseBuffer`(cap+ren,**热路径**)、`GetCurrentPadding`(**热路径**);Win32: `CreateEventW`/`CloseHandle`/`SetEvent`/`WaitForSingleObject`/`GetLastError`/`std::thread`。
+- **`MonitorEngine.cpp`**: 无直接 WASAPI;`ComInitGuard`、`WaitForSingleObject`/`SetEvent`;经 `IAudioBackend` 的 `open`/`start`/`stop`/`stats`/`dataReadyEvent`(高层入口,info/debug 该覆盖,每个内部展开成上面一串)。
+- **`ComUtil.h`**: `CoInitializeEx`/`CoUninitialize`(接受 `RPC_E_CHANGED_MODE`)。`HrToResult(hr,"where")` 现有 `where` 文案可复用为 debug 的 module/call 种子。
+
+## 附录 B:基础设施现状(复用点)
+
+- `Result{ok, code, message}`(`Result.h:9`);`HrToResult(hr, where)`(`ComUtil.h:24`,产出十六进制 Result,可作日志文案种子)。
+- `AudioFormat`(`AudioFormat.h:4`,缺 `toString()`);`toWaveFormatExtensible`/`fromWaveFormat` 已有。
+- GUI `logLines_`(`AppUi.h:36`,绘制 `AppUi.cpp:329-333`)——面板 sink 落点。
+- CLI 全 `printf`/`wprintf`(`cli/main.cpp`),`Result::message` 已在 7+ 处回显。
+- `third_party/`(已有 `implot` submodule 惯例)——`spdlog` submodule 落此。

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -8,6 +8,7 @@
 #include "FormatSpec.h"
 #include "MonitorEngine.h"
 #include "Capabilities.h"
+#include "Log.h"
 
 using namespace wa;
 
@@ -68,9 +69,30 @@ static bool formatArg(int argc, wchar_t** argv, AudioFormat& fmt) {
     return true;
 }
 
+struct LogShutdown { ~LogShutdown() { wa::log::shutdown(); } };
+
+// Logging: stderr sink always; optional --log-file; level from --log-level (default info).
+// stderr keeps the \r status lines (stdout) clean for redirection.
+static void initLogging(int argc, wchar_t** argv) {
+    wa::log::init();
+    wa::log::setThreadName("main");
+    wa::log::addStderrSink();
+    std::wstring lf = arg(argc, argv, L"--log-file");
+    if (!lf.empty()) wa::log::addFileSink(narrow(lf));
+    std::wstring lv = arg(argc, argv, L"--log-level");
+    wa::log::Level lvl = wa::log::Level::Info;
+    if      (lv == L"trace") lvl = wa::log::Level::Trace;
+    else if (lv == L"debug") lvl = wa::log::Level::Debug;
+    else if (lv == L"warn")  lvl = wa::log::Level::Warn;
+    else if (lv == L"err" || lv == L"error") lvl = wa::log::Level::Err;
+    wa::log::setLevel(lvl);
+}
+
 int wmain(int argc, wchar_t** argv) {
     if (argc < 2) { usage(); return 1; }
     ComInitGuard com;
+    LogShutdown logShutdownGuard;
+    initLogging(argc, argv);
     std::wstring cmd = argv[1];
 
     if (cmd == L"list") {

--- a/src/core/AudioFormatStr.h
+++ b/src/core/AudioFormatStr.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "AudioFormat.h"
+#include <string>
+
+namespace wa {
+
+// "48000/16/2" (integer PCM) or "48000/32f/2" (float). A free function rather
+// than a member so the vendored AudioFormat struct stays untouched; used by log
+// arguments and CLI/GUI display so the format string is written once.
+inline std::string formatAudio(const AudioFormat& f) {
+    return std::to_string(f.sampleRate) + "/" + std::to_string(f.bitsPerSample) +
+           (f.isFloat ? "f" : "") + "/" + std::to_string(f.channels);
+}
+
+// Narrow a wide device id/name to ASCII for log arguments. The explicit per-char
+// cast avoids the C4244 that std::string(w.begin(), w.end()) trips under /W4.
+inline std::string narrowAscii(const std::wstring& w) {
+    std::string s;
+    s.reserve(w.size());
+    for (wchar_t c : w) s += static_cast<char>(c);
+    return s;
+}
+
+} // namespace wa

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(WinAudioCore STATIC
     FormatSpec.cpp
     MonitorEngine.cpp
     Capabilities.cpp
+    Log.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32)
+target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 spdlog)
 wa_set_project_warnings(WinAudioCore)

--- a/src/core/DeviceEnumerator.cpp
+++ b/src/core/DeviceEnumerator.cpp
@@ -4,6 +4,8 @@
 #include <mmdeviceapi.h>
 #include <audioclient.h>
 #include <functiondiscoverykeys_devpkey.h>
+#include "Log.h"
+#include "AudioFormatStr.h"
 
 namespace wa {
 
@@ -14,7 +16,9 @@ EDataFlow toEDataFlow(DataFlow f) { return f == DataFlow::Capture ? eCapture : e
 bool readFormatKey(IPropertyStore* props, const PROPERTYKEY& key, AudioFormat& out) {
     PROPVARIANT pv; PropVariantInit(&pv);
     bool ok = false;
-    if (SUCCEEDED(props->GetValue(key, &pv)) && pv.vt == VT_BLOB &&
+    HRESULT gvHr = props->GetValue(key, &pv);
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IPropertyStore::GetValue", "key=format", ::wa::log::hrName(gvHr));
+    if (SUCCEEDED(gvHr) && pv.vt == VT_BLOB &&
         pv.blob.cbSize >= sizeof(WAVEFORMATEX) && pv.blob.pBlobData != nullptr) {
         const auto* wf = reinterpret_cast<const WAVEFORMATEX*>(pv.blob.pBlobData);
         if (wf->wFormatTag != WAVE_FORMAT_EXTENSIBLE ||
@@ -31,27 +35,51 @@ Result openDevice(DataFlow flow, const DeviceId& id, ComPtr<IMMDevice>& dev) {
     ComPtr<IMMDeviceEnumerator> e;
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
         __uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "CoCreateInstance");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+        return HrToResult(hr, "CoCreateInstance");
+    }
     const EDataFlow ef = (flow == DataFlow::Capture) ? eCapture : eRender;
     hr = id.empty() ? e->GetDefaultAudioEndpoint(ef, eConsole, dev.GetAddressOf())
                     : e->GetDevice(id.c_str(), dev.GetAddressOf());
-    if (FAILED(hr)) return HrToResult(hr, id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum",
+           id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+           id.empty() ? "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render")
+                      : "id=" + wa::narrowAscii(id),
+           ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum",
+               id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+               id.empty() ? "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render")
+                          : "id=" + wa::narrowAscii(id),
+               ::wa::log::hrName(hr));
+        return HrToResult(hr, id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice");
+    }
     return Result::Ok();
 }
 
 Result readInfo(IMMDevice* dev, DataFlow flow, bool isDefault, DeviceInfo& info) {
     LPWSTR idStr = nullptr;
     HRESULT hr = dev->GetId(&idStr);
-    if (FAILED(hr)) return HrToResult(hr, "IMMDevice::GetId");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::GetId", "", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IMMDevice::GetId", "", ::wa::log::hrName(hr));
+        return HrToResult(hr, "IMMDevice::GetId");
+    }
     info.id = idStr;
     CoTaskMemFree(idStr);
     info.flow = flow;
     info.isDefault = isDefault;
 
     ComPtr<IPropertyStore> props;
-    if (SUCCEEDED(dev->OpenPropertyStore(STGM_READ, &props))) {
+    HRESULT opsHr = dev->OpenPropertyStore(STGM_READ, &props);
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(opsHr));
+    if (SUCCEEDED(opsHr)) {
         PROPVARIANT name; PropVariantInit(&name);
-        if (SUCCEEDED(props->GetValue(PKEY_Device_FriendlyName, &name)) &&
+        HRESULT fnHr = props->GetValue(PKEY_Device_FriendlyName, &name);
+        WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IPropertyStore::GetValue", "key=FriendlyName", ::wa::log::hrName(fnHr));
+        if (SUCCEEDED(fnHr) &&
             name.vt == VT_LPWSTR)
             info.name = name.pwszVal;
         PropVariantClear(&name);
@@ -60,10 +88,14 @@ Result readInfo(IMMDevice* dev, DataFlow flow, bool isDefault, DeviceInfo& info)
     }
 
     ComPtr<IAudioClient> client;
-    if (SUCCEEDED(dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-                                reinterpret_cast<void**>(client.GetAddressOf())))) {
+    HRESULT actHr = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                                  reinterpret_cast<void**>(client.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::Activate", "iid=IAudioClient", ::wa::log::hrName(actHr));
+    if (SUCCEEDED(actHr)) {
         WAVEFORMATEX* mix = nullptr;
-        if (SUCCEEDED(client->GetMixFormat(&mix)) && mix) {
+        HRESULT gmHr = client->GetMixFormat(&mix);
+        WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IAudioClient::GetMixFormat", "", ::wa::log::hrName(gmHr));
+        if (SUCCEEDED(gmHr) && mix) {
             info.mixFormat = fromWaveFormat(mix);
             CoTaskMemFree(mix);
         }
@@ -74,30 +106,57 @@ Result readInfo(IMMDevice* dev, DataFlow flow, bool isDefault, DeviceInfo& info)
 
 Result DeviceEnumerator::enumerate(DataFlow flow, std::vector<DeviceInfo>& out) {
     out.clear();
+    WA_LOG(wa::log::Level::Info, "DeviceEnum", "enumerate",
+           "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render"), "start");
     ComPtr<IMMDeviceEnumerator> e;
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                                   __uuidof(IMMDeviceEnumerator),
                                   reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+        return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    }
 
     DeviceId defaultId;
     {
         ComPtr<IMMDevice> def;
-        if (SUCCEEDED(e->GetDefaultAudioEndpoint(toEDataFlow(flow), eConsole, &def))) {
+        HRESULT defHr = e->GetDefaultAudioEndpoint(toEDataFlow(flow), eConsole, &def);
+        WA_LOG(wa::log::Level::Debug, "DeviceEnum", "GetDefaultAudioEndpoint",
+               "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render"), ::wa::log::hrName(defHr));
+        if (SUCCEEDED(defHr)) {
             LPWSTR s = nullptr;
-            if (SUCCEEDED(def->GetId(&s))) { defaultId = s; CoTaskMemFree(s); }
+            HRESULT idHr = def->GetId(&s);
+            WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::GetId", "default", ::wa::log::hrName(idHr));
+            if (SUCCEEDED(idHr)) {
+                defaultId = s; CoTaskMemFree(s);
+                WA_LOG(wa::log::Level::Info, "DeviceEnum", "GetDefaultAudioEndpoint", "defaultId", "selected");
+            }
         }
     }
 
     ComPtr<IMMDeviceCollection> coll;
     hr = e->EnumAudioEndpoints(toEDataFlow(flow), DEVICE_STATE_ACTIVE, &coll);
-    if (FAILED(hr)) return HrToResult(hr, "EnumAudioEndpoints");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "EnumAudioEndpoints",
+           "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render") + " state=ACTIVE",
+           ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "EnumAudioEndpoints", "", ::wa::log::hrName(hr));
+        return HrToResult(hr, "EnumAudioEndpoints");
+    }
 
     UINT count = 0;
-    coll->GetCount(&count);
+    {
+        HRESULT gcHr = coll->GetCount(&count);
+        WA_LOG(wa::log::Level::Warn, "DeviceEnum", "IMMDeviceCollection::GetCount",
+               "count=" + std::to_string(count), ::wa::log::hrName(gcHr));
+    }
     for (UINT i = 0; i < count; ++i) {
         ComPtr<IMMDevice> dev;
-        if (FAILED(coll->Item(i, &dev))) continue;
+        HRESULT itemHr = coll->Item(i, &dev);
+        WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDeviceCollection::Item",
+               "i=" + std::to_string(i), ::wa::log::hrName(itemHr));
+        if (FAILED(itemHr)) continue;
         DeviceInfo info{};
         if (readInfo(dev.Get(), flow, false, info)) {
             info.isDefault = (info.id == defaultId);
@@ -112,11 +171,24 @@ Result DeviceEnumerator::defaultDevice(DataFlow flow, DeviceInfo& out) {
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                                   __uuidof(IMMDeviceEnumerator),
                                   reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+        return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    }
     ComPtr<IMMDevice> dev;
     hr = e->GetDefaultAudioEndpoint(toEDataFlow(flow), eConsole, &dev);
-    if (FAILED(hr)) return HrToResult(hr, "GetDefaultAudioEndpoint");
-    return readInfo(dev.Get(), flow, true, out);
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "GetDefaultAudioEndpoint",
+           "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render"), ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "GetDefaultAudioEndpoint",
+               "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render"), ::wa::log::hrName(hr));
+        return HrToResult(hr, "GetDefaultAudioEndpoint");
+    }
+    Result r = readInfo(dev.Get(), flow, true, out);
+    if (r) WA_LOG(wa::log::Level::Info, "DeviceEnum", "defaultDevice",
+                  "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render"), "ok");
+    return r;
 }
 
 Result DeviceEnumerator::mixFormat(const DeviceId& id, AudioFormat& out) {
@@ -124,21 +196,43 @@ Result DeviceEnumerator::mixFormat(const DeviceId& id, AudioFormat& out) {
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                                   __uuidof(IMMDeviceEnumerator),
                                   reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "CoCreateInstance", "clsid=MMDeviceEnumerator", ::wa::log::hrName(hr));
+        return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+    }
     ComPtr<IMMDevice> dev;
     if (id.empty())
         hr = e->GetDefaultAudioEndpoint(eRender, eConsole, &dev);
     else
         hr = e->GetDevice(id.c_str(), &dev);
-    if (FAILED(hr)) return HrToResult(hr, "GetDevice");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum",
+           id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+           id.empty() ? std::string("flow=render") : "id=" + wa::narrowAscii(id),
+           ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum",
+               id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+               id.empty() ? std::string("flow=render") : "id=" + wa::narrowAscii(id),
+               ::wa::log::hrName(hr));
+        return HrToResult(hr, "GetDevice");
+    }
 
     ComPtr<IAudioClient> client;
     hr = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
                        reinterpret_cast<void**>(client.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "IMMDevice::Activate");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::Activate", "iid=IAudioClient", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IMMDevice::Activate", "iid=IAudioClient", ::wa::log::hrName(hr));
+        return HrToResult(hr, "IMMDevice::Activate");
+    }
     WAVEFORMATEX* mix = nullptr;
     hr = client->GetMixFormat(&mix);
-    if (FAILED(hr)) return HrToResult(hr, "GetMixFormat");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IAudioClient::GetMixFormat", "", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IAudioClient::GetMixFormat", "", ::wa::log::hrName(hr));
+        return HrToResult(hr, "GetMixFormat");
+    }
     out = fromWaveFormat(mix);
     CoTaskMemFree(mix);
     return Result::Ok();
@@ -150,7 +244,11 @@ Result DeviceEnumerator::deviceFormat(const DeviceId& id, AudioFormat& out) {
     if (Result r = openDevice(DataFlow::Render, id, dev); !r) return r;
     ComPtr<IPropertyStore> props;
     HRESULT hr = dev->OpenPropertyStore(STGM_READ, props.GetAddressOf());
-    if (FAILED(hr)) return HrToResult(hr, "OpenPropertyStore");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(hr));
+        return HrToResult(hr, "OpenPropertyStore");
+    }
     if (!readFormatKey(props.Get(), PKEY_AudioEngine_DeviceFormat, out))
         return Result::Fail(1, "DeviceFormat not present");
     return Result::Ok();
@@ -162,7 +260,11 @@ Result DeviceEnumerator::oemFormat(const DeviceId& id, AudioFormat& out) {
     if (Result r = openDevice(DataFlow::Render, id, dev); !r) return r;
     ComPtr<IPropertyStore> props;
     HRESULT hr = dev->OpenPropertyStore(STGM_READ, props.GetAddressOf());
-    if (FAILED(hr)) return HrToResult(hr, "OpenPropertyStore");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(hr));
+        return HrToResult(hr, "OpenPropertyStore");
+    }
     if (!readFormatKey(props.Get(), PKEY_AudioEngine_OEMFormat, out))
         return Result::Fail(1, "OemFormat not present");
     return Result::Ok();
@@ -176,12 +278,19 @@ Result DeviceEnumerator::queryCapabilities(DataFlow flow, const DeviceId& id, De
     ComPtr<IAudioClient> client;
     HRESULT hr = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
                      reinterpret_cast<void**>(client.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "Activate");
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::Activate", "iid=IAudioClient", ::wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "DeviceEnum", "IMMDevice::Activate", "iid=IAudioClient", ::wa::log::hrName(hr));
+        return HrToResult(hr, "Activate");
+    }
     auto probe = [&](const AudioFormat& f, AUDCLNT_SHAREMODE sm) -> HRESULT {
         WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(f);
         WAVEFORMATEX* closest = nullptr;
         HRESULT h = client->IsFormatSupported(sm, reinterpret_cast<WAVEFORMATEX*>(&wfx),
                         (sm == AUDCLNT_SHAREMODE_EXCLUSIVE) ? nullptr : &closest);
+        WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IAudioClient::IsFormatSupported",
+               wa::formatAudio(f) + (sm == AUDCLNT_SHAREMODE_EXCLUSIVE ? " excl" : " shared"),
+               ::wa::log::hrName(h));
         if (closest) CoTaskMemFree(closest);
         return h;
     };
@@ -191,11 +300,15 @@ Result DeviceEnumerator::queryCapabilities(DataFlow flow, const DeviceId& id, De
         [&](const AudioFormat& f){ return probe(f, AUDCLNT_SHAREMODE_EXCLUSIVE) == S_OK; });
     // 三来源
     WAVEFORMATEX* mix = nullptr;
-    if (SUCCEEDED(client->GetMixFormat(&mix)) && mix) {
+    HRESULT gmHr = client->GetMixFormat(&mix);
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IAudioClient::GetMixFormat", "", ::wa::log::hrName(gmHr));
+    if (SUCCEEDED(gmHr) && mix) {
         out.mixFormat = fromWaveFormat(mix); out.hasMix = true; CoTaskMemFree(mix);
     }
     ComPtr<IPropertyStore> props;
-    if (SUCCEEDED(dev->OpenPropertyStore(STGM_READ, props.GetAddressOf()))) {
+    HRESULT opsHr = dev->OpenPropertyStore(STGM_READ, props.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "DeviceEnum", "IMMDevice::OpenPropertyStore", "mode=STGM_READ", ::wa::log::hrName(opsHr));
+    if (SUCCEEDED(opsHr)) {
         out.hasDevice = readFormatKey(props.Get(), PKEY_AudioEngine_DeviceFormat, out.deviceFormat);
         out.hasOem    = readFormatKey(props.Get(), PKEY_AudioEngine_OEMFormat,    out.oemFormat);
     }

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -2,6 +2,8 @@
 #define NOMINMAX
 #endif
 #include "Engine.h"
+#include "Log.h"
+#include "AudioFormatStr.h"
 #include "WasapiStream.h"
 #include "WavFile.h"
 #include "DeviceEnumerator.h"
@@ -55,59 +57,104 @@ std::vector<DeviceInfo> Engine::enumerate(DataFlow flow) {
 Result Engine::probeFormat(BackendKind kind, DataFlow flow, const DeviceId& id,
                            const AudioFormat& fmt) {
     ComInitGuard com;
+    WA_LOG(wa::log::Level::Info, "Engine", "probeFormat",
+        "kind=" + std::string(kind == BackendKind::WasapiExclusive ? "exclusive" : "shared")
+        + " flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render")
+        + " id=" + (id.empty() ? std::string("(default)") : wa::narrowAscii(id))
+        + " fmt=" + wa::formatAudio(fmt), "");
     ComPtr<IMMDeviceEnumerator> e;
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
             __uuidof(IMMDeviceEnumerator),
             reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "probeFormat: CoCreateInstance");
+    WA_LOG(wa::log::Level::Debug, "Engine", "CoCreateInstance(MMDeviceEnumerator)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "Engine", "CoCreateInstance(MMDeviceEnumerator)", "", wa::log::hrName(hr));
+        return HrToResult(hr, "probeFormat: CoCreateInstance");
+    }
     ComPtr<IMMDevice> dev;
     EDataFlow ef = (flow == DataFlow::Capture) ? eCapture : eRender;
     hr = id.empty() ? e->GetDefaultAudioEndpoint(ef, eConsole, dev.GetAddressOf())
                     : e->GetDevice(id.c_str(), dev.GetAddressOf());
-    if (FAILED(hr)) return HrToResult(hr, "probeFormat: GetDevice");
+    WA_LOG(wa::log::Level::Debug, "Engine",
+        id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+        id.empty() ? "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render")
+                   : "id=" + wa::narrowAscii(id),
+        wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "Engine",
+            id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice", "", wa::log::hrName(hr));
+        return HrToResult(hr, "probeFormat: GetDevice");
+    }
     ComPtr<IAudioClient> client;
     hr = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
             reinterpret_cast<void**>(client.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "probeFormat: Activate");
+    WA_LOG(wa::log::Level::Debug, "Engine", "IMMDevice::Activate(IAudioClient)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "Engine", "IMMDevice::Activate(IAudioClient)", "", wa::log::hrName(hr));
+        return HrToResult(hr, "probeFormat: Activate");
+    }
     AUDCLNT_SHAREMODE sm = (kind == BackendKind::WasapiExclusive)
                                ? AUDCLNT_SHAREMODE_EXCLUSIVE : AUDCLNT_SHAREMODE_SHARED;
     WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(fmt);
     WAVEFORMATEX* closest = nullptr;
     hr = client->IsFormatSupported(sm, reinterpret_cast<WAVEFORMATEX*>(&wfx),
                                    (sm == AUDCLNT_SHAREMODE_EXCLUSIVE) ? nullptr : &closest);
+    WA_LOG(wa::log::Level::Debug, "Engine", "IAudioClient::IsFormatSupported",
+        "mode=" + std::string(sm == AUDCLNT_SHAREMODE_EXCLUSIVE ? "exclusive" : "shared")
+        + " fmt=" + wa::formatAudio(fmt), wa::log::hrName(hr));
     if (closest) CoTaskMemFree(closest);
-    if (hr == S_OK) return Result::Ok();
+    if (hr == S_OK) {
+        WA_LOG(wa::log::Level::Info, "Engine", "probeFormat", "fmt=" + wa::formatAudio(fmt), "supported");
+        return Result::Ok();
+    }
     if (hr == S_FALSE) {
         // Shared mode can convert (AUTOCONVERTPCM); treat convertible as supported.
         // Exclusive mode requires exact match (S_OK only).
-        if (kind != BackendKind::WasapiExclusive) return Result::Ok();
+        if (kind != BackendKind::WasapiExclusive) {
+            WA_LOG(wa::log::Level::Info, "Engine", "probeFormat", "fmt=" + wa::formatAudio(fmt), "supported(convertible)");
+            return Result::Ok();
+        }
+        WA_LOG(wa::log::Level::Info, "Engine", "probeFormat", "fmt=" + wa::formatAudio(fmt), "not_exact_exclusive");
         return Result::Fail(1, "format not supported exactly (closest available)");
     }
+    WA_LOG(wa::log::Level::Err, "Engine", "probeFormat", "fmt=" + wa::formatAudio(fmt), wa::log::hrName(hr));
     return HrToResult(hr, "probeFormat: not supported");
 }
 
 Result Engine::startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
                             const AudioFormat* requested) {
     stop();
+    WA_LOG(wa::log::Level::Info, "Engine", "startCapture",
+        "kind=" + std::string(kind == BackendKind::WasapiExclusive ? "exclusive" : "shared")
+        + " id=" + (id.empty() ? std::string("(default)") : wa::narrowAscii(id))
+        + (requested ? " fmt=" + wa::formatAudio(*requested) : std::string("")), "");
     try {
         ring_ = std::make_unique<RingBuffer>(kRingBytes);
         WasapiMode mode = (kind == BackendKind::WasapiExclusive) ? WasapiMode::Exclusive
                                                                  : WasapiMode::Shared;
         backend_ = std::make_unique<WasapiCaptureStream>(mode, requested);
         Result r = backend_->open(id, AudioFormat{}, ring_.get(), StreamParams{});
-        if (!r) return r;
+        if (!r) {
+            WA_LOG(wa::log::Level::Err, "Engine", "startCapture", "open", r.message);
+            return r;
+        }
         r = backend_->start();
-        if (!r) return r;
+        if (!r) {
+            WA_LOG(wa::log::Level::Err, "Engine", "startCapture", "start", r.message);
+            return r;
+        }
         running_.store(true);
         startTick_ = GetTickCount64();
         { std::lock_guard<std::mutex> lk(mtx_); status_ = {}; status_.state = EngineState::Capturing; }
         pump_ = std::thread(&Engine::captureLoop, this, wavPath);
+        WA_LOG(wa::log::Level::Info, "Engine", "startCapture", "", "ok");
         return Result::Ok();
     } catch (const std::exception& e) {
         stop();
         std::lock_guard<std::mutex> lk(mtx_);
         status_.state = EngineState::Error;
         status_.message = e.what();
+        WA_LOG(wa::log::Level::Err, "Engine", "startCapture", "", std::string(e.what()));
         return Result::Fail(-1, e.what());
     }
 }
@@ -115,6 +162,10 @@ Result Engine::startCapture(BackendKind kind, const DeviceId& id, const std::wst
 Result Engine::startPlayback(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
                              const AudioFormat* requested) {
     stop();
+    WA_LOG(wa::log::Level::Info, "Engine", "startPlayback",
+        "kind=" + std::string(kind == BackendKind::WasapiExclusive ? "exclusive" : "shared")
+        + " id=" + (id.empty() ? std::string("(default)") : wa::narrowAscii(id))
+        + (requested ? " fmt=" + wa::formatAudio(*requested) : std::string("")), "");
     try {
         // Exclusive playback must run at the WAV file's own format (there is no
         // resampler); derive it from the file header instead of a UI/CLI value.
@@ -123,7 +174,10 @@ Result Engine::startPlayback(BackendKind kind, const DeviceId& id, const std::ws
         if (kind == BackendKind::WasapiExclusive) {
             WavReader hdr;
             Result hr = hdr.open(wavPath);
-            if (!hr) return hr;
+            if (!hr) {
+                WA_LOG(wa::log::Level::Err, "Engine", "startPlayback", "WavReader::open", hr.message);
+                return hr;
+            }
             wavFmt = hdr.format();
             hdr.close();
             effReq = &wavFmt;
@@ -133,17 +187,22 @@ Result Engine::startPlayback(BackendKind kind, const DeviceId& id, const std::ws
                                                                  : WasapiMode::Shared;
         backend_ = std::make_unique<WasapiRenderStream>(mode, effReq);
         Result r = backend_->open(id, AudioFormat{}, ring_.get(), StreamParams{});
-        if (!r) return r;
+        if (!r) {
+            WA_LOG(wa::log::Level::Err, "Engine", "startPlayback", "open", r.message);
+            return r;
+        }
         running_.store(true);
         startTick_ = GetTickCount64();
         { std::lock_guard<std::mutex> lk(mtx_); status_ = {}; status_.state = EngineState::Playing; }
         pump_ = std::thread(&Engine::playbackLoop, this, wavPath);
+        WA_LOG(wa::log::Level::Info, "Engine", "startPlayback", "", "ok");
         return Result::Ok();
     } catch (const std::exception& e) {
         stop();
         std::lock_guard<std::mutex> lk(mtx_);
         status_.state = EngineState::Error;
         status_.message = e.what();
+        WA_LOG(wa::log::Level::Err, "Engine", "startPlayback", "", std::string(e.what()));
         return Result::Fail(-1, e.what());
     }
 }
@@ -159,6 +218,7 @@ void Engine::stop() {
 }
 
 void Engine::captureLoop(std::wstring wavPath) {
+    wa::log::setThreadName("cap");
     // Backend already started; its actualFormat is known after start.
     AudioFormat fmt = backend_->stats().actualFormat;
     WavWriter writer;
@@ -188,6 +248,7 @@ void Engine::captureLoop(std::wstring wavPath) {
 }
 
 void Engine::playbackLoop(std::wstring wavPath) {
+    wa::log::setThreadName("play");
     WavReader reader;
     if (!reader.open(wavPath)) {
         std::lock_guard<std::mutex> lk(mtx_);
@@ -200,6 +261,7 @@ void Engine::playbackLoop(std::wstring wavPath) {
     {
         Result r = backend_->start();
         if (!r) {
+            WA_LOG(wa::log::Level::Err, "Engine", "startPlayback", "backend::start", r.message);
             std::lock_guard<std::mutex> lk(mtx_);
             status_.state = EngineState::Error;
             status_.message = r.message;

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -1,0 +1,224 @@
+#include "Log.h"
+
+#include <spdlog/spdlog.h>
+#include <spdlog/async.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <windows.h>
+#include <audioclient.h>
+
+#include <memory>
+#include <mutex>
+
+namespace wa::log {
+namespace {
+
+constexpr const char* kPattern   = "%H:%M:%S.%e %v";
+constexpr size_t      kQueueSize = 8192;
+
+std::shared_ptr<spdlog::logger> g_logger;
+std::mutex                      g_sinkMutex;
+thread_local const char*        t_threadName = "?";
+
+spdlog::level::level_enum toSpd(Level l) {
+    switch (l) {
+        case Level::Trace: return spdlog::level::trace;
+        case Level::Debug: return spdlog::level::debug;
+        case Level::Info:  return spdlog::level::info;
+        case Level::Warn:  return spdlog::level::warn;
+        case Level::Err:   return spdlog::level::err;
+    }
+    return spdlog::level::info;
+}
+
+Level fromSpd(spdlog::level::level_enum l) {
+    switch (l) {
+        case spdlog::level::trace:    return Level::Trace;
+        case spdlog::level::debug:    return Level::Debug;
+        case spdlog::level::info:     return Level::Info;
+        case spdlog::level::warn:     return Level::Warn;
+        case spdlog::level::err:      return Level::Err;
+        case spdlog::level::critical: return Level::Err;
+        case spdlog::level::off:      return Level::Err;
+        case spdlog::level::n_levels: return Level::Info;
+    }
+    return Level::Info;
+}
+
+const char* levelStr(Level l) {
+    switch (l) {
+        case Level::Trace: return "TRACE";
+        case Level::Debug: return "DEBUG";
+        case Level::Info:  return "INFO";
+        case Level::Warn:  return "WARN";
+        case Level::Err:   return "ERROR";
+    }
+    return "INFO";
+}
+
+// Static table of the HRESULTs this tool actually encounters. Returns nullptr
+// for anything not listed (callers fall back to the system message or hex).
+const char* hrNameC(long hr) {
+    switch (static_cast<HRESULT>(hr)) {
+        case S_OK:                                return "S_OK";
+        case S_FALSE:                             return "S_FALSE";
+        case E_INVALIDARG:                        return "E_INVALIDARG";
+        case E_POINTER:                           return "E_POINTER";
+        case E_NOINTERFACE:                       return "E_NOINTERFACE";
+        case E_OUTOFMEMORY:                       return "E_OUTOFMEMORY";
+        case E_FAIL:                              return "E_FAIL";
+        case E_ACCESSDENIED:                      return "E_ACCESSDENIED";
+        case RPC_E_CHANGED_MODE:                  return "RPC_E_CHANGED_MODE";
+        case AUDCLNT_E_NOT_INITIALIZED:           return "AUDCLNT_E_NOT_INITIALIZED";
+        case AUDCLNT_E_ALREADY_INITIALIZED:       return "AUDCLNT_E_ALREADY_INITIALIZED";
+        case AUDCLNT_E_WRONG_ENDPOINT_TYPE:       return "AUDCLNT_E_WRONG_ENDPOINT_TYPE";
+        case AUDCLNT_E_DEVICE_INVALIDATED:        return "AUDCLNT_E_DEVICE_INVALIDATED";
+        case AUDCLNT_E_NOT_STOPPED:               return "AUDCLNT_E_NOT_STOPPED";
+        case AUDCLNT_E_BUFFER_TOO_LARGE:          return "AUDCLNT_E_BUFFER_TOO_LARGE";
+        case AUDCLNT_E_OUT_OF_ORDER:              return "AUDCLNT_E_OUT_OF_ORDER";
+        case AUDCLNT_E_UNSUPPORTED_FORMAT:        return "AUDCLNT_E_UNSUPPORTED_FORMAT";
+        case AUDCLNT_E_INVALID_SIZE:              return "AUDCLNT_E_INVALID_SIZE";
+        case AUDCLNT_E_DEVICE_IN_USE:             return "AUDCLNT_E_DEVICE_IN_USE";
+        case AUDCLNT_E_BUFFER_OPERATION_PENDING:  return "AUDCLNT_E_BUFFER_OPERATION_PENDING";
+        case AUDCLNT_E_THREAD_NOT_REGISTERED:     return "AUDCLNT_E_THREAD_NOT_REGISTERED";
+        case AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED:return "AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED";
+        case AUDCLNT_E_ENDPOINT_CREATE_FAILED:    return "AUDCLNT_E_ENDPOINT_CREATE_FAILED";
+        case AUDCLNT_E_SERVICE_NOT_RUNNING:       return "AUDCLNT_E_SERVICE_NOT_RUNNING";
+        case AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED:   return "AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED";
+        case AUDCLNT_S_BUFFER_EMPTY:              return "AUDCLNT_S_BUFFER_EMPTY";
+        default:                                  return nullptr;
+    }
+}
+
+// Sink that forwards each formatted line to a user callback (GUI panel).
+template <typename Mutex>
+class CallbackSink : public spdlog::sinks::base_sink<Mutex> {
+public:
+    explicit CallbackSink(std::function<void(Level, const std::string&)> cb)
+        : cb_(std::move(cb)) {}
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t buf;
+        this->formatter_->format(msg, buf);
+        cb_(fromSpd(msg.level), fmt::to_string(buf));
+    }
+    void flush_() override {}
+
+private:
+    std::function<void(Level, const std::string&)> cb_;
+};
+
+void ensureLogger() {
+    if (g_logger) return;
+    spdlog::init_thread_pool(kQueueSize, 1);
+    g_logger = std::make_shared<spdlog::async_logger>(
+        "wa", spdlog::sinks_init_list{}, spdlog::thread_pool(),
+        spdlog::async_overflow_policy::overrun_oldest);
+    g_logger->set_pattern(kPattern);
+    g_logger->set_level(spdlog::level::info);
+}
+
+void pushSink(const spdlog::sink_ptr& sink) {
+    std::lock_guard<std::mutex> lk(g_sinkMutex);
+    ensureLogger();
+    sink->set_pattern(kPattern);
+    g_logger->sinks().push_back(sink);
+}
+
+} // namespace
+
+void setThreadName(const char* name) { t_threadName = name ? name : "?"; }
+
+void init() {
+    std::lock_guard<std::mutex> lk(g_sinkMutex);
+    ensureLogger();
+}
+
+void shutdown() {
+    // Must not throw: called from CLI's LogShutdown destructor (a sink flush
+    // failure must not escape into the destructor path).
+    try {
+        if (g_logger) g_logger->flush();
+        spdlog::shutdown();
+    } catch (...) {
+    }
+    g_logger.reset();
+}
+
+void setLevel(Level lvl) {
+    std::lock_guard<std::mutex> lk(g_sinkMutex);
+    ensureLogger();
+    g_logger->set_level(toSpd(lvl));
+}
+
+Level getLevel() {
+    std::lock_guard<std::mutex> lk(g_sinkMutex);
+    if (!g_logger) return Level::Info;  // a query has no side effects: don't create a logger
+    return fromSpd(g_logger->level());
+}
+
+bool shouldLog(Level lvl) {
+    return g_logger && g_logger->should_log(toSpd(lvl));
+}
+
+void addFileSink(const std::string& path, size_t maxBytes, size_t maxFiles) {
+    pushSink(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(path, maxBytes, maxFiles));
+}
+
+void addStderrSink() {
+    pushSink(std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
+}
+
+void addCallbackSink(std::function<void(Level, const std::string&)> cb) {
+    pushSink(std::make_shared<CallbackSink<std::mutex>>(std::move(cb)));
+}
+
+void emit(Level lvl, const char* module, const char* call,
+          const std::string& args, const std::string& ret) {
+    if (!g_logger) return;
+    const std::string modcall = std::string(module) + "::" + call;
+    const std::string payload =
+        fmt::format("{:<5} [{:<4}] {:<46} args: {:<38} ret: {}", levelStr(lvl),
+                    t_threadName, modcall, args.empty() ? std::string("-") : args, ret);
+    g_logger->log(toSpd(lvl), payload);
+}
+
+void emitTrace(const char* module, const char* call,
+               unsigned frames, unsigned flags, long hr) {
+    if (!g_logger) return;
+    // Audio thread: no heap allocation here — spdlog formats into an inline
+    // stack buffer (memory_buf_t, 250B; these trace lines are well under that)
+    // and enqueues with overrun_oldest (drops the oldest rather than waiting on
+    // a full queue); hrNameC returns a static string. NOTE: spdlog's async queue
+    // is an mpmc_blocking_queue, so the enqueue takes a short mutex — Trace is a
+    // diagnostic aid that may perturb the audio thread slightly (see spec).
+    const char* sym = hrNameC(hr);
+    g_logger->trace("TRACE [{:<4}] {}::{} frames={} flags={:#x} hr={:#010x} {}",
+                    t_threadName, module, call, frames, flags,
+                    static_cast<unsigned long>(hr), sym ? sym : "");
+}
+
+std::string hrName(long hr) {
+    if (const char* s = hrNameC(hr)) return s;
+    std::string out = fmt::format("{:#010x}", static_cast<unsigned long>(hr));
+    LPSTR buf = nullptr;
+    const DWORD n = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, static_cast<DWORD>(hr), 0, reinterpret_cast<LPSTR>(&buf), 0, nullptr);
+    if (n && buf) {
+        std::string msg(buf, n);
+        while (!msg.empty() &&
+               (msg.back() == '\n' || msg.back() == '\r' || msg.back() == ' '))
+            msg.pop_back();
+        if (!msg.empty()) out += " " + msg;
+    }
+    if (buf) LocalFree(buf);
+    return out;
+}
+
+} // namespace wa::log

--- a/src/core/Log.h
+++ b/src/core/Log.h
@@ -1,0 +1,57 @@
+#pragma once
+#include <string>
+#include <functional>
+
+// wa::log — a thin logging facade over spdlog. The implementation (Log.cpp) is
+// the only translation unit that includes spdlog, so the rest of core stays
+// spdlog-free in its headers and instrumentation sites only depend on this.
+// Design: docs/superpowers/specs/2026-07-06-winaudio-verbose-logging-design.md
+namespace wa::log {
+
+enum class Level { Trace, Debug, Info, Warn, Err };
+
+// Per-thread short name shown in the [..] column (e.g. "pump", "capW").
+// Call once at each thread's entry; defaults to "?" if unset.
+void setThreadName(const char* name);
+
+// Initialize the async logger (overrun_oldest overflow policy → never blocks a
+// caller). Idempotent. No output is produced until a sink is added.
+void init();
+// Flush the queue and stop the background pump; call once before process exit.
+void shutdown();
+
+void  setLevel(Level lvl);
+Level getLevel();
+bool  shouldLog(Level lvl);   // hot path calls this first to short-circuit
+
+// Sinks may coexist (file + stderr + GUI callback all at once).
+void addFileSink(const std::string& path,
+                 size_t maxBytes = 10u * 1024u * 1024u, size_t maxFiles = 3);
+void addStderrSink();
+// Feeds each formatted line to cb (used by the GUI panel). cb runs on the
+// logging pump thread — it must be thread-safe and must not block.
+void addCallbackSink(std::function<void(Level, const std::string&)> cb);
+
+// Control-path record (synchronous). Prefer the WA_LOG macro so the args/ret
+// strings are only built when the level is enabled.
+void emit(Level lvl, const char* module, const char* call,
+          const std::string& args, const std::string& ret);
+
+// Hot-path record (audio thread): integer payload only, no std::string
+// allocation on the caller — spdlog formats into a stack buffer and enqueues
+// without blocking.
+void emitTrace(const char* module, const char* call,
+               unsigned frames, unsigned flags, long hr);
+
+// HRESULT → symbolic name ("S_OK", "AUDCLNT_E_DEVICE_INVALIDATED", …), falling
+// back to the system message text, then a bare hex string. Never empty.
+std::string hrName(long hr);
+
+} // namespace wa::log
+
+// Short-circuits arg/ret construction when the level is disabled.
+#define WA_LOG(lvl, mod, call, args, ret)                              \
+    do {                                                               \
+        if (::wa::log::shouldLog(lvl))                                 \
+            ::wa::log::emit((lvl), (mod), (call), (args), (ret));      \
+    } while (0)

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -20,6 +20,8 @@
 #include <windows.h>
 #include <algorithm>
 #include <exception>
+#include "Log.h"
+#include "AudioFormatStr.h"
 
 namespace wa {
 
@@ -89,6 +91,11 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
                         static_cast<long>(MonitorError::InvalidDelay),
                         "MonitorEngine: delayMs exceeds maximum (10000 ms)");
 
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "start",
+           "cap=" + wa::narrowAscii(capId) +
+           " ren=" + wa::narrowAscii(renderId) +
+           " delay=" + std::to_string(delayMs) + "ms" +
+           " playback=" + (playbackEnabled ? "1" : "0"), "");
     kind_ = kind; renderId_ = renderId; delayMs_ = delayMs;
     capParams_ = capParams;
     { std::lock_guard<std::mutex> lk(paramsMtx_); renderParams_ = renderParams; }
@@ -100,12 +107,21 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
     capBackend_  = makeBackend(DataFlow::Capture, kind, hasCapFormat_ ? &capRequestedFormat_ : nullptr);
     if (!capBackend_)
         return rollback(StreamState::Idle, MonitorError::Factory, -1, "MonitorEngine: capture factory null");
-    if (Result r = capBackend_->open(capId, AudioFormat{}, captureRing_.get(), capParams_); !r)
-        return rollback(StreamState::Idle, MonitorError::CaptureOpen, r.code, r.message);
-    if (Result r = capBackend_->start(); !r)
-        return rollback(StreamState::Idle, MonitorError::CaptureStart, r.code, r.message);
+    {
+        Result r = capBackend_->open(capId, AudioFormat{}, captureRing_.get(), capParams_);
+        WA_LOG(wa::log::Level::Debug, "MonitorEngine", "capture.open",
+               "dev=" + wa::narrowAscii(capId), r.ok ? "ok" : r.message);
+        if (!r) return rollback(StreamState::Idle, MonitorError::CaptureOpen, r.code, r.message);
+    }
+    {
+        Result r = capBackend_->start();
+        WA_LOG(wa::log::Level::Debug, "MonitorEngine", "capture.start", "", r.ok ? "ok" : r.message);
+        if (!r) return rollback(StreamState::Idle, MonitorError::CaptureStart, r.code, r.message);
+    }
     capState_.store(StreamState::Running, std::memory_order_relaxed);
     capFmt_ = capBackend_->stats().actualFormat;
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "capture.started",
+           "dev=" + wa::narrowAscii(capId) + " fmt=" + wa::formatAudio(capFmt_), "ok");
 
     const uint32_t sr = capFmt_.sampleRate;
     capCh_         = capFmt_.channels ? capFmt_.channels : static_cast<uint16_t>(1);
@@ -135,6 +151,7 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
         if (Result r = engageRender(); !r) {
             long code = r.code;
             std::string msg = r.message;
+            WA_LOG(wa::log::Level::Err, "MonitorEngine", "start.engageRender", "playback=1", msg);
             MonitorError err = (code == static_cast<long>(MonitorError::RateMismatch))
                                    ? MonitorError::RateMismatch : MonitorError::RenderStart;
             return rollback(StreamState::Error, err, code, std::move(msg));   // stops capture too
@@ -143,6 +160,10 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
 
     // Capture is up -> engine Running (independent of render prefill).
     overall_.store(StreamState::Running, std::memory_order_relaxed);
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "engine.running",
+           "cap=" + wa::narrowAscii(capId) +
+           " ren=" + wa::narrowAscii(renderId) +
+           " sr=" + std::to_string(capFmt_.sampleRate), "ok");
 
     running_.store(true, std::memory_order_release);
     try {
@@ -152,6 +173,7 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
         return rollback(StreamState::Error, MonitorError::PumpLaunch, -1,
                         std::string("MonitorEngine: pump launch failed: ") + e.what());
     }
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "start", "pump ready", "ok");
     return Result::Ok();
 }
 
@@ -162,14 +184,22 @@ Result MonitorEngine::engageRender() {
     renderRing_    = std::make_unique<RingBuffer>(kRingBytes);            // per-engage
     renderBackend_ = makeBackend(DataFlow::Render, kind_, &capFmt_);
     if (!renderBackend_) { renderRing_.reset(); return Result::Fail(-1, "MonitorEngine: render factory null"); }
-    if (Result r = renderBackend_->open(renderId_, AudioFormat{}, renderRing_.get(), rp); !r) {
-        renderBackend_.reset(); renderRing_.reset(); return Result::Fail(r.code, r.message);
+    {
+        Result r = renderBackend_->open(renderId_, AudioFormat{}, renderRing_.get(), rp);
+        WA_LOG(wa::log::Level::Debug, "MonitorEngine", "render.open",
+               "dev=" + wa::narrowAscii(renderId_), r.ok ? "ok" : r.message);
+        if (!r) { renderBackend_.reset(); renderRing_.reset(); return Result::Fail(r.code, r.message); }
     }
-    if (Result r = renderBackend_->start(); !r) {
-        renderBackend_->stop(); renderBackend_.reset(); renderRing_.reset(); return Result::Fail(r.code, r.message);
+    {
+        Result r = renderBackend_->start();
+        WA_LOG(wa::log::Level::Debug, "MonitorEngine", "render.start", "", r.ok ? "ok" : r.message);
+        if (!r) { renderBackend_->stop(); renderBackend_.reset(); renderRing_.reset(); return Result::Fail(r.code, r.message); }
     }
     renderFmt_ = renderBackend_->stats().actualFormat;
     if (renderFmt_.sampleRate == 0 || renderFmt_.sampleRate != sr) {
+        WA_LOG(wa::log::Level::Warn, "MonitorEngine", "engageRender",
+               "cap_sr=" + std::to_string(sr) + " ren_sr=" + std::to_string(renderFmt_.sampleRate),
+               "rate mismatch");
         renderBackend_->stop(); renderBackend_.reset(); renderRing_.reset();
         return Result::Fail(static_cast<long>(MonitorError::RateMismatch),
                             "MonitorEngine: capture/render sample-rate mismatch");
@@ -202,10 +232,14 @@ Result MonitorEngine::engageRender() {
     renderLevel_.store(0.f, std::memory_order_relaxed);
     prefilled_.store(false, std::memory_order_relaxed);          // this engage's fill not done yet
     renderState_.store(StreamState::Running, std::memory_order_relaxed); // device up (fills, then pops)
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "render.engaged",
+           "dev=" + wa::narrowAscii(renderId_) +
+           " fmt=" + wa::formatAudio(renderFmt_), "ok");
     return Result::Ok();
 }
 
 void MonitorEngine::disengageRender() {
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "render.disengaged", "", "");
     if (renderBackend_) renderBackend_->stop();
     renderBackend_.reset();
     renderRing_.reset();
@@ -224,11 +258,13 @@ void MonitorEngine::setPlaybackEnabled(bool enabled) {
 }
 
 void MonitorEngine::setRenderParams(const StreamParams& p) {
+    WA_LOG(wa::log::Level::Debug, "MonitorEngine", "setRenderParams", "", "");
     std::lock_guard<std::mutex> lk(paramsMtx_);
     renderParams_ = p;
 }
 
 void MonitorEngine::pumpLoop() {
+    wa::log::setThreadName("pump");
     ComInitGuard com;   // pump owns COM (it now does render backend COM lifetime on toggle)
     const uint16_t capCh         = capCh_;
     const uint32_t capFrameBytes = capFrameBytes_;
@@ -246,6 +282,7 @@ void MonitorEngine::pumpLoop() {
         const bool active = (renderBackend_ != nullptr);
         if (want && !active) {
             if (Result r = engageRender(); !r) {
+                WA_LOG(wa::log::Level::Err, "MonitorEngine", "render.engage", "", r.message);
                 renderState_.store(StreamState::Error, std::memory_order_relaxed);
                 errorCode_.store(static_cast<uint32_t>(
                     r.code == static_cast<long>(MonitorError::RateMismatch)
@@ -330,6 +367,7 @@ void MonitorEngine::teardown() {
 }
 
 void MonitorEngine::stop() {
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "stop", "", "");
     teardown();
     capState_.store(StreamState::Idle, std::memory_order_relaxed);
     renderState_.store(StreamState::Idle, std::memory_order_relaxed);

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -4,6 +4,8 @@
 #include <audiopolicy.h>
 #include <system_error>
 #include <cstring>
+#include "Log.h"
+#include "AudioFormatStr.h"
 
 namespace wa {
 
@@ -113,14 +115,18 @@ Result WasapiStream::applyClientProperties() {
     ComPtr<IAudioClient2> client2;
     HRESULT hr = client_->QueryInterface(__uuidof(IAudioClient2),
                      reinterpret_cast<void**>(client2.GetAddressOf()));
-    if (FAILED(hr) || !client2.Get())
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "QueryInterface(IAudioClient2)", "", wa::log::hrName(hr));
+    if (FAILED(hr) || !client2.Get()) {
+        WA_LOG(wa::log::Level::Err, "WasapiStream", "QueryInterface(IAudioClient2)", "", wa::log::hrName(FAILED(hr) ? hr : E_NOINTERFACE));
         return HrToResult(FAILED(hr) ? hr : E_NOINTERFACE,
                           "WasapiStream: IAudioClient2 unavailable; cannot apply advanced stream params");
+    }
     const AUDIO_STREAM_CATEGORY cat = mapCategory(params_.category);
     if (params_.offload == OffloadMode::Force) {
         BOOL capable = FALSE;
         hr = client2->IsOffloadCapable(cat, &capable);
-        if (FAILED(hr)) return HrToResult(hr, "WasapiStream: IsOffloadCapable");
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "IsOffloadCapable", "", wa::log::hrName(hr));
+        if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "IsOffloadCapable", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: IsOffloadCapable"); }
         if (!capable)
             return Result::Fail(-1, "WasapiStream: device/category does not support hardware offload");
     }
@@ -130,7 +136,8 @@ Result WasapiStream::applyClientProperties() {
     p.eCategory  = cat;
     p.Options    = mapStreamOption(params_.option);
     hr = client2->SetClientProperties(&p);
-    if (FAILED(hr)) return HrToResult(hr, "WasapiStream: SetClientProperties");
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "SetClientProperties", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "SetClientProperties", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: SetClientProperties"); }
     return Result::Ok();
 }
 
@@ -139,14 +146,19 @@ Result WasapiStream::applyDucking() {
     ComPtr<IAudioSessionControl> sc;
     HRESULT hr = client_->GetService(__uuidof(IAudioSessionControl),
                      reinterpret_cast<void**>(sc.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "WasapiStream: GetService(IAudioSessionControl)");
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetService(IAudioSessionControl)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetService(IAudioSessionControl)", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: GetService(IAudioSessionControl)"); }
     ComPtr<IAudioSessionControl2> sc2;
     hr = sc->QueryInterface(__uuidof(IAudioSessionControl2),
                      reinterpret_cast<void**>(sc2.GetAddressOf()));
-    if (FAILED(hr) || !sc2.Get())
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "QueryInterface(IAudioSessionControl2)", "", wa::log::hrName(hr));
+    if (FAILED(hr) || !sc2.Get()) {
+        WA_LOG(wa::log::Level::Err, "WasapiStream", "QueryInterface(IAudioSessionControl2)", "", wa::log::hrName(FAILED(hr) ? hr : E_NOINTERFACE));
         return HrToResult(FAILED(hr) ? hr : E_NOINTERFACE, "WasapiStream: IAudioSessionControl2 unavailable");
+    }
     hr = sc2->SetDuckingPreference(TRUE);
-    if (FAILED(hr)) return HrToResult(hr, "WasapiStream: SetDuckingPreference");
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "SetDuckingPreference", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "SetDuckingPreference", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: SetDuckingPreference"); }
     return Result::Ok();
 }
 
@@ -170,21 +182,24 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
                 AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
                 dur, 0,
                 reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
-            if (FAILED(hr)) return HrToResult(hr, "WasapiStream: Initialize(shared, requested)");
+            WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared,requested)", "fmt=" + wa::formatAudio(requestedFormat_), wa::log::hrName(hr));
+            if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(shared,requested)", "fmt=" + wa::formatAudio(requestedFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(shared, requested)"); }
             return Result::Ok();
         }
 
         // Default: use the device mix format (no conversion flags needed).
         WAVEFORMATEX* mix = nullptr;
         HRESULT hr = client_->GetMixFormat(&mix);
-        if (FAILED(hr)) return HrToResult(hr, "WasapiStream: GetMixFormat");
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetMixFormat", "", wa::log::hrName(hr));
+        if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetMixFormat", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: GetMixFormat"); }
         if (!mix) return Result::Fail(-1, "WasapiStream: GetMixFormat returned null");
         actualFormat_ = fromWaveFormat(mix);
         frameBytes_ = actualFormat_.blockAlign();
         hr = client_->Initialize(AUDCLNT_SHAREMODE_SHARED,
                                  AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, 0, mix, nullptr);
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
         CoTaskMemFree(mix);
-        if (FAILED(hr)) return HrToResult(hr, "WasapiStream: Initialize(shared)");
+        if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(shared)"); }
         return Result::Ok();
     }
     // ---- Exclusive ----
@@ -196,8 +211,10 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
 
     int idx = selectSupportedFormat(candidates, [this](const AudioFormat& cand) {
         WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(cand);
-        return client_->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
-                   reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr) == S_OK;
+        HRESULT hr = client_->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
+                         reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "IsFormatSupported(exclusive)", "fmt=" + wa::formatAudio(cand), wa::log::hrName(hr));
+        return hr == S_OK;
     });
     if (idx < 0)
         return Result::Fail(static_cast<long>(AUDCLNT_E_UNSUPPORTED_FORMAT),
@@ -207,7 +224,8 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
     frameBytes_ = actualFormat_.blockAlign();
 
     REFERENCE_TIME defPer = 0, minPer = 0;
-    client_->GetDevicePeriod(&defPer, &minPer);
+    HRESULT hrGP = client_->GetDevicePeriod(&defPer, &minPer);
+    WA_LOG(wa::log::Level::Warn, "WasapiStream", "GetDevicePeriod", "", wa::log::hrName(hrGP));
     REFERENCE_TIME dur = params_.bufferMs
         ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10'000
         : minPer;
@@ -216,9 +234,11 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
     HRESULT hr = client_->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE,
                      AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, dur,
                      reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(exclusive)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
     if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
         UINT32 aligned = 0;
-        client_->GetBufferSize(&aligned);
+        HRESULT hrGBS = client_->GetBufferSize(&aligned);
+        WA_LOG(wa::log::Level::Warn, "WasapiStream", "GetBufferSize(realign)", "", wa::log::hrName(hrGBS));
         dur = alignedBufferDuration100ns(actualFormat_.sampleRate, aligned);
         // MSDN: the client must be rebuilt before re-Initializing with the aligned size.
         // Note: advanced client props (category/option/offload) are rejected in open() for
@@ -226,34 +246,40 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
         client_.Reset();
         HRESULT hr2 = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
                           reinterpret_cast<void**>(client_.GetAddressOf()));
-        if (FAILED(hr2)) return HrToResult(hr2, "WasapiStream: exclusive realign Activate");
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Activate(realign)", "", wa::log::hrName(hr2));
+        if (FAILED(hr2)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Activate(realign)", "", wa::log::hrName(hr2)); return HrToResult(hr2, "WasapiStream: exclusive realign Activate"); }
         WAVEFORMATEXTENSIBLE wfx2 = toWaveFormatExtensible(actualFormat_);
         hr = client_->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE,
                  AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, dur,
                  reinterpret_cast<WAVEFORMATEX*>(&wfx2), nullptr);
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(exclusive,realign)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
     }
-    if (FAILED(hr)) return HrToResult(hr, "WasapiStream: Initialize(exclusive)");
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(exclusive)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(exclusive)"); }
     return Result::Ok();
 }
 
 void WasapiStream::threadMain() {
     ComInitGuard com; // this thread's own MTA apartment
+    WA_LOG(wa::log::Level::Info, "WasapiStream", "threadMain", "worker thread started", "");
 
     ComPtr<IMMDeviceEnumerator> e;
     HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
             __uuidof(IMMDeviceEnumerator),
             reinterpret_cast<void**>(e.GetAddressOf()));
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: CoCreateInstance")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "CoCreateInstance", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "CoCreateInstance", "", wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: CoCreateInstance")); return; }
 
     ComPtr<IMMDevice> dev;
     hr = deviceId_.empty()
         ? e->GetDefaultAudioEndpoint(dataFlow(), eConsole, &dev)
         : e->GetDevice(deviceId_.c_str(), &dev);
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: GetDevice")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetDevice", "id=" + wa::narrowAscii(deviceId_), wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetDevice", "id=" + wa::narrowAscii(deviceId_), wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: GetDevice")); return; }
 
     hr = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
             reinterpret_cast<void**>(client_.GetAddressOf()));
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: Activate")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "Activate", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Activate", "", wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: Activate")); return; }
 
     if (Result ap = applyClientProperties(); !ap) { signalReady(ap); return; }
 
@@ -263,9 +289,11 @@ void WasapiStream::threadMain() {
     if (Result dk = applyDucking(); !dk) { signalReady(dk); return; }
 
     hr = client_->GetBufferSize(&bufferFrames_);
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: GetBufferSize")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetBufferSize", "frames=" + std::to_string(bufferFrames_), wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetBufferSize", "", wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: GetBufferSize")); return; }
     hr = client_->SetEventHandle(static_cast<HANDLE>(hEvent_));
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: SetEventHandle")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "SetEventHandle", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "SetEventHandle", "", wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: SetEventHandle")); return; }
 
     Result cs = createService();
     if (!cs) { signalReady(cs); return; }
@@ -273,13 +301,16 @@ void WasapiStream::threadMain() {
     preRoll();
 
     hr = client_->Start();
-    if (FAILED(hr)) { signalReady(HrToResult(hr, "WasapiStream: Start")); return; }
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "Start", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Start", "", wa::log::hrName(hr)); signalReady(HrToResult(hr, "WasapiStream: Start")); return; }
 
+    WA_LOG(wa::log::Level::Info, "WasapiStream", "Start", "stream started", "");
     signalReady(Result::Ok()); // device ready; actualFormat_/bufferFrames_ valid
 
     runLoop();
 
-    client_->Stop();
+    HRESULT hrStop = client_->Stop();
+    WA_LOG(wa::log::Level::Warn, "WasapiStream", "Stop", "", wa::log::hrName(hrStop));
 }
 
 // --------------------------------------------------------------------------
@@ -314,17 +345,25 @@ void WasapiCaptureStream::close() {
 Result WasapiCaptureStream::createService() {
     HRESULT hr = client_->GetService(__uuidof(IAudioCaptureClient),
             reinterpret_cast<void**>(capture_.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "WasapiCaptureStream: GetService");
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetService(IAudioCaptureClient)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetService(IAudioCaptureClient)", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiCaptureStream: GetService"); }
     return Result::Ok();
 }
 
 void WasapiCaptureStream::runLoop() {
+    wa::log::setThreadName("capW");
+    WA_LOG(wa::log::Level::Info, "WasapiStream", "runLoop", "capture loop started", "");
     while (running_.load()) {
         WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
         UINT32 packet = 0;
-        while (SUCCEEDED(capture_->GetNextPacketSize(&packet)) && packet > 0) {
+        HRESULT hrNP;
+        while (hrNP = capture_->GetNextPacketSize(&packet),
+               wa::log::emitTrace("WasapiStream", "GetNextPacketSize", packet, 0, (long)hrNP),
+               SUCCEEDED(hrNP) && packet > 0) {
             BYTE* data = nullptr; UINT32 frames = 0; DWORD flags = 0;
-            if (FAILED(capture_->GetBuffer(&data, &frames, &flags, nullptr, nullptr)))
+            HRESULT hrGB = capture_->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
+            wa::log::emitTrace("WasapiStream", "GetBuffer", frames, (unsigned)flags, (long)hrGB);
+            if (FAILED(hrGB))
                 break;
             const size_t bytes = static_cast<size_t>(frames) * frameBytes_;
             if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
@@ -336,7 +375,8 @@ void WasapiCaptureStream::runLoop() {
                 ring_->write(data, bytes);
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             }
-            capture_->ReleaseBuffer(frames);
+            HRESULT hrRB = capture_->ReleaseBuffer(frames);
+            wa::log::emitTrace("WasapiStream", "ReleaseBuffer", frames, 0, (long)hrRB);
         }
     }
 }
@@ -353,17 +393,26 @@ WasapiRenderStream::~WasapiRenderStream() { close(); }
 Result WasapiRenderStream::createService() {
     HRESULT hr = client_->GetService(__uuidof(IAudioRenderClient),
             reinterpret_cast<void**>(render_.GetAddressOf()));
-    if (FAILED(hr)) return HrToResult(hr, "WasapiRenderStream: GetService");
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetService(IAudioRenderClient)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetService(IAudioRenderClient)", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiRenderStream: GetService"); }
     return Result::Ok();
 }
 
 void WasapiRenderStream::preRoll() {
     BYTE* buf = nullptr;
-    if (SUCCEEDED(render_->GetBuffer(bufferFrames_, &buf)))
-        render_->ReleaseBuffer(bufferFrames_, AUDCLNT_BUFFERFLAGS_SILENT);
+    HRESULT hrPre = render_->GetBuffer(bufferFrames_, &buf);
+    WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetBuffer(preRoll)",
+           "frames=" + std::to_string(bufferFrames_), wa::log::hrName(hrPre));
+    if (SUCCEEDED(hrPre)) {
+        HRESULT hrRel = render_->ReleaseBuffer(bufferFrames_, AUDCLNT_BUFFERFLAGS_SILENT);
+        WA_LOG(wa::log::Level::Debug, "WasapiStream", "ReleaseBuffer(preRoll)", "",
+               wa::log::hrName(hrRel));
+    }
 }
 
 void WasapiRenderStream::runLoop() {
+    wa::log::setThreadName("renW");
+    WA_LOG(wa::log::Level::Info, "WasapiStream", "runLoop", "render loop started", "");
     const bool exclusive = isExclusive();
     std::vector<uint8_t> scratch;
     while (running_.load()) {
@@ -377,18 +426,23 @@ void WasapiRenderStream::runLoop() {
             frames = bufferFrames_;
         } else {
             UINT32 padding = 0;
-            if (FAILED(client_->GetCurrentPadding(&padding))) break;
+            HRESULT hrPad = client_->GetCurrentPadding(&padding);
+            wa::log::emitTrace("WasapiStream", "GetCurrentPadding", padding, 0, (long)hrPad);
+            if (FAILED(hrPad)) break;
             frames = bufferFrames_ - padding;
             if (frames == 0) continue;
         }
         BYTE* buf = nullptr;
-        if (FAILED(render_->GetBuffer(frames, &buf))) break;
+        HRESULT hrGB = render_->GetBuffer(frames, &buf);
+        wa::log::emitTrace("WasapiStream", "GetBuffer", frames, 0, (long)hrGB);
+        if (FAILED(hrGB)) break;
         const size_t want = static_cast<size_t>(frames) * frameBytes_;
         scratch.resize(want);
         size_t got = ring_->read(scratch.data(), want);
         std::memcpy(buf, scratch.data(), got);
         if (got < want) std::memset(buf + got, 0, want - got); // underrun -> silence
-        render_->ReleaseBuffer(frames, 0);
+        HRESULT hrRB = render_->ReleaseBuffer(frames, 0);
+        wa::log::emitTrace("WasapiStream", "ReleaseBuffer", frames, 0, (long)hrRB);
     }
 }
 

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -5,6 +5,7 @@
 #include "Fft.h"
 #include "Analysis.h"
 #include "FormatSpec.h"
+#include "Log.h"
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
@@ -84,6 +85,11 @@ void AppUi::refreshMonitorDevices() {
 
 void AppUi::stopAll() {
     monitor_.stop();
+}
+
+void AppUi::pushLog(int /*level*/, const std::string& line) {
+    std::lock_guard<std::mutex> lk(logMutex_);
+    pendingLog_.push_back(line);
 }
 
 void AppUi::recomputeDefaultFormat() {
@@ -209,6 +215,17 @@ const char* AppUi::chartTitle(int id) {
 }
 
 void AppUi::draw() {
+    // Drain lines buffered by the logging pump thread into the panel history (bounded).
+    {
+        std::lock_guard<std::mutex> lk(logMutex_);
+        for (auto& l : pendingLog_) logLines_.push_back(std::move(l));
+        pendingLog_.clear();
+    }
+    constexpr size_t kMaxLogLines = 5000;
+    if (logLines_.size() > kMaxLogLines)
+        logLines_.erase(logLines_.begin(),
+                        logLines_.begin() + (logLines_.size() - kMaxLogLines));
+
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
     ms_ = monitor_.poll();
     const int curRenderState = (int)ms_.renderState;
@@ -332,8 +349,16 @@ void AppUi::drawLeftPanel() {
 
     // --- Log (fills remaining height) ---
     ImGui::SeparatorText("Log");
+    static const char* kLevels[] = {"Trace", "Debug", "Info", "Warn", "Err"};
+    ImGui::SetNextItemWidth(90.0f);
+    if (ImGui::Combo("##loglevel", &logLevelIdx_, kLevels, IM_ARRAYSIZE(kLevels)))
+        wa::log::setLevel(static_cast<wa::log::Level>(logLevelIdx_));
+    ImGui::SameLine();
+    if (ImGui::Button("Clear")) logLines_.clear();
     ImGui::BeginChild("log", ImVec2(0, 0), true);
     for (const auto& l : logLines_) ImGui::TextUnformatted(l.c_str());
+    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
+        ImGui::SetScrollHereY(1.0f);   // autoscroll while pinned to the bottom
     ImGui::EndChild();
 }
 

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <complex>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include "DeviceEnumerator.h"
@@ -11,6 +12,7 @@ class AppUi {
 public:
     void draw();          // called each frame; polls monitor and redraws the two-column UI
     void stopAll();       // stop monitor on shutdown (idempotent)
+    void pushLog(int level, const std::string& line);  // thread-safe; called from the logging pump thread
 private:
     void refreshMonitorDevices();
     void drawLeftPanel();
@@ -34,6 +36,9 @@ private:
     std::vector<int>         chartOrder_      = {0, 1};   // 0=cap combo, 1=ren combo
     int                      prevRenderState_ = 0;
     std::vector<std::string> logLines_;
+    std::mutex               logMutex_;    // guards pendingLog_ (pump thread → draw drains it)
+    std::vector<std::string> pendingLog_;
+    int                      logLevelIdx_ = 2;   // 0=Trace..4=Err; default Info
 
     // Monitor device selection
     bool                        monitorDevicesLoaded_ = false;

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -8,6 +8,7 @@
 // - Introduction, links and more at the top of imgui.cpp
 
 #include "AppUi.h"
+#include "Log.h"
 #include "imgui.h"
 #include "implot.h"
 #include "imgui_impl_win32.h"
@@ -94,6 +95,16 @@ int main(int, char**)
     // WinAudio: UI (owns both engine and monitor engine)
     static AppUi ui;
 
+    // WinAudio: logging — file (winaudio.log, exe dir) + GUI panel via callback sink.
+    // The callback runs on the logging pump thread; pushLog buffers thread-safely.
+    wa::log::init();
+    wa::log::setThreadName("main");
+    wa::log::addFileSink("winaudio.log");
+    wa::log::addCallbackSink([](wa::log::Level lvl, const std::string& line) {
+        ui.pushLog(static_cast<int>(lvl), line);
+    });
+    wa::log::setLevel(wa::log::Level::Info);
+
     // Main loop
     bool done = false;
     while (!done)
@@ -151,6 +162,7 @@ int main(int, char**)
 
     // WinAudio: stop both engines so worker threads are joined before teardown
     ui.stopAll();
+    wa::log::shutdown();   // flush + stop the logging pump before teardown
 
     // Cleanup
     ImGui_ImplDX11_Shutdown();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(WinAudioTests
     test_monitorengine.cpp
     test_spectrogram.cpp
     test_capabilities.cpp
+    test_log.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
 )
 target_include_directories(WinAudioTests PRIVATE

--- a/src/tests/test_log.cpp
+++ b/src/tests/test_log.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+
+#include "Log.h"
+#include "AudioFormatStr.h"
+
+#include <windows.h>
+#include <audioclient.h>
+
+#include <mutex>
+#include <vector>
+
+using namespace wa;
+
+TEST(AudioFormatStr, FormatAudio) {
+    EXPECT_EQ(formatAudio({48000, 2, 16, false}), "48000/16/2");
+    EXPECT_EQ(formatAudio({44100, 1, 24, false}), "44100/24/1");
+    EXPECT_EQ(formatAudio({48000, 2, 32, true}), "48000/32f/2");
+    EXPECT_EQ(formatAudio({96000, 1, 32, true}), "96000/32f/1");
+}
+
+TEST(AudioFormatStr, NarrowAscii) {
+    EXPECT_EQ(narrowAscii(L""), "");
+    EXPECT_EQ(narrowAscii(L"{0.0.1}.{abc-123}"), "{0.0.1}.{abc-123}");
+}
+
+TEST(Log, HrNameKnownSymbols) {
+    EXPECT_EQ(log::hrName(S_OK), "S_OK");
+    EXPECT_EQ(log::hrName(S_FALSE), "S_FALSE");
+    EXPECT_EQ(log::hrName(AUDCLNT_E_DEVICE_INVALIDATED), "AUDCLNT_E_DEVICE_INVALIDATED");
+    EXPECT_EQ(log::hrName(AUDCLNT_E_UNSUPPORTED_FORMAT), "AUDCLNT_E_UNSUPPORTED_FORMAT");
+}
+
+TEST(Log, HrNameUnknownFallsBackToHex) {
+    // Unknown HRESULT: never empty, contains the hex form.
+    std::string s = log::hrName(0x12345678L);
+    EXPECT_FALSE(s.empty());
+    EXPECT_NE(s.find("0x12345678"), std::string::npos);
+}
+
+TEST(Log, LevelFilterAndSinkDelivery) {
+    std::mutex m;
+    std::vector<log::Level> got;
+    log::init();
+    log::addCallbackSink([&](log::Level lv, const std::string&) {
+        std::lock_guard<std::mutex> lk(m);
+        got.push_back(lv);
+    });
+    log::setLevel(log::Level::Info);
+    log::emit(log::Level::Debug, "T", "dbg", "", "");  // below Info -> filtered
+    log::emit(log::Level::Info, "T", "inf", "", "");    // delivered
+    log::emit(log::Level::Err, "T", "err", "", "");     // delivered
+    log::shutdown();  // drains the async queue
+
+    std::lock_guard<std::mutex> lk(m);
+    EXPECT_EQ(got.size(), 2u);
+    for (log::Level lv : got) EXPECT_NE(lv, log::Level::Debug);
+}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,35 +1,40 @@
-# gtest, imgui, implot are vendored as git submodules under third_party/.
-# Static CRT (/MT) is inherited from the top-level CMAKE_MSVC_RUNTIME_LIBRARY (CMP0091 NEW).
-# All third_party targets are excluded from our /W4 + Werror policy (they set their own warning levels).
-
-set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
-set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
-add_subdirectory(googletest)
-
-# Dear ImGui (docking branch) — built as a small static lib we control.
+# --- Dear ImGui: core + Win32/DX11 backends (static lib, warnings off) ---
 add_library(imgui STATIC
     imgui/imgui.cpp
     imgui/imgui_draw.cpp
     imgui/imgui_tables.cpp
     imgui/imgui_widgets.cpp
-    imgui/imgui_demo.cpp
     imgui/backends/imgui_impl_win32.cpp
     imgui/backends/imgui_impl_dx11.cpp
 )
-target_include_directories(imgui PUBLIC imgui imgui/backends)
-target_link_libraries(imgui PUBLIC d3d11 dxgi d3dcompiler)
+target_include_directories(imgui PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui
+    ${CMAKE_CURRENT_SOURCE_DIR}/imgui/backends
+)
+target_compile_options(imgui PRIVATE /W0)
 
-# ImPlot — plotting on top of ImGui.
+# --- ImPlot (depends on ImGui) ---
 add_library(implot STATIC
     implot/implot.cpp
     implot/implot_items.cpp
 )
-target_include_directories(implot PUBLIC implot imgui)
 target_link_libraries(implot PUBLIC imgui)
-wa_set_project_warnings(implot)
-# NOTE: implot uses our warnings but we allow it to build; core stays the strict one.
+target_include_directories(implot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/implot)
+target_compile_options(implot PRIVATE /W0)
 
-# spdlog (v1.15.3) — header-only, vendored as a submodule. Marked SYSTEM so its
-# headers stay out of our /W4 + Werror policy; only Log.cpp compiles spdlog.
+# --- GoogleTest (vendored full tree); skip gmock/install ---
+# CRT is unified to static (/MT, /MTd) via CMAKE_MSVC_RUNTIME_LIBRARY in the top-level
+# CMakeLists (CMP0091 NEW), so gtest inherits it automatically — no gtest_force_shared_crt needed.
+set(BUILD_GMOCK OFF)
+set(INSTALL_GTEST OFF)
+# Real layout: third_party/googletest has no root CMakeLists.txt;
+# the actual one lives at googletest/googletest/CMakeLists.txt.
+# GOOGLETEST_VERSION must be set here because the root-level CMakeLists.txt
+# (which normally defines it) is absent from this vendored copy.
+set(GOOGLETEST_VERSION "1.14.0")
+add_subdirectory(googletest/googletest)
+
+# --- spdlog (v1.15.3): header-only, vendored as a git submodule ---
+# Marked SYSTEM so its headers stay out of our /W4 + /WX policy; only Log.cpp includes it.
 add_library(spdlog INTERFACE)
 target_include_directories(spdlog SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/spdlog/include)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,35 +1,35 @@
-# --- Dear ImGui: core + Win32/DX11 backends (static lib, warnings off) ---
+# gtest, imgui, implot are vendored as git submodules under third_party/.
+# Static CRT (/MT) is inherited from the top-level CMAKE_MSVC_RUNTIME_LIBRARY (CMP0091 NEW).
+# All third_party targets are excluded from our /W4 + Werror policy (they set their own warning levels).
+
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+add_subdirectory(googletest)
+
+# Dear ImGui (docking branch) — built as a small static lib we control.
 add_library(imgui STATIC
     imgui/imgui.cpp
     imgui/imgui_draw.cpp
     imgui/imgui_tables.cpp
     imgui/imgui_widgets.cpp
+    imgui/imgui_demo.cpp
     imgui/backends/imgui_impl_win32.cpp
     imgui/backends/imgui_impl_dx11.cpp
 )
-target_include_directories(imgui PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/imgui
-    ${CMAKE_CURRENT_SOURCE_DIR}/imgui/backends
-)
-target_compile_options(imgui PRIVATE /W0)
+target_include_directories(imgui PUBLIC imgui imgui/backends)
+target_link_libraries(imgui PUBLIC d3d11 dxgi d3dcompiler)
 
-# --- ImPlot (depends on ImGui) ---
+# ImPlot — plotting on top of ImGui.
 add_library(implot STATIC
     implot/implot.cpp
     implot/implot_items.cpp
 )
+target_include_directories(implot PUBLIC implot imgui)
 target_link_libraries(implot PUBLIC imgui)
-target_include_directories(implot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/implot)
-target_compile_options(implot PRIVATE /W0)
+wa_set_project_warnings(implot)
+# NOTE: implot uses our warnings but we allow it to build; core stays the strict one.
 
-# --- GoogleTest (vendored full tree); skip gmock/install ---
-# CRT is unified to static (/MT, /MTd) via CMAKE_MSVC_RUNTIME_LIBRARY in the top-level
-# CMakeLists (CMP0091 NEW), so gtest inherits it automatically — no gtest_force_shared_crt needed.
-set(BUILD_GMOCK OFF)
-set(INSTALL_GTEST OFF)
-# Real layout: third_party/googletest has no root CMakeLists.txt;
-# the actual one lives at googletest/googletest/CMakeLists.txt.
-# GOOGLETEST_VERSION must be set here because the root-level CMakeLists.txt
-# (which normally defines it) is absent from this vendored copy.
-set(GOOGLETEST_VERSION "1.14.0")
-add_subdirectory(googletest/googletest)
+# spdlog (v1.15.3) — header-only, vendored as a submodule. Marked SYSTEM so its
+# headers stay out of our /W4 + Werror policy; only Log.cpp compiles spdlog.
+add_library(spdlog INTERFACE)
+target_include_directories(spdlog SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/spdlog/include)


### PR DESCRIPTION
## Summary

Adds detailed, level-switchable logging so every WASAPI/COM/Win32 interface call's parameters and return values (HRESULT) are visible. Previously only a handful of key events were logged (monitor started/stopped, invalid format).

Backed by **spdlog v1.15.3**, added as a git submodule at `third_party/spdlog` (header-only, static-CRT compatible).

## What's included

- **`wa::log` facade** (`src/core/Log.{h,cpp}`): async logger (`overrun_oldest`, non-blocking) with three sinks — rotating file, colored stderr, and a callback sink for the GUI panel. Aligned-column output (`LEVEL [thread] Module::call args: … ret: …`); `hrName` HRESULT symbol table; a `WA_LOG` macro that short-circuits on level via `shouldLog`; per-thread names via `setThreadName`.
- **`AudioFormatStr.h`**: `formatAudio` (format string) + `narrowAscii` (wide→ASCII for log args; explicit cast to avoid C4244 under /W4).
- **~134 instrumentation sites** across `DeviceEnumerator`, `Engine`, `WasapiStream`, `MonitorEngine` — Info for lifecycle, Debug for every control-path call, Trace for the audio hot path (6 `emitTrace` sites, no heap allocation), Warn for previously-ignored return values. Pure observation; control flow unchanged.
- **CLI**: `--log-level <trace|debug|info|warn|err>` and `--log-file <path>` (plus a stderr sink; default `info`).
- **GUI**: `winaudio.log` file sink + callback panel sink; panel level dropdown / clear / autoscroll / 5000-line ring buffer.
- **Tests**: `test_log.cpp` (formatAudio, narrowAscii, hrName known/unknown, level filtering + sink delivery). Test count 73 → 78.
- **CI**: `actions/checkout` now fetches submodules (`recursive`), and `.gitmodules` uses an HTTPS URL so the runner can clone spdlog without an SSH key.

## Levels

`Error / Warn / Info / Debug / Trace`, default `Info`. Debug shows all control-path interface calls; Trace adds the per-frame audio hot path.

## Verification

- Debug **and** Release: `/W4` **0 warnings, 0 errors**.
- **78 / 78** tests pass (ctest, both configs).

## Notes

- Trace runs on the audio callback thread. spdlog formats into an inline stack buffer (no heap allocation) and enqueues with `overrun_oldest`, but the async queue is an `mpmc_blocking_queue`, so the enqueue takes a short mutex — Trace is a **diagnostic aid** that may slightly perturb the audio thread (documented in the spec and in `emitTrace`).
- Design spec: `docs/superpowers/specs/2026-07-06-winaudio-verbose-logging-design.md`.

## Not yet done (needs hardware)

Desktop smoke test of the GUI panel + live log output (Debug interface calls, Trace per-frame, `winaudio.log` on disk).
