### PR TITLE
Add Windows system loopback capture

### DIFF
--- a/docs/superpowers/specs/2026-07-09-winaudio-system-loopback-design.md
+++ b/docs/superpowers/specs/2026-07-09-winaudio-system-loopback-design.md
@@ -1,0 +1,77 @@
+# WinAudio System Loopback Design
+
+## Scope
+
+This phase adds system loopback capture only. Application/process loopback stays
+out of scope because it uses a different activation path
+(`ActivateAudioInterfaceAsync` with a process-loopback virtual device) and should
+be a separate backend rather than a `WasapiStream` subclass.
+
+System loopback captures a render endpoint with `IAudioCaptureClient` and
+`AUDCLNT_STREAMFLAGS_LOOPBACK`. It is shared-mode only. The app does not expose a
+fake capture device; render endpoints remain render endpoints.
+
+## WASAPI Facts and Risks
+
+System loopback is tied to the selected render device. Empty device ids resolve
+to the default render endpoint in the WASAPI open path.
+
+Event-driven loopback was verified on the current Windows target with active
+playback: a float32 tone produced non-zero loopback capture and the wait path
+woke from events rather than the timeout fallback. Idle/no-playback behavior is
+OS dependent: loopback may deliver silent packets or may have no packets at all.
+The UI treats no-packet gaps as a frozen capture scope, not generated silence.
+
+Requested shared formats are passed through the normal shared initialization
+path. `--format 48000/16/2 --loopback` was verified to initialize on the target
+machine; failures should surface as normal WASAPI Initialize errors.
+
+## Core Architecture
+
+`CaptureSource` distinguishes endpoint capture from system loopback:
+
+- `Endpoint`: device id is a capture endpoint.
+- `SystemLoopback`: device id is a render endpoint.
+
+`WasapiSystemLoopbackCaptureStream` reuses the capture service and ring path,
+but overrides WASAPI flow to render and adds the loopback stream flag. Exclusive
+mode is rejected from `open()` with `Result::Fail`.
+
+`MonitorEngine` accepts `CaptureSource` while retaining the legacy `capId`
+overload. The backend factory seam receives the source for capture creation so
+tests can assert source plumbing. Feedback protection lives in core: loopback
+capture with playback enabled is rejected when source and output are the same
+render endpoint, including the runtime `setPlaybackEnabled(true)` path.
+
+## CLI and GUI
+
+`capture --loopback` records system output to WAV. In loopback mode, `--device`
+is a render endpoint id.
+
+`monitor --loopback` uses `--cap` as the loopback source render endpoint and
+`--render` as the playback output. Exclusive mode is rejected before start.
+
+The GUI has a top-level Loopback page. It uses a separate `MonitorEngine`
+instance in capture-only mode:
+
+```text
+CaptureSource{SystemLoopback, renderId}, playbackEnabled=false
+```
+
+The page reuses the existing waveform/spectrogram drawing and MonitorEngine
+snapshot plumbing through a parameterized visual state. Monitor and Loopback
+state are separate; shutdown stops both engines.
+
+## Verification
+
+Automated coverage includes loopback source representation, exclusive rejection,
+factory source plumbing, feedback rejection at start, and feedback rejection when
+playback is enabled at runtime.
+
+Manual or environment-dependent checks:
+
+- Real system audio capture with active playback.
+- Idle/no-playback visualization behavior on target OS builds.
+- GUI click-through of the Loopback page Start/Stop path. In the current runner,
+  `PrintWindow` can capture the UI, but synthetic mouse messages do not reliably
+  drive Dear ImGui tab selection.

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -21,10 +21,11 @@ static void usage() {
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
         "WinAudioCli probe   --format 48000/16/2 [--device <id>] [--render|--capture]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
-        "WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N]\n"
+        "WinAudioCli monitor [--loopback] [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive] [--format R/B/C[f]]\n"
         "  (shared: WASAPI engine bridges sample rate on render side;\n"
         "   exclusive: render device must support capture format)\n"
+        "  --loopback uses render endpoint ids for capture --device / monitor --cap.\n"
         "WinAudioCli caps  [--device <id>] [--render|--capture]\n");
 }
 
@@ -211,9 +212,17 @@ int wmain(int argc, wchar_t** argv) {
         int seconds      = secStr.empty()   ? 5   : _wtoi(secStr.c_str());
         AudioFormat capFmt{};
         bool haveFmt = formatArg(argc, argv, capFmt);
+        const bool loopback = has(argc, argv, L"--loopback");
+        BackendKind kind = backendArg(argc, argv);
+        if (loopback && kind == BackendKind::WasapiExclusive) {
+            std::printf("monitor: --loopback requires --backend wasapi-shared\n");
+            return 2;
+        }
+        CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint,
+                             capId};
 
         wa::MonitorEngine mon;
-        wa::Result r = mon.start(backendArg(argc, argv), capId, renderId, delayMs,
+        wa::Result r = mon.start(kind, source, renderId, delayMs,
                                  true, {}, {}, haveFmt ? &capFmt : nullptr);
         if (!r) { std::printf("monitor start failed: %s\n", r.message.c_str()); return 2; }
         for (int i = 0; i < seconds * 5; ++i) {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -15,7 +15,7 @@ using namespace wa;
 static void usage() {
     std::printf(
         "WinAudioCli list  [--render|--capture]\n"
-        "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N]\n"
+        "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N] [--loopback]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2] (both backends)\n"
         "WinAudioCli play    --in  <file.wav> [--device <id>]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
@@ -120,8 +120,14 @@ int wmain(int argc, wchar_t** argv) {
         int seconds = secStr.empty() ? 5 : _wtoi(secStr.c_str());
         AudioFormat fmt{};
         bool haveFmt = formatArg(argc, argv, fmt);
-        Result r = eng.startCapture(backendArg(argc, argv), id, out,
-                                    haveFmt ? &fmt : nullptr);
+        const bool loopback = has(argc, argv, L"--loopback");
+        BackendKind kind = backendArg(argc, argv);
+        if (loopback && kind == BackendKind::WasapiExclusive) {
+            std::printf("capture: --loopback requires --backend wasapi-shared\n");
+            return 2;
+        }
+        CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint, id};
+        Result r = eng.startCapture(kind, source, out, haveFmt ? &fmt : nullptr);
         if (!r) { std::printf("capture start failed: %s\n", r.message.c_str()); return 2; }
         for (int i = 0; i < seconds * 10; ++i) {
             Sleep(100);

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -41,6 +41,20 @@ void computeLevels(const uint8_t* data, size_t bytes, const AudioFormat& fmt,
         }
     }
 }
+
+std::unique_ptr<IAudioBackend> makeCaptureBackend(BackendKind kind, const CaptureSource& source,
+                                                  const AudioFormat* requested) {
+    const WasapiMode mode = (kind == BackendKind::WasapiExclusive) ? WasapiMode::Exclusive
+                                                                   : WasapiMode::Shared;
+    if (source.kind == CaptureSourceKind::SystemLoopback) {
+        return std::make_unique<WasapiSystemLoopbackCaptureStream>(mode, requested);
+    }
+    return std::make_unique<WasapiCaptureStream>(mode, requested);
+}
+
+const char* captureSourceName(CaptureSourceKind kind) {
+    return kind == CaptureSourceKind::SystemLoopback ? "system-loopback" : "endpoint";
+}
 } // namespace
 
 Engine::Engine() = default;
@@ -121,19 +135,18 @@ Result Engine::probeFormat(BackendKind kind, DataFlow flow, const DeviceId& id,
     return HrToResult(hr, "probeFormat: not supported");
 }
 
-Result Engine::startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
-                            const AudioFormat* requested) {
+Result Engine::startCapture(BackendKind kind, const CaptureSource& source,
+                            const std::wstring& wavPath, const AudioFormat* requested) {
     stop();
     WA_LOG(wa::log::Level::Info, "Engine", "startCapture",
-        "kind=" + std::string(kind == BackendKind::WasapiExclusive ? "exclusive" : "shared")
-        + " id=" + (id.empty() ? std::string("(default)") : wa::narrowAscii(id))
+        "source=" + std::string(captureSourceName(source.kind))
+        + " kind=" + std::string(kind == BackendKind::WasapiExclusive ? "exclusive" : "shared")
+        + " id=" + (source.deviceId.empty() ? std::string("(default)") : wa::narrowAscii(source.deviceId))
         + (requested ? " fmt=" + wa::formatAudio(*requested) : std::string("")), "");
     try {
         ring_ = std::make_unique<RingBuffer>(kRingBytes);
-        WasapiMode mode = (kind == BackendKind::WasapiExclusive) ? WasapiMode::Exclusive
-                                                                 : WasapiMode::Shared;
-        backend_ = std::make_unique<WasapiCaptureStream>(mode, requested);
-        Result r = backend_->open(id, AudioFormat{}, ring_.get(), StreamParams{});
+        backend_ = makeCaptureBackend(kind, source, requested);
+        Result r = backend_->open(source.deviceId, AudioFormat{}, ring_.get(), StreamParams{});
         if (!r) {
             WA_LOG(wa::log::Level::Err, "Engine", "startCapture", "open", r.message);
             return r;

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -33,8 +33,12 @@ public:
     ~Engine();
 
     std::vector<DeviceInfo> enumerate(DataFlow flow);
-    Result startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
+    Result startCapture(BackendKind kind, const CaptureSource& source, const std::wstring& wavPath,
                         const AudioFormat* requested = nullptr);
+    Result startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
+                        const AudioFormat* requested = nullptr) {
+        return startCapture(kind, CaptureSource{CaptureSourceKind::Endpoint, id}, wavPath, requested);
+    }
     Result startPlayback(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
                          const AudioFormat* requested = nullptr);
     Result probeFormat(BackendKind kind, DataFlow flow, const DeviceId& id,

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -12,6 +12,16 @@ class RingBuffer;
 enum class DataFlow { Capture, Render };
 using DeviceId = std::wstring;     // MMDevice id; empty string = default endpoint
 
+enum class CaptureSourceKind {
+    Endpoint,
+    SystemLoopback,
+};
+
+struct CaptureSource {
+    CaptureSourceKind kind = CaptureSourceKind::Endpoint;
+    DeviceId deviceId; // Endpoint: capture endpoint; SystemLoopback: render endpoint
+};
+
 struct DeviceInfo {
     DeviceId     id;
     std::wstring name;

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -13,6 +13,7 @@
 #include "MonitorEngine.h"
 #include "ComUtil.h"
 #include "DelayFifo.h"
+#include "DeviceEnumerator.h"
 #include "RingBuffer.h"
 #include "SampleConvert.h"
 #include "ScopeBuffer.h"
@@ -39,18 +40,43 @@ size_t readWholeFrames(RingBuffer& ring, uint8_t* dst, uint32_t frameBytes, size
     const size_t got = ring.read(dst, frames * frameBytes);
     return got / frameBytes; // guard against a short read leaving a partial frame
 }
+
+Result sameRenderEndpoint(const DeviceId& a, const DeviceId& b, bool& same) {
+    same = false;
+    if (a.empty() && b.empty()) {
+        same = true;
+        return Result::Ok();
+    }
+    if (!a.empty() && !b.empty()) {
+        same = (a == b);
+        return Result::Ok();
+    }
+
+    ComInitGuard com;
+    if (!com.ok()) return HrToResult(com.hr, "MonitorEngine: CoInitializeEx");
+    DeviceInfo def{};
+    DeviceEnumerator de;
+    Result r = de.defaultDevice(DataFlow::Render, def);
+    if (!r) return r;
+    same = a.empty() ? (def.id == b) : (a == def.id);
+    return Result::Ok();
+}
 } // namespace
 
 MonitorEngine::MonitorEngine(BackendFactory factory) : factory_(std::move(factory)) {}
 MonitorEngine::~MonitorEngine() { teardown(); }
 
 std::unique_ptr<IAudioBackend> MonitorEngine::makeBackend(DataFlow flow, BackendKind kind,
+                                                          const CaptureSource* source,
                                                           const AudioFormat* requested) {
-    if (factory_) return factory_(flow, requested);
+    if (factory_) return factory_(flow, source, requested);
     const WasapiMode mode = (kind == BackendKind::WasapiExclusive) ? WasapiMode::Exclusive
                                                                    : WasapiMode::Shared;
-    if (flow == DataFlow::Capture)
+    if (flow == DataFlow::Capture) {
+        if (source && source->kind == CaptureSourceKind::SystemLoopback)
+            return std::make_unique<WasapiSystemLoopbackCaptureStream>(mode, requested);
         return std::make_unique<WasapiCaptureStream>(mode, requested);
+    }
     return std::make_unique<WasapiRenderStream>(mode, requested);
 }
 
@@ -64,8 +90,19 @@ Result MonitorEngine::rollback(StreamState finalState, MonitorError err, long co
     return Result::Fail(code, std::move(msg));
 }
 
-Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const DeviceId& renderId,
-                            uint32_t delayMs, bool playbackEnabled,
+Result MonitorEngine::guardLoopbackFeedback() {
+    if (capSource_.kind != CaptureSourceKind::SystemLoopback) return Result::Ok();
+    bool same = false;
+    if (Result r = sameRenderEndpoint(capSource_.deviceId, renderId_, same); !r) return r;
+    if (same) {
+        return Result::Fail(static_cast<long>(MonitorError::LoopbackFeedback),
+                            "MonitorEngine: loopback source and render output are the same device");
+    }
+    return Result::Ok();
+}
+
+Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
+                            const DeviceId& renderId, uint32_t delayMs, bool playbackEnabled,
                             const StreamParams& capParams, const StreamParams& renderParams,
                             const AudioFormat* capFormat) {
     teardown();
@@ -91,12 +128,18 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
                         static_cast<long>(MonitorError::InvalidDelay),
                         "MonitorEngine: delayMs exceeds maximum (10000 ms)");
 
+    kind_ = kind; capSource_ = capSource; renderId_ = renderId; delayMs_ = delayMs;
+    if (playbackEnabled) {
+        if (Result r = guardLoopbackFeedback(); !r)
+            return rollback(StreamState::Error, MonitorError::LoopbackFeedback, r.code, r.message);
+    }
+
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "start",
-           "cap=" + wa::narrowAscii(capId) +
+           "cap=" + wa::narrowAscii(capSource.deviceId) +
+           " source=" + std::string(capSource.kind == CaptureSourceKind::SystemLoopback ? "loopback" : "endpoint") +
            " ren=" + wa::narrowAscii(renderId) +
            " delay=" + std::to_string(delayMs) + "ms" +
            " playback=" + (playbackEnabled ? "1" : "0"), "");
-    kind_ = kind; renderId_ = renderId; delayMs_ = delayMs;
     capParams_ = capParams;
     { std::lock_guard<std::mutex> lk(paramsMtx_); renderParams_ = renderParams; }
     hasCapFormat_ = (capFormat != nullptr);
@@ -104,13 +147,14 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
 
     // --- Capture (always) ---
     captureRing_ = std::make_unique<RingBuffer>(kRingBytes);
-    capBackend_  = makeBackend(DataFlow::Capture, kind, hasCapFormat_ ? &capRequestedFormat_ : nullptr);
+    capBackend_  = makeBackend(DataFlow::Capture, kind, &capSource,
+                               hasCapFormat_ ? &capRequestedFormat_ : nullptr);
     if (!capBackend_)
         return rollback(StreamState::Idle, MonitorError::Factory, -1, "MonitorEngine: capture factory null");
     {
-        Result r = capBackend_->open(capId, AudioFormat{}, captureRing_.get(), capParams_);
+        Result r = capBackend_->open(capSource.deviceId, AudioFormat{}, captureRing_.get(), capParams_);
         WA_LOG(wa::log::Level::Debug, "MonitorEngine", "capture.open",
-               "dev=" + wa::narrowAscii(capId), r.ok ? "ok" : r.message);
+               "dev=" + wa::narrowAscii(capSource.deviceId), r.ok ? "ok" : r.message);
         if (!r) return rollback(StreamState::Idle, MonitorError::CaptureOpen, r.code, r.message);
     }
     {
@@ -121,7 +165,7 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
     capState_.store(StreamState::Running, std::memory_order_relaxed);
     capFmt_ = capBackend_->stats().actualFormat;
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "capture.started",
-           "dev=" + wa::narrowAscii(capId) + " fmt=" + wa::formatAudio(capFmt_), "ok");
+           "dev=" + wa::narrowAscii(capSource.deviceId) + " fmt=" + wa::formatAudio(capFmt_), "ok");
 
     const uint32_t sr = capFmt_.sampleRate;
     capCh_         = capFmt_.channels ? capFmt_.channels : static_cast<uint16_t>(1);
@@ -153,7 +197,10 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
             std::string msg = r.message;
             WA_LOG(wa::log::Level::Err, "MonitorEngine", "start.engageRender", "playback=1", msg);
             MonitorError err = (code == static_cast<long>(MonitorError::RateMismatch))
-                                   ? MonitorError::RateMismatch : MonitorError::RenderStart;
+                                   ? MonitorError::RateMismatch
+                               : (code == static_cast<long>(MonitorError::LoopbackFeedback))
+                                   ? MonitorError::LoopbackFeedback
+                                   : MonitorError::RenderStart;
             return rollback(StreamState::Error, err, code, std::move(msg));   // stops capture too
         }
     }
@@ -161,7 +208,7 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
     // Capture is up -> engine Running (independent of render prefill).
     overall_.store(StreamState::Running, std::memory_order_relaxed);
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "engine.running",
-           "cap=" + wa::narrowAscii(capId) +
+           "cap=" + wa::narrowAscii(capSource.deviceId) +
            " ren=" + wa::narrowAscii(renderId) +
            " sr=" + std::to_string(capFmt_.sampleRate), "ok");
 
@@ -178,11 +225,12 @@ Result MonitorEngine::start(BackendKind kind, const DeviceId& capId, const Devic
 }
 
 Result MonitorEngine::engageRender() {
+    if (Result r = guardLoopbackFeedback(); !r) return r;
     StreamParams rp;
     { std::lock_guard<std::mutex> lk(paramsMtx_); rp = renderParams_; }
     const uint32_t sr = capFmt_.sampleRate;
     renderRing_    = std::make_unique<RingBuffer>(kRingBytes);            // per-engage
-    renderBackend_ = makeBackend(DataFlow::Render, kind_, &capFmt_);
+    renderBackend_ = makeBackend(DataFlow::Render, kind_, nullptr, &capFmt_);
     if (!renderBackend_) { renderRing_.reset(); return Result::Fail(-1, "MonitorEngine: render factory null"); }
     {
         Result r = renderBackend_->open(renderId_, AudioFormat{}, renderRing_.get(), rp);
@@ -286,7 +334,10 @@ void MonitorEngine::pumpLoop() {
                 renderState_.store(StreamState::Error, std::memory_order_relaxed);
                 errorCode_.store(static_cast<uint32_t>(
                     r.code == static_cast<long>(MonitorError::RateMismatch)
-                        ? MonitorError::RateMismatch : MonitorError::RenderStart),
+                        ? MonitorError::RateMismatch
+                    : r.code == static_cast<long>(MonitorError::LoopbackFeedback)
+                        ? MonitorError::LoopbackFeedback
+                        : MonitorError::RenderStart),
                     std::memory_order_relaxed);
                 wantPlayback_.store(false, std::memory_order_relaxed); // don't retry every wake
                 // capture continues untouched

--- a/src/core/MonitorEngine.h
+++ b/src/core/MonitorEngine.h
@@ -33,6 +33,7 @@ enum class MonitorError : uint32_t {
     RateMismatch,
     PumpLaunch,
     InvalidDelay,
+    LoopbackFeedback,
 };
 
 struct MonitorStatus {
@@ -58,7 +59,11 @@ struct MonitorStatus {
 // with a fake backend (no WASAPI hardware).
 class MonitorEngine {
 public:
-    using BackendFactory = std::function<std::unique_ptr<IAudioBackend>(DataFlow, const AudioFormat*)>;
+    // `source` is non-null only for capture backend creation and is valid only
+    // during the factory call; render backend creation passes nullptr.
+    using BackendFactory =
+        std::function<std::unique_ptr<IAudioBackend>(DataFlow, const CaptureSource*,
+                                                     const AudioFormat*)>;
 
     explicit MonitorEngine(BackendFactory factory = {}); // empty => real WASAPI streams
     ~MonitorEngine();
@@ -66,10 +71,17 @@ public:
     MonitorEngine(const MonitorEngine&)            = delete;
     MonitorEngine& operator=(const MonitorEngine&) = delete;
 
-    Result start(BackendKind kind, const DeviceId& capId, const DeviceId& renderId,
+    Result start(BackendKind kind, const CaptureSource& capSource, const DeviceId& renderId,
                  uint32_t delayMs, bool playbackEnabled = true,
                  const StreamParams& capParams = {}, const StreamParams& renderParams = {},
                  const AudioFormat* capFormat = nullptr);
+    Result start(BackendKind kind, const DeviceId& capId, const DeviceId& renderId,
+                 uint32_t delayMs, bool playbackEnabled = true,
+                 const StreamParams& capParams = {}, const StreamParams& renderParams = {},
+                 const AudioFormat* capFormat = nullptr) {
+        return start(kind, CaptureSource{CaptureSourceKind::Endpoint, capId}, renderId,
+                     delayMs, playbackEnabled, capParams, renderParams, capFormat);
+    }
     void   stop();
     MonitorStatus poll();
     void   setPlaybackEnabled(bool enabled);                        // 运行期实时开关（GUI 线程）
@@ -85,7 +97,9 @@ private:
     void   pumpLoop();
     void   teardown();   // stop+join pump, stop+free backends/rings/scopes/fifo
     Result rollback(StreamState finalState, MonitorError err, long code, std::string msg);
+    Result guardLoopbackFeedback();
     std::unique_ptr<IAudioBackend> makeBackend(DataFlow flow, BackendKind kind,
+                                               const CaptureSource* source,
                                                const AudioFormat* requested);
     Result engageRender();      // pump 前(start) 或 pump 线程调用；开渲染+校验+建 FIFO/刮擦；失败原子(全关渲染)
     void   disengageRender();   // 停+关渲染、释放设备、reset renderRing_/delayFifo_；不动 renderScope_
@@ -94,6 +108,7 @@ private:
 
     // Run-const session parameters (set in start(), consumed in engageRender()).
     BackendKind kind_{BackendKind::WasapiShared};
+    CaptureSource capSource_{};
     DeviceId    renderId_{};
     uint32_t    delayMs_ = 0;
     std::atomic<bool> wantPlayback_{false};

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -33,6 +33,17 @@ AUDCLNT_STREAMOPTIONS mapStreamOption(StreamOption o) {
     }
 }
 
+uint32_t loopbackSilenceFramesForTimeout(uint32_t sampleRate, uint32_t timeoutMs) {
+    if (sampleRate == 0 || timeoutMs == 0) return 0;
+    return static_cast<uint32_t>((static_cast<uint64_t>(sampleRate) * timeoutMs) / 1000u);
+}
+
+bool shouldWriteLoopbackIdleSilence(unsigned waitResult, long packetStatus,
+                                    bool sawPacket, bool wroteFrames) {
+    return waitResult == WAIT_TIMEOUT && SUCCEEDED(static_cast<HRESULT>(packetStatus)) &&
+           !sawPacket && !wroteFrames;
+}
+
 WasapiStream::WasapiStream(WasapiMode mode, const AudioFormat* requested)
     : mode_(mode), hasRequested_(requested != nullptr) {
     if (requested) requestedFormat_ = *requested;
@@ -313,7 +324,8 @@ void WasapiStream::threadMain() {
     runLoop();
 
     HRESULT hrStop = client_->Stop();
-    WA_LOG(wa::log::Level::Warn, "WasapiStream", "Stop", "", wa::log::hrName(hrStop));
+    WA_LOG(FAILED(hrStop) ? wa::log::Level::Err : wa::log::Level::Debug,
+           "WasapiStream", "Stop", "", wa::log::hrName(hrStop));
 }
 
 // --------------------------------------------------------------------------
@@ -356,14 +368,18 @@ Result WasapiCaptureStream::createService() {
 void WasapiCaptureStream::runLoop() {
     wa::log::setThreadName("capW");
     WA_LOG(wa::log::Level::Info, "WasapiStream", "runLoop", "capture loop started", "");
+    constexpr DWORD kCaptureWaitMs = 200;
     while (running_.load()) {
-        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
+        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), kCaptureWaitMs);
         wa::log::emitTrace("WasapiStream", "WaitForSingleObject", 0, waitRc, 0);
+        bool wroteFrames = false;
+        bool sawPacket = false;
         UINT32 packet = 0;
-        HRESULT hrNP;
+        HRESULT hrNP = S_OK;
         while (hrNP = capture_->GetNextPacketSize(&packet),
                wa::log::emitTrace("WasapiStream", "GetNextPacketSize", packet, 0, (long)hrNP),
                SUCCEEDED(hrNP) && packet > 0) {
+            sawPacket = true;
             BYTE* data = nullptr; UINT32 frames = 0; DWORD flags = 0;
             HRESULT hrGB = capture_->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
             wa::log::emitTrace("WasapiStream", "GetBuffer", frames, (unsigned)flags, (long)hrGB);
@@ -374,13 +390,24 @@ void WasapiCaptureStream::runLoop() {
                 static thread_local std::vector<uint8_t> zeros;
                 zeros.assign(bytes, 0);
                 ring_->write(zeros.data(), bytes);
+                wroteFrames = true;
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             } else if (data) {
                 ring_->write(data, bytes);
+                wroteFrames = true;
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             }
             HRESULT hrRB = capture_->ReleaseBuffer(frames);
             wa::log::emitTrace("WasapiStream", "ReleaseBuffer", frames, 0, (long)hrRB);
+        }
+        if (shouldWriteLoopbackIdleSilence(waitRc, static_cast<long>(hrNP), sawPacket, wroteFrames)) {
+            const uint32_t frames = idleSilenceFrames(kCaptureWaitMs);
+            if (frames > 0 && frameBytes_ > 0) {
+                static thread_local std::vector<uint8_t> zeros;
+                zeros.assign(static_cast<size_t>(frames) * frameBytes_, 0);
+                ring_->write(zeros.data(), zeros.size());
+                if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
+            }
         }
     }
 }

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -167,6 +167,7 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
         REFERENCE_TIME dur = params_.bufferMs
             ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10'000
             : 10'000'000 / 10; // default: 100 ms buffer
+        const DWORD extraFlags = extraSharedInitFlags();
 
         if (hasRequested_) {
             // Caller specified a format: ask WASAPI's engine to convert via AUTOCONVERTPCM.
@@ -179,7 +180,8 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
                 AUDCLNT_SHAREMODE_SHARED,
                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
                 AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
-                AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+                AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY |
+                extraFlags,
                 dur, 0,
                 reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
             WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared,requested)", "fmt=" + wa::formatAudio(requestedFormat_), wa::log::hrName(hr));
@@ -196,7 +198,8 @@ Result WasapiStream::prepareClient(IMMDevice* dev) {
         actualFormat_ = fromWaveFormat(mix);
         frameBytes_ = actualFormat_.blockAlign();
         hr = client_->Initialize(AUDCLNT_SHAREMODE_SHARED,
-                                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, 0, mix, nullptr);
+                                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK | extraFlags,
+                                 dur, 0, mix, nullptr);
         WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
         CoTaskMemFree(mix);
         if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(shared)"); }
@@ -354,7 +357,8 @@ void WasapiCaptureStream::runLoop() {
     wa::log::setThreadName("capW");
     WA_LOG(wa::log::Level::Info, "WasapiStream", "runLoop", "capture loop started", "");
     while (running_.load()) {
-        WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
+        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
+        wa::log::emitTrace("WasapiStream", "WaitForSingleObject", 0, waitRc, 0);
         UINT32 packet = 0;
         HRESULT hrNP;
         while (hrNP = capture_->GetNextPacketSize(&packet),
@@ -379,6 +383,22 @@ void WasapiCaptureStream::runLoop() {
             wa::log::emitTrace("WasapiStream", "ReleaseBuffer", frames, 0, (long)hrRB);
         }
     }
+}
+
+// --------------------------------------------------------------------------
+// WasapiSystemLoopbackCaptureStream
+// --------------------------------------------------------------------------
+
+WasapiSystemLoopbackCaptureStream::WasapiSystemLoopbackCaptureStream(
+    WasapiMode mode, const AudioFormat* requested)
+    : WasapiCaptureStream(mode, requested) {}
+
+Result WasapiSystemLoopbackCaptureStream::open(const DeviceId& id, const AudioFormat& fmt,
+                                               RingBuffer* ring, const StreamParams& params) {
+    if (isExclusive()) {
+        return Result::Fail(-1, "WASAPI system loopback requires Shared mode");
+    }
+    return WasapiCaptureStream::open(id, fmt, ring, params);
 }
 
 // --------------------------------------------------------------------------

--- a/src/core/WasapiStream.h
+++ b/src/core/WasapiStream.h
@@ -37,6 +37,7 @@ protected:
     virtual void   preRoll() {}           // render: one silent buffer; capture: nothing
     virtual void   runLoop() = 0;         // drain/feed loop; runs while running_
     virtual void   resetService() = 0;    // Reset() the service ComPtr (called from close())
+    virtual DWORD  extraSharedInitFlags() const { return 0; }
 
     bool isExclusive() const { return mode_ == WasapiMode::Exclusive; }
 
@@ -84,6 +85,16 @@ protected:
 private:
     ComPtr<IAudioCaptureClient> capture_;
     void* pumpEvent_ = nullptr; // auto-reset event; signaled after each ring write
+};
+
+class WasapiSystemLoopbackCaptureStream : public WasapiCaptureStream {
+public:
+    WasapiSystemLoopbackCaptureStream(WasapiMode mode, const AudioFormat* requested);
+    Result open(const DeviceId& id, const AudioFormat& fmt, RingBuffer* ring,
+                const StreamParams& params) override;
+protected:
+    EDataFlow dataFlow() const override { return eRender; }
+    DWORD extraSharedInitFlags() const override { return AUDCLNT_STREAMFLAGS_LOOPBACK; }
 };
 
 class WasapiRenderStream : public WasapiStream {

--- a/src/core/WasapiStream.h
+++ b/src/core/WasapiStream.h
@@ -18,6 +18,9 @@ enum class WasapiMode { Shared, Exclusive };
 // StreamParams -> WASAPI enum mapping (free functions, exposed for unit tests).
 AUDIO_STREAM_CATEGORY mapCategory(AudioCategory c);
 AUDCLNT_STREAMOPTIONS mapStreamOption(StreamOption o);
+uint32_t loopbackSilenceFramesForTimeout(uint32_t sampleRate, uint32_t timeoutMs);
+bool shouldWriteLoopbackIdleSilence(unsigned waitResult, long packetStatus,
+                                    bool sawPacket, bool wroteFrames);
 
 class WasapiStream : public IAudioBackend {
 public:
@@ -82,6 +85,7 @@ protected:
     Result createService() override;
     void   runLoop() override;
     void   resetService() override { capture_.Reset(); }
+    virtual uint32_t idleSilenceFrames(uint32_t timeoutMs) const { (void)timeoutMs; return 0; }
 private:
     ComPtr<IAudioCaptureClient> capture_;
     void* pumpEvent_ = nullptr; // auto-reset event; signaled after each ring write
@@ -95,6 +99,9 @@ public:
 protected:
     EDataFlow dataFlow() const override { return eRender; }
     DWORD extraSharedInitFlags() const override { return AUDCLNT_STREAMFLAGS_LOOPBACK; }
+    uint32_t idleSilenceFrames(uint32_t timeoutMs) const override {
+        return loopbackSilenceFramesForTimeout(actualFormat_.sampleRate, timeoutMs);
+    }
 };
 
 class WasapiRenderStream : public WasapiStream {

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -382,12 +382,7 @@ void AppUi::drawLoopbackLeftPanel() {
     ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
 
     ImGui::SeparatorText("Log");
-    if (ImGui::Button("Clear")) logLines_.clear();
-    ImGui::BeginChild("loopbackLog", ImVec2(0, 0), true);
-    for (const auto& l : logLines_) ImGui::TextUnformatted(l.c_str());
-    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
-        ImGui::SetScrollHereY(1.0f);
-    ImGui::EndChild();
+    drawLogPanel("loopbackLog", false);
 }
 
 void AppUi::drawLeftPanel() {
@@ -483,16 +478,28 @@ void AppUi::drawLeftPanel() {
 
     // --- Log (fills remaining height) ---
     ImGui::SeparatorText("Log");
-    static const char* kLevels[] = {"Trace", "Debug", "Info", "Warn", "Err"};
-    ImGui::SetNextItemWidth(90.0f);
-    if (ImGui::Combo("##loglevel", &logLevelIdx_, kLevels, IM_ARRAYSIZE(kLevels)))
-        wa::log::setLevel(static_cast<wa::log::Level>(logLevelIdx_));
-    ImGui::SameLine();
-    if (ImGui::Button("Clear")) logLines_.clear();
-    ImGui::BeginChild("log", ImVec2(0, 0), true);
+    drawLogPanel("log", true);
+}
+
+void AppUi::drawLogPanel(const char* childId, bool showLevelFilter) {
+    if (showLevelFilter) {
+        static const char* kLevels[] = {"Trace", "Debug", "Info", "Warn", "Err"};
+        ImGui::SetNextItemWidth(90.0f);
+        if (ImGui::Combo("##loglevel", &logLevelIdx_, kLevels, IM_ARRAYSIZE(kLevels)))
+            wa::log::setLevel(static_cast<wa::log::Level>(logLevelIdx_));
+        ImGui::SameLine();
+        if (ImGui::Button("Clear##mainLog")) logLines_.clear();
+    } else {
+        if (ImGui::Button("Clear##loopbackLog")) logLines_.clear();
+    }
+
+    ImGui::BeginChild(childId, ImVec2(0, 0), true);
+    const bool wasPinned = ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f;
+    ImGui::PushTextWrapPos(0.0f);
     for (const auto& l : logLines_) ImGui::TextUnformatted(l.c_str());
-    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
-        ImGui::SetScrollHereY(1.0f);   // autoscroll while pinned to the bottom
+    ImGui::PopTextWrapPos();
+    if (wasPinned)
+        ImGui::SetScrollHereY(1.0f);
     ImGui::EndChild();
 }
 

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -65,6 +65,8 @@ void AppUi::refreshMonitorDevices() {
                                      ? capDevices_[(size_t)capDevIdx_].id : L"";
     const wa::DeviceId prevRen = (renderDevIdx_ >= 0 && renderDevIdx_ < (int)renderDevices_.size())
                                      ? renderDevices_[(size_t)renderDevIdx_].id : L"";
+    const wa::DeviceId prevLoopback = (loopbackDevIdx_ >= 0 && loopbackDevIdx_ < (int)renderDevices_.size())
+                                      ? renderDevices_[(size_t)loopbackDevIdx_].id : L"";
     capDevices_.clear();
     renderDevices_.clear();
     enumerator_.enumerate(wa::DataFlow::Capture, capDevices_);
@@ -80,11 +82,13 @@ void AppUi::refreshMonitorDevices() {
     };
     capDevIdx_    = pick(capDevices_, prevCap);
     renderDevIdx_ = pick(renderDevices_, prevRen);
+    loopbackDevIdx_ = pick(renderDevices_, prevLoopback);
     monitorDevicesLoaded_ = true;
 }
 
 void AppUi::stopAll() {
     monitor_.stop();
+    loopback_.stop();
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -211,6 +215,36 @@ const char* AppUi::chartTitle(int id) {
     }
 }
 
+void AppUi::resetVisuals(VisualState& viz) {
+    viz.capWave.clear();
+    viz.renderWave.clear();
+    viz.waveSr = 0;
+    viz.waveN = 0;
+    viz.xLink0 = 0.0;
+    viz.xLink1 = 0.0;
+    viz.envX.clear();
+    viz.envMin.clear();
+    viz.envMax.clear();
+    viz.workCap.clear();
+    viz.workRender.clear();
+    viz.specWin.clear();
+    viz.magCap.clear();
+    viz.magRender.clear();
+    viz.nextCapEnd = 0;
+    viz.nextRenderEnd = 0;
+    viz.specSr = 0;
+    viz.capSpec.reset();
+    viz.renderSpec.reset();
+    std::fill(std::begin(viz.plotHovPrev), std::end(viz.plotHovPrev), false);
+}
+
+void AppUi::resetRenderVisuals(VisualState& viz) {
+    viz.magRender.clear();
+    viz.renderSpec.reset();
+    viz.nextRenderEnd = 0;
+    std::fill(viz.renderWave.begin(), viz.renderWave.end(), 0.f);
+}
+
 void AppUi::draw() {
     // Drain lines buffered by the logging pump thread into the panel history (bounded).
     {
@@ -225,32 +259,135 @@ void AppUi::draw() {
 
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
     ms_ = monitor_.poll();
+    loopbackMs_ = loopback_.poll();
     const int curRenderState = (int)ms_.renderState;
     if (prevRenderState_ == (int)wa::StreamState::Running &&
         curRenderState  != (int)wa::StreamState::Running) {
-        magRender_.clear();
-        renderSpec_.reset();
-        nextRenderEnd_ = 0;
-        std::fill(renderWave_.begin(), renderWave_.end(), 0.f);
+        resetRenderVisuals(monitorViz_);
     }
     prevRenderState_ = curRenderState;
 
     ImGui::SetNextWindowSizeConstraints(ImVec2(800, 400), ImVec2(FLT_MAX, FLT_MAX));
     ImGui::Begin("WinAudio");
 
-    // Left column: Devices / Control / Status / Log
+    if (ImGui::BeginTabBar("##pages")) {
+        if (ImGui::BeginTabItem("Monitor")) {
+            drawMonitorPage();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem("Loopback")) {
+            drawLoopbackPage();
+            ImGui::EndTabItem();
+        }
+        ImGui::EndTabBar();
+    }
+
+    ImGui::End();
+}
+
+void AppUi::drawMonitorPage() {
     ImGui::BeginChild("left", ImVec2(360, 0), true);
     drawLeftPanel();
     ImGui::EndChild();
 
     ImGui::SameLine();
 
-    // Right column: two combo panels (capture + render), drag to reorder
     ImGui::BeginChild("charts", ImVec2(0, 0), true);
-    drawChartsColumn();
+    drawChartsColumn(monitor_, ms_, monitorViz_);
+    ImGui::EndChild();
+}
+
+void AppUi::drawLoopbackPage() {
+    ImGui::BeginChild("loopbackLeft", ImVec2(320, 0), true);
+    drawLoopbackLeftPanel();
     ImGui::EndChild();
 
-    ImGui::End();
+    ImGui::SameLine();
+
+    ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
+    const uint32_t sr = loopbackMs_.sampleRate;
+    const bool overallRunning = (loopbackMs_.overall == wa::StreamState::Running && sr > 0);
+    const uint32_t hz = (sr > 0) ? sr : 48000u;
+    if (loopbackViz_.xLink1 <= 0.0)
+        loopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)hz;
+    if (overallRunning) {
+        if (sr != loopbackViz_.waveSr) {
+            loopbackViz_.waveSr = sr;
+            loopbackViz_.waveN = (int)(kSpecCols * kFftHop);
+            loopbackViz_.capWave.assign((size_t)loopbackViz_.waveN, 0.f);
+            loopbackViz_.xLink0 = 0.0;
+            loopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)sr;
+        }
+        if (sr != loopbackViz_.specSr) {
+            loopbackViz_.specSr = sr;
+            loopbackViz_.workCap.resize(kFftWin);
+            loopbackViz_.specWin.resize(kFftWin);
+            loopbackViz_.capSpec = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
+        }
+    }
+    ImGui::TextUnformatted("System audio waveform + spectrogram");
+    drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
+    ImGui::EndChild();
+}
+
+void AppUi::drawLoopbackLeftPanel() {
+    if (!monitorDevicesLoaded_) refreshMonitorDevices();
+
+    ImGui::SeparatorText("Source");
+    if (ImGui::Button("Refresh devices")) refreshMonitorDevices();
+    std::string preview = "(no render devices)";
+    if (!renderDevices_.empty() && loopbackDevIdx_ >= 0 && loopbackDevIdx_ < (int)renderDevices_.size())
+        preview = (renderDevices_[(size_t)loopbackDevIdx_].isDefault ? "* " : "") +
+                  wtou(renderDevices_[(size_t)loopbackDevIdx_].name);
+    ImGui::SetNextItemWidth(-1);
+    if (ImGui::BeginCombo("System audio", preview.c_str())) {
+        for (int i = 0; i < (int)renderDevices_.size(); ++i) {
+            std::string l = (renderDevices_[(size_t)i].isDefault ? "* " : "  ") +
+                            wtou(renderDevices_[(size_t)i].name);
+            if (ImGui::Selectable((l + "##loopdev" + std::to_string(i)).c_str(),
+                                  loopbackDevIdx_ == i))
+                loopbackDevIdx_ = i;
+        }
+        ImGui::EndCombo();
+    }
+
+    ImGui::SeparatorText("Control");
+    const ImVec2 ctrlBtn(120.0f, ImGui::GetFrameHeight() * 1.3f);
+    if (!loopbackStarted_) {
+        if (ImGui::Button("Start", ctrlBtn)) {
+            wa::DeviceId id = renderDevices_.empty() ? L"" : renderDevices_[(size_t)loopbackDevIdx_].id;
+            wa::CaptureSource source{wa::CaptureSourceKind::SystemLoopback, id};
+            wa::Result r = loopback_.start(wa::BackendKind::WasapiShared, source, L"", 0,
+                                           false);
+            logLines_.push_back(r ? "loopback started" : ("loopback error: " + r.message));
+            if (r) {
+                loopbackStarted_ = true;
+                resetVisuals(loopbackViz_);
+            }
+        }
+    } else {
+        if (ImGui::Button("Stop", ctrlBtn)) {
+            loopback_.stop();
+            loopbackStarted_ = false;
+            resetVisuals(loopbackViz_);
+            logLines_.push_back("loopback stopped");
+        }
+    }
+
+    ImGui::SeparatorText("Status");
+    const char* ss[] = {"Idle", "Running", "Error"};
+    ImGui::Text("overall=%s  cap=%s  sr=%u",
+        ss[(int)loopbackMs_.overall], ss[(int)loopbackMs_.capState], loopbackMs_.sampleRate);
+    ImGui::Text("xrun=%llu", (unsigned long long)loopbackMs_.capXruns);
+    ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
+
+    ImGui::SeparatorText("Log");
+    if (ImGui::Button("Clear")) logLines_.clear();
+    ImGui::BeginChild("loopbackLog", ImVec2(0, 0), true);
+    for (const auto& l : logLines_) ImGui::TextUnformatted(l.c_str());
+    if (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 1.0f)
+        ImGui::SetScrollHereY(1.0f);
+    ImGui::EndChild();
 }
 
 void AppUi::drawLeftPanel() {
@@ -310,13 +447,14 @@ void AppUi::drawLeftPanel() {
             logLines_.push_back(r ? "monitor started" : ("monitor error: " + r.message));
             if (r) {
                 monitorStarted_ = true;
-                nextCapEnd_ = 0; nextRenderEnd_ = 0; specSr_ = 0; waveSr_ = 0;
+                resetVisuals(monitorViz_);
             }
         }
     } else {
         if (ImGui::Button("Stop", ctrlBtn)) {
             monitor_.stop();
             monitorStarted_ = false;
+            resetVisuals(monitorViz_);
             logLines_.push_back("monitor stopped");
         }
     }
@@ -418,33 +556,34 @@ void AppUi::drawAdvancedModal() {
     ImGui::EndPopup();
 }
 
-void AppUi::drawChartsColumn() {
-    const uint32_t sr         = ms_.sampleRate;
-    const bool overallRunning = (ms_.overall == wa::StreamState::Running && sr > 0);
+void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
+                             VisualState& viz) {
+    const uint32_t sr         = status.sampleRate;
+    const bool overallRunning = (status.overall == wa::StreamState::Running && sr > 0);
 
     // Shared time axis (seconds) for all time-domain charts = the spectrogram's history window.
     // Initialize once; reset to the full window whenever the rate changes (below).
     const uint32_t hz = (sr > 0) ? sr : 48000u;
-    if (xLink1_ <= 0.0) { xLink0_ = 0.0; xLink1_ = (double)(kSpecCols * kFftHop) / (double)hz; }
+    if (viz.xLink1 <= 0.0) { viz.xLink0 = 0.0; viz.xLink1 = (double)(kSpecCols * kFftHop) / (double)hz; }
 
     if (overallRunning) {
         // Waveform buffers cover the same window as the spectrogram (kSpecCols*kFftHop samples).
-        if (sr != waveSr_) {
-            waveSr_ = sr; waveN_ = (int)(kSpecCols * kFftHop);
-            capWave_.assign((size_t)waveN_, 0.f);
-            renderWave_.assign((size_t)waveN_, 0.f);
-            xLink0_ = 0.0; xLink1_ = (double)(kSpecCols * kFftHop) / (double)sr;  // reset zoom to full window
+        if (sr != viz.waveSr) {
+            viz.waveSr = sr; viz.waveN = (int)(kSpecCols * kFftHop);
+            viz.capWave.assign((size_t)viz.waveN, 0.f);
+            viz.renderWave.assign((size_t)viz.waveN, 0.f);
+            viz.xLink0 = 0.0; viz.xLink1 = (double)(kSpecCols * kFftHop) / (double)sr;  // reset zoom to full window
         }
 
         // Spectrum / spectrogram buffers: rebuild on rate change; recreate renderSpec_ if cleared.
-        if (sr != specSr_) {
-            specSr_ = sr;
-            workCap_.resize(kFftWin); workRender_.resize(kFftWin); specWin_.resize(kFftWin);
-            capSpec_    = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
-            renderSpec_ = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
-        } else if (!renderSpec_) {
+        if (sr != viz.specSr) {
+            viz.specSr = sr;
+            viz.workCap.resize(kFftWin); viz.workRender.resize(kFftWin); viz.specWin.resize(kFftWin);
+            viz.capSpec    = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
+            viz.renderSpec = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
+        } else if (!viz.renderSpec) {
             // renderSpec_ was cleared by a playback-stop transition; recreate fresh.
-            renderSpec_ = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)specSr_ / 2.0, specSr_);
+            viz.renderSpec = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)viz.specSr / 2.0, viz.specSr);
         }
     }
 
@@ -464,7 +603,7 @@ void AppUi::drawChartsColumn() {
             ImGui::EndDragDropSource();
         }
         ImGui::SameLine(); ImGui::TextUnformatted(chartTitle(id));
-        drawChartPanel(id);
+        drawChartPanel(id, engine, status, viz);
         if (ImGui::BeginDragDropTarget()) {
             if (const ImGuiPayload* pl = ImGui::AcceptDragDropPayload("CHART_POS")) {
                 int from = *(const int*)pl->Data;
@@ -507,7 +646,8 @@ static ImPlotColormap waSpectroColormap() {
 // label the real frequencies, so the axis reads in Hz. The range is set once (not Always) so the
 // user can pan/zoom the frequency axis; the explicit Once limits apply on the plot's first frame,
 // so the always-created (possibly empty) plot never pins to the [0,1] defaults.
-void AppUi::drawSpectrogramPanel(const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot) {
+void AppUi::drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spectrogram* spec,
+                                 double histSec, float height, int slot) {
     // spec == null (not running / no data yet): draw the axes only with a default 20..24 kHz range
     // so the panel is ALWAYS visible, consistent with the waveform panel. The explicit
     // log-range SetupAxisLimits keeps the empty plot from pinning to [0,1] (the old auto-fit bug).
@@ -532,10 +672,10 @@ void AppUi::drawSpectrogramPanel(const char* plotId, wa::Spectrogram* spec, doub
         // hover the Y ruler (plot-area hover = false -> unlocked) to zoom/pan the frequency axis.
         // Audition-style: no time labels here (the waveform above carries the top time ruler);
         // Hz ruler on the RIGHT.
-        const ImPlotAxisFlags yf = (plotHovPrev_[slot] ? ImPlotAxisFlags_Lock : ImPlotAxisFlags_None)
+        const ImPlotAxisFlags yf = (viz.plotHovPrev[slot] ? ImPlotAxisFlags_Lock : ImPlotAxisFlags_None)
                                  | ImPlotAxisFlags_Opposite;
         ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_NoTickLabels, yf);
-        ImPlot::SetupAxisLinks(ImAxis_X1, &xLink0_, &xLink1_);   // shared time axis (waveforms + spectrograms)
+        ImPlot::SetupAxisLinks(ImAxis_X1, &viz.xLink0, &viz.xLink1);   // shared time axis (waveforms + spectrograms)
         // Clamp panning/zooming to the buffered history / frequency range — no empty space.
         ImPlot::SetupAxisLimitsConstraints(ImAxis_X1, 0.0, histSec);
         ImPlot::SetupAxisLimitsConstraints(ImAxis_Y1, loL, hiL);
@@ -545,7 +685,7 @@ void AppUi::drawSpectrogramPanel(const char* plotId, wa::Spectrogram* spec, doub
             ImPlot::PlotHeatmap("##hm", spec->data(), spec->rows(), spec->cols(), -96.0, 0.0, nullptr,
                 ImPlotPoint(0, loL), ImPlotPoint(histSec, hiL));
         drawYUnitLabel("Hz", true);
-        plotHovPrev_[slot] = ImPlot::IsPlotHovered();
+        viz.plotHovPrev[slot] = ImPlot::IsPlotHovered();
         ImPlot::EndPlot();
     }
     ImPlot::PopColormap();
@@ -555,15 +695,16 @@ void AppUi::drawSpectrogramPanel(const char* plotId, wa::Spectrogram* spec, doub
 // so the buffer's tail holds the newest samples (right edge). Level-of-detail: zoomed in -> raw
 // line; zoomed out -> per-pixel min/max envelope, so detail sharpens as you zoom and the waveform
 // stays column-aligned with the spectrogram.
-void AppUi::drawWaveformPanel(const char* plotId, const float* wave, int n, uint32_t sr, bool haveData, float height, int slot) {
+void AppUi::drawWaveformPanel(VisualState& viz, const char* plotId, const float* wave, int n,
+                              uint32_t sr, bool haveData, float height, int slot) {
     if (!ImPlot::BeginPlot(plotId, ImVec2(-1, height))) return;
     // Y locked while the plot area was hovered last frame -> in-plot wheel/drag act on X only;
     // zoom amplitude via the Y ruler. X tick labels hidden: the spectrogram below shows the time.
     // Audition-style: time ruler on TOP of the waveform, dB ruler on the RIGHT.
-    const ImPlotAxisFlags yf = (plotHovPrev_[slot] ? ImPlotAxisFlags_Lock : ImPlotAxisFlags_None)
+    const ImPlotAxisFlags yf = (viz.plotHovPrev[slot] ? ImPlotAxisFlags_Lock : ImPlotAxisFlags_None)
                              | ImPlotAxisFlags_Opposite;
     ImPlot::SetupAxes(nullptr, nullptr, ImPlotAxisFlags_Opposite, yf);
-    ImPlot::SetupAxisLinks(ImAxis_X1, &xLink0_, &xLink1_);        // shared time axis
+    ImPlot::SetupAxisLinks(ImAxis_X1, &viz.xLink0, &viz.xLink1);        // shared time axis
     // Clamp panning/zooming to the buffered history — no scrolling into empty space.
     const double hist = (sr > 0 && n > 0) ? (double)n / (double)sr
                                           : (double)(kSpecCols * kFftHop) / 48000.0;
@@ -576,8 +717,8 @@ void AppUi::drawWaveformPanel(const char* plotId, const float* wave, int n, uint
     ImPlot::SetupAxisTicks(ImAxis_Y1, kAmpV, 11, kAmpL);
     if (haveData && n > 0 && sr > 0) {
         const double invSr = 1.0 / (double)sr;
-        int iLo = (int)std::floor(xLink0_ * (double)sr);
-        int iHi = (int)std::ceil (xLink1_ * (double)sr);
+        int iLo = (int)std::floor(viz.xLink0 * (double)sr);
+        int iHi = (int)std::ceil (viz.xLink1 * (double)sr);
         if (iLo < 0) iLo = 0;
         if (iHi > n - 1) iHi = n - 1;
         if (iHi > iLo) {
@@ -585,13 +726,13 @@ void AppUi::drawWaveformPanel(const char* plotId, const float* wave, int n, uint
             float pw = ImPlot::GetPlotSize().x;
             if (pw < 1.0f) pw = 1.0f;
             if (visN <= (int)(2.0f * pw)) {
-                envMax_.resize((size_t)visN);                     // scratch: warped raw samples
-                for (int i = 0; i < visN; ++i) envMax_[(size_t)i] = dbWarp(wave[iLo + i]);
+                viz.envMax.resize((size_t)visN);                     // scratch: warped raw samples
+                for (int i = 0; i < visN; ++i) viz.envMax[(size_t)i] = dbWarp(wave[iLo + i]);
                 ImPlot::SetNextLineStyle(ImVec4(0.40f, 0.89f, 0.59f, 1.00f));   // Audition green
-                ImPlot::PlotLine("##wave", envMax_.data(), visN, invSr, (double)iLo * invSr);
+                ImPlot::PlotLine("##wave", viz.envMax.data(), visN, invSr, (double)iLo * invSr);
             } else {
                 const int cols = (int)pw;
-                envX_.resize((size_t)cols); envMin_.resize((size_t)cols); envMax_.resize((size_t)cols);
+                viz.envX.resize((size_t)cols); viz.envMin.resize((size_t)cols); viz.envMax.resize((size_t)cols);
                 for (int c = 0; c < cols; ++c) {
                     int s0 = iLo + (int)((int64_t)visN * c / cols);
                     int s1 = iLo + (int)((int64_t)visN * (c + 1) / cols);
@@ -599,45 +740,46 @@ void AppUi::drawWaveformPanel(const char* plotId, const float* wave, int n, uint
                     if (s1 > n)   s1 = n;
                     float mn = wave[s0], mx = wave[s0];
                     for (int s = s0 + 1; s < s1; ++s) { mn = std::min(mn, wave[s]); mx = std::max(mx, wave[s]); }
-                    envX_[(size_t)c]   = (float)(0.5 * (double)(s0 + s1) * invSr);
-                    envMin_[(size_t)c] = dbWarp(mn);              // warp commutes with min/max
-                    envMax_[(size_t)c] = dbWarp(mx);
+                    viz.envX[(size_t)c]   = (float)(0.5 * (double)(s0 + s1) * invSr);
+                    viz.envMin[(size_t)c] = dbWarp(mn);              // warp commutes with min/max
+                    viz.envMax[(size_t)c] = dbWarp(mx);
                 }
                 ImPlot::SetNextFillStyle(ImVec4(0.40f, 0.89f, 0.59f, 1.00f), 1.0f);   // Audition green, solid
-                ImPlot::PlotShaded("##wave", envX_.data(), envMin_.data(), envMax_.data(), cols);
+                ImPlot::PlotShaded("##wave", viz.envX.data(), viz.envMin.data(), viz.envMax.data(), cols);
             }
         }
     }
     drawYUnitLabel("dB", true);
-    plotHovPrev_[slot] = ImPlot::IsPlotHovered();
+    viz.plotHovPrev[slot] = ImPlot::IsPlotHovered();
     ImPlot::EndPlot();
 }
 
 // One combined cell per stream: waveform on top, spectrogram below (Audition-style), sharing the
 // linked time axis, with a draggable horizontal splitter between them. comboRatio_ is shared by
 // both streams so the capture and render cells stay height-aligned for side-by-side comparison.
-void AppUi::drawComboPanel(bool renderSide) {
-    const uint32_t sr         = ms_.sampleRate;
-    const bool overallRunning = (ms_.overall     == wa::StreamState::Running && sr > 0);
-    const bool renderRunning  = (ms_.renderState == wa::StreamState::Running);
+void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
+                           VisualState& viz, bool renderSide) {
+    const uint32_t sr         = status.sampleRate;
+    const bool overallRunning = (status.overall     == wa::StreamState::Running && sr > 0);
+    const bool renderRunning  = (status.renderState == wa::StreamState::Running);
 
     // Snapshot the newest samples into the tail of the history buffer (progressive fill).
-    std::vector<float>& wave = renderSide ? renderWave_ : capWave_;
+    std::vector<float>& wave = renderSide ? viz.renderWave : viz.capWave;
     bool ok = false;
-    if (overallRunning && waveSr_ > 0 && (!renderSide || renderRunning)) {
-        const size_t avail = (size_t)(renderSide ? monitor_.renderWritten() : monitor_.capWritten());
-        const size_t nn = std::min(avail, (size_t)waveN_);
+    if (overallRunning && viz.waveSr > 0 && (!renderSide || renderRunning)) {
+        const size_t avail = (size_t)(renderSide ? engine.renderWritten() : engine.capWritten());
+        const size_t nn = std::min(avail, (size_t)viz.waveN);
         if (nn > 0) {
-            const int head = waveN_ - (int)nn;
+            const int head = viz.waveN - (int)nn;
             std::fill(wave.begin(), wave.begin() + head, 0.f);
             uint64_t end = 0;
-            ok = renderSide ? monitor_.snapshotRender(nn, wave.data() + head, end)
-                            : monitor_.snapshotCapture(nn, wave.data() + head, end);
+            ok = renderSide ? engine.snapshotRender(nn, wave.data() + head, end)
+                            : engine.snapshotCapture(nn, wave.data() + head, end);
         }
     }
 
-    const float waveH = kComboH * comboRatio_;
-    drawWaveformPanel(renderSide ? "##renWave" : "##capWave", wave.data(), waveN_, waveSr_, ok,
+    const float waveH = kComboH * viz.comboRatio;
+    drawWaveformPanel(viz, renderSide ? "##renWave" : "##capWave", wave.data(), viz.waveN, viz.waveSr, ok,
                       waveH, renderSide ? kSlotRenWave : kSlotCapWave);
 
     // Splitter: drag to rebalance waveform vs spectrogram height (the axes re-lay out to fit).
@@ -645,7 +787,7 @@ void AppUi::drawComboPanel(bool renderSide) {
                            ImVec2(std::max(ImGui::GetContentRegionAvail().x, 1.0f), kSplitH));
     if (ImGui::IsItemHovered() || ImGui::IsItemActive()) ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
     if (ImGui::IsItemActive())
-        comboRatio_ = std::clamp(comboRatio_ + ImGui::GetIO().MouseDelta.y / kComboH, 0.15f, 0.85f);
+        viz.comboRatio = std::clamp(viz.comboRatio + ImGui::GetIO().MouseDelta.y / kComboH, 0.15f, 0.85f);
     const ImVec2 smn = ImGui::GetItemRectMin(), smx = ImGui::GetItemRectMax();
     ImGui::GetWindowDrawList()->AddLine(ImVec2(smn.x, (smn.y + smx.y) * 0.5f),
                                         ImVec2(smx.x, (smn.y + smx.y) * 0.5f),
@@ -654,37 +796,38 @@ void AppUi::drawComboPanel(bool renderSide) {
     // Advance the FFT analysis feeding this stream's spectrogram (relocated here from the former
     // spectrum panels): one column per hop, catching up a few frames per poll. workCap_/workRender_
     // and magCap_/magRender_ are reused as scratch.
-    if (overallRunning && specSr_ > 0 && (!renderSide || renderRunning)) {
+    if (overallRunning && viz.specSr > 0 && (!renderSide || renderRunning)) {
         uint64_t se = 0;
-        const uint64_t written = renderSide ? monitor_.renderWritten() : monitor_.capWritten();
-        uint64_t& nextEnd      = renderSide ? nextRenderEnd_ : nextCapEnd_;
+        const uint64_t written = renderSide ? engine.renderWritten() : engine.capWritten();
+        uint64_t& nextEnd      = renderSide ? viz.nextRenderEnd : viz.nextCapEnd;
         wa::advanceAnalysis(written, nextEnd, kFftWin, kFftHop, kCatchup, [&](uint64_t) {
-            const bool got = renderSide ? monitor_.snapshotRender(kFftWin, specWin_.data(), se)
-                                        : monitor_.snapshotCapture(kFftWin, specWin_.data(), se);
+            const bool got = renderSide ? engine.snapshotRender(kFftWin, viz.specWin.data(), se)
+                                        : engine.snapshotCapture(kFftWin, viz.specWin.data(), se);
             if (!got) return;
-            std::vector<std::complex<float>>& work = renderSide ? workRender_ : workCap_;
-            std::vector<float>&               mag  = renderSide ? magRender_  : magCap_;
-            wa::magnitudeSpectrumDb(specWin_.data(), kFftWin, work.data(), mag);
-            if (wa::Spectrogram* sp = renderSide ? renderSpec_.get() : capSpec_.get())
+            std::vector<std::complex<float>>& work = renderSide ? viz.workRender : viz.workCap;
+            std::vector<float>&               mag  = renderSide ? viz.magRender  : viz.magCap;
+            wa::magnitudeSpectrumDb(viz.specWin.data(), kFftWin, work.data(), mag);
+            if (wa::Spectrogram* sp = renderSide ? viz.renderSpec.get() : viz.capSpec.get())
                 sp->pushColumn(mag);
         });
     }
 
     wa::Spectrogram* spec = nullptr;
-    if (overallRunning) spec = renderSide ? (renderRunning ? renderSpec_.get() : nullptr) : capSpec_.get();
+    if (overallRunning) spec = renderSide ? (renderRunning ? viz.renderSpec.get() : nullptr) : viz.capSpec.get();
     const uint32_t hz = (sr > 0) ? sr : 48000u;   // idle: assume 48 kHz for the axis ranges
-    drawSpectrogramPanel(renderSide ? "##renSpec" : "##capSpec", spec,
+    drawSpectrogramPanel(viz, renderSide ? "##renSpec" : "##capSpec", spec,
                          (double)(kSpecCols * kFftHop) / (double)hz, kComboH - waveH,
                          renderSide ? kSlotRenSpectro : kSlotCapSpectro);
 }
 
-void AppUi::drawChartPanel(int id) {
+void AppUi::drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status,
+                           VisualState& viz) {
     switch (id) {
     case 0:   // Capture waveform + spectrogram combo
-        drawComboPanel(false);
+        drawComboPanel(engine, status, viz, false);
         break;
     case 1:   // Render waveform + spectrogram combo — data only while playback runs
-        drawComboPanel(true);
+        drawComboPanel(engine, status, viz, true);
         break;
     default:
         break;

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -10,26 +10,52 @@
 
 class AppUi {
 public:
-    void draw();          // called each frame; polls monitor and redraws the two-column UI
-    void stopAll();       // stop monitor on shutdown (idempotent)
+    void draw();          // called each frame; polls engines and redraws the active page
+    void stopAll();       // stop engines on shutdown (idempotent)
     void pushLog(int level, const std::string& line);  // thread-safe; called from the logging pump thread
 private:
+    struct VisualState {
+        std::vector<float> capWave, renderWave;
+        uint32_t waveSr = 0;
+        int      waveN  = 0;
+        double   xLink0 = 0.0, xLink1 = 0.0;
+        std::vector<float> envX, envMin, envMax;
+        float comboRatio = 0.5f;
+        bool  plotHovPrev[4] = {};
+
+        std::vector<std::complex<float>> workCap, workRender;
+        std::vector<float>               specWin;
+        std::vector<float>               magCap, magRender;
+        uint64_t nextCapEnd    = 0;
+        uint64_t nextRenderEnd = 0;
+        uint32_t specSr        = 0;
+
+        std::unique_ptr<wa::Spectrogram> capSpec, renderSpec;
+    };
+
     void refreshMonitorDevices();
+    void drawMonitorPage();
+    void drawLoopbackPage();
+    void drawLoopbackLeftPanel();
     void drawLeftPanel();
     void drawAdvancedModal();
     void drawCapsModal();
     void drawFormatRegion();
     void recomputeDefaultFormat();
-    void drawChartsColumn();
-    void drawChartPanel(int id);
-    void drawComboPanel(bool renderSide);   // waveform + splitter + spectrogram in one cell
-    void drawSpectrogramPanel(const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot);
-    void drawWaveformPanel(const char* plotId, const float* wave, int n, uint32_t sr, bool haveData, float height, int slot);
+    void drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
+    void drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
+    void drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz, bool renderSide);
+    void drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot);
+    void drawWaveformPanel(VisualState& viz, const char* plotId, const float* wave, int n, uint32_t sr, bool haveData, float height, int slot);
     const char* chartTitle(int id);
+    void resetVisuals(VisualState& viz);
+    void resetRenderVisuals(VisualState& viz);
 
     wa::MonitorEngine    monitor_;
+    wa::MonitorEngine    loopback_;
     wa::DeviceEnumerator enumerator_;
     wa::MonitorStatus    ms_;   // polled once per frame in draw(); shared by helper methods
+    wa::MonitorStatus    loopbackMs_;
 
     int  backendIdx_      = 0;
     bool playbackEnabled_ = false;
@@ -46,8 +72,10 @@ private:
     std::vector<wa::DeviceInfo> renderDevices_;
     int                         capDevIdx_    = 0;
     int                         renderDevIdx_ = 0;
+    int                         loopbackDevIdx_ = 0;
     int                         delayMs_      = 100;
     bool                        monitorStarted_ = false;
+    bool                        loopbackStarted_ = false;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};
@@ -61,27 +89,6 @@ private:
     int                    capDevShown_     = -1;
     wa::DeviceCapabilities capsCache_{};
 
-    // Waveform buffers — full spectrogram-history window (kSpecCols*kFftHop samples), rebuilt on rate change
-    std::vector<float> capWave_, renderWave_;
-    uint32_t waveSr_ = 0;
-    int      waveN_  = 0;
-    // Shared time X axis (seconds), linked across all time-domain charts; min/max envelope scratch.
-    double xLink0_ = 0.0, xLink1_ = 0.0;
-    std::vector<float> envX_, envMin_, envMax_;
-    // Waveform:spectrogram height split in the combo cells (shared so cap/ren stay aligned).
-    float comboRatio_ = 0.5f;
-    // Last-frame plot-area hover per plot slot: locks Y that frame so in-plot wheel/drag act on X
-    // only; hovering a Y ruler (not plot area) leaves Y free for per-axis zoom/pan.
-    bool plotHovPrev_[4] = {};
-
-    // Spectrum analysis (2048-point Hann FFT, dBFS)
-    std::vector<std::complex<float>> workCap_, workRender_;
-    std::vector<float>               specWin_;
-    std::vector<float>               magCap_, magRender_;
-    uint64_t nextCapEnd_    = 0;
-    uint64_t nextRenderEnd_ = 0;
-    uint32_t specSr_        = 0;
-
-    // Scrolling log-frequency spectrograms
-    std::unique_ptr<wa::Spectrogram> capSpec_, renderSpec_;
+    VisualState monitorViz_;
+    VisualState loopbackViz_;
 };

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -47,6 +47,7 @@ private:
     void drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz, bool renderSide);
     void drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot);
     void drawWaveformPanel(VisualState& viz, const char* plotId, const float* wave, int n, uint32_t sr, bool haveData, float height, int slot);
+    void drawLogPanel(const char* childId, bool showLevelFilter);
     const char* chartTitle(int id);
     void resetVisuals(VisualState& viz);
     void resetRenderVisuals(VisualState& viz);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(WinAudioTests
     test_spectrogram.cpp
     test_capabilities.cpp
     test_log.cpp
+    test_loopback.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
 )
 target_include_directories(WinAudioTests PRIVATE

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -3,6 +3,7 @@
 #include "IAudioBackend.h"
 #include "RingBuffer.h"
 #include "WasapiStream.h"
+#include <windows.h>
 
 using namespace wa;
 
@@ -27,4 +28,19 @@ TEST(WasapiSystemLoopbackCaptureStream, RejectsExclusiveInOpen) {
     EXPECT_FALSE(static_cast<bool>(r));
     EXPECT_NE(r.message.find("loopback"), std::string::npos);
     EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}
+
+TEST(WasapiSystemLoopbackCaptureStream, IdleTimeoutSilenceKeepsWallClockCadence) {
+    EXPECT_EQ(loopbackSilenceFramesForTimeout(48000, 200), 9600u);
+    EXPECT_EQ(loopbackSilenceFramesForTimeout(44100, 50), 2205u);
+    EXPECT_EQ(loopbackSilenceFramesForTimeout(0, 200), 0u);
+}
+
+TEST(WasapiSystemLoopbackCaptureStream, IdleSilenceOnlyWhenTimeoutHasNoPackets) {
+    EXPECT_TRUE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, false, false));
+    EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_OBJECT_0, S_OK, false, false));
+    EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, true, false));
+    EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, false, true));
+    EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, AUDCLNT_E_DEVICE_INVALIDATED,
+                                               false, false));
 }

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include <string>
+#include "IAudioBackend.h"
+#include "RingBuffer.h"
+#include "WasapiStream.h"
+
+using namespace wa;
+
+TEST(CaptureSource, DefaultsToEndpoint) {
+    CaptureSource source;
+    EXPECT_EQ(source.kind, CaptureSourceKind::Endpoint);
+    EXPECT_TRUE(source.deviceId.empty());
+}
+
+TEST(CaptureSource, CanRepresentSystemLoopbackRenderDevice) {
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"render-device-id"};
+    EXPECT_EQ(source.kind, CaptureSourceKind::SystemLoopback);
+    EXPECT_EQ(source.deviceId, L"render-device-id");
+}
+
+TEST(WasapiSystemLoopbackCaptureStream, RejectsExclusiveInOpen) {
+    RingBuffer ring(4096);
+    WasapiSystemLoopbackCaptureStream stream(WasapiMode::Exclusive, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, &ring, StreamParams{});
+
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_NE(r.message.find("loopback"), std::string::npos);
+    EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -88,14 +88,20 @@ struct FakeRig {
 
     std::atomic<bool> capStopped{false};
     std::atomic<bool> renderStopped{false};
+    std::atomic<int>  capOpenCount{0};
     std::atomic<int>  renderOpenCount{0};  // increments each time render factory is called
     std::atomic<int>  renderOpenDone{0};   // release-incremented inside open() for race-free sync
     FakeBackend*      capPtr    = nullptr;
     FakeBackend*      renderPtr = nullptr;
+    CaptureSource     lastCaptureSource{};
+    bool              sawCaptureSource = false;
 
     MonitorEngine::BackendFactory factory() {
-        return [this](DataFlow flow, const AudioFormat* req) -> std::unique_ptr<IAudioBackend> {
+        return [this](DataFlow flow, const CaptureSource* source,
+                      const AudioFormat* req) -> std::unique_ptr<IAudioBackend> {
             if (flow == DataFlow::Capture) {
+                capOpenCount.fetch_add(1, std::memory_order_relaxed);
+                if (source) { lastCaptureSource = *source; sawCaptureSource = true; }
                 auto b  = std::make_unique<FakeBackend>(capFmt, false, &capStopped);
                 capPtr  = b.get();
                 if (req) { b->lastRequested_ = *req; b->sawRequested_ = true; }
@@ -457,5 +463,95 @@ TEST(MonitorEngine, CaptureFormatReachesBackend) {
     ASSERT_NE(rig.capPtr, nullptr);
     EXPECT_TRUE(rig.capPtr->sawRequested_);
     EXPECT_EQ(rig.capPtr->lastRequested_, want);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LegacyStartUsesEndpointCaptureSource) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, L"capture-id", L"render-id", 50,
+                          false));
+
+    EXPECT_EQ(rig.capOpenCount.load(), 1);
+    EXPECT_TRUE(rig.sawCaptureSource);
+    EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::Endpoint);
+    EXPECT_EQ(rig.lastCaptureSource.deviceId, L"capture-id");
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LoopbackCaptureSourceReachesFactory) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"playback-render-id", 50,
+                          false));
+
+    EXPECT_EQ(rig.capOpenCount.load(), 1);
+    EXPECT_TRUE(rig.sawCaptureSource);
+    EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::SystemLoopback);
+    EXPECT_EQ(rig.lastCaptureSource.deviceId, L"loopback-render-id");
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LoopbackPlaybackRejectsSameRenderDevice) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"same-render-id"};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"same-render-id", 50, true);
+
+    EXPECT_FALSE(r);
+    MonitorStatus st = eng.poll();
+    EXPECT_EQ(st.overall, StreamState::Error);
+    EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::LoopbackFeedback));
+    EXPECT_EQ(rig.capOpenCount.load(), 0);
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
+}
+
+TEST(MonitorEngine, LoopbackPlaybackRejectsBothDefaultRenderDevices) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L""};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"", 50, true);
+
+    EXPECT_FALSE(r);
+    MonitorStatus st = eng.poll();
+    EXPECT_EQ(st.overall, StreamState::Error);
+    EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::LoopbackFeedback));
+    EXPECT_EQ(rig.capOpenCount.load(), 0);
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
+}
+
+TEST(MonitorEngine, LoopbackRuntimePlaybackRejectsSameRenderDevice) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"same-render-id"};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"same-render-id", 50,
+                          false));
+    ASSERT_EQ(rig.capOpenCount.load(), 1);
+    ASSERT_EQ(rig.renderOpenCount.load(), 0);
+    ASSERT_NE(rig.capPtr, nullptr);
+
+    eng.setPlaybackEnabled(true);
+    std::vector<int16_t> ramp(1024, 3);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+
+    ASSERT_TRUE(waitFor([&] {
+        return eng.poll().renderState == StreamState::Error;
+    })) << "runtime playback feedback guard did not reject render engage";
+
+    MonitorStatus st = eng.poll();
+    EXPECT_EQ(st.overall, StreamState::Running);
+    EXPECT_EQ(st.capState, StreamState::Running);
+    EXPECT_EQ(st.renderState, StreamState::Error);
+    EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::LoopbackFeedback));
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
     eng.stop();
 }


### PR DESCRIPTION
## Summary
- Add shared-mode Windows system loopback capture using render endpoints and `AUDCLNT_STREAMFLAGS_LOOPBACK`.
- Wire loopback through CLI capture/monitor, MonitorEngine source plumbing, and core feedback protection.
- Add a dedicated GUI Loopback page that reuses existing realtime waveform/spectrogram visualization.

## Test Plan
- `.uild.bat Debug`
- `.	est.bat Debug`
- `.uild.bat Release`
- `.	est.bat Release`
- CLI smoke: loopback exclusive rejection and monitor feedback rejection
- GUI smoke: Debug/Release launch + nonblank `PrintWindow` capture

## Notes
- Application/process loopback is intentionally out of scope for this phase.
- GUI click-through Start/Stop still needs manual validation on an interactive desktop because synthetic input did not reliably drive Dear ImGui in this runner.