### PR TITLE
Add loopback silent render diagnostics

### DIFF
--- a/docs/superpowers/plans/2026-07-10-winaudio-loopback-ui-adjustments.md
+++ b/docs/superpowers/plans/2026-07-10-winaudio-loopback-ui-adjustments.md
@@ -1,0 +1,999 @@
+# WinAudio Loopback UI Adjustments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现已确认的 Loopback UI 调整：两个 tab 底部全宽日志，以及默认开启、可关闭、可观察的 System Loopback silent render helper。
+
+**Architecture:** 用一个小的 `LoopbackOptions` 结构贯穿 CLI、GUI、`Engine` 和 `MonitorEngine`。新增专用 `WasapiSilentRenderStream` 负责提交 `AUDCLNT_BUFFERFLAGS_SILENT`，避免复用普通 playback render 路径导致语义混淆。`MonitorEngine` 增加可测试的 silent render factory seam；`Engine` 走真实 WASAPI helper，用日志暴露状态。
+
+**Tech Stack:** C++17、WASAPI、Dear ImGui、CMake、GoogleTest、PowerShell。
+
+---
+
+## 文件结构
+
+- 修改 `src/core/IAudioBackend.h`：新增 `LoopbackOptions`，不放 GUI 或 monitor 状态字段。
+- 修改 `src/core/WasapiStream.h` / `src/core/WasapiStream.cpp`：新增 `WasapiSilentRenderStream`，专门用于 shared-mode silent render。
+- 修改 `src/core/Engine.h` / `src/core/Engine.cpp`：`capture --loopback` 路径按 `LoopbackOptions` 启停 silent render helper。
+- 修改 `src/core/MonitorEngine.h` / `src/core/MonitorEngine.cpp`：`monitor --loopback` 和 GUI Loopback 页按 `LoopbackOptions` 启停 silent render helper，并通过 `MonitorStatus` 暴露状态。
+- 新增 `src/cli/CliOptions.h`：只放可单测的 CLI loopback options 解析。
+- 修改 `src/cli/main.cpp`：usage 文案和 `capture` / `monitor` 参数传递。
+- 修改 `src/gui/AppUi.h` / `src/gui/AppUi.cpp`：Loopback checkbox、状态显示、两个 tab 底部全宽日志布局。
+- 修改 `src/tests/test_loopback.cpp`：`LoopbackOptions` 和 `WasapiSilentRenderStream` 基础测试。
+- 修改 `src/tests/test_monitorengine.cpp`：fake seam 覆盖 silent render 默认开启、关闭、失败非 fatal。
+- 新增 `src/tests/test_cli_options.cpp`：覆盖 `--no-silent-render` 解析。
+- 修改 `src/tests/CMakeLists.txt`：注册 `test_cli_options.cpp`，并让 tests 能 include `src/cli`。
+- 不修改 `docs/superpowers/specs/2026-07-10-winaudio-loopback-ui-adjustments-design.md`，除非实现中发现 spec 与现实冲突。
+
+---
+
+### Task 1: LoopbackOptions 与 CLI 解析测试
+
+**Files:**
+- Modify: `src/core/IAudioBackend.h`
+- Create: `src/cli/CliOptions.h`
+- Create: `src/tests/test_cli_options.cpp`
+- Modify: `src/tests/CMakeLists.txt`
+
+- [ ] **Step 1: 写失败测试 `test_cli_options.cpp`**
+
+创建 `src/tests/test_cli_options.cpp`：
+
+```cpp
+#include <gtest/gtest.h>
+#include "CliOptions.h"
+
+TEST(CliOptions, LoopbackSilentRenderDefaultsEnabled) {
+    const wchar_t* argv[] = {L"WinAudioCli", L"capture", L"--loopback"};
+
+    wa::LoopbackOptions opts =
+        wa::cli::parseLoopbackOptions(3, const_cast<wchar_t**>(argv));
+
+    EXPECT_TRUE(opts.silentRender);
+}
+
+TEST(CliOptions, NoSilentRenderDisablesHelper) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"monitor", L"--loopback", L"--no-silent-render"
+    };
+
+    wa::LoopbackOptions opts =
+        wa::cli::parseLoopbackOptions(4, const_cast<wchar_t**>(argv));
+
+    EXPECT_FALSE(opts.silentRender);
+}
+```
+
+- [ ] **Step 2: 注册测试并运行，确认失败**
+
+修改 `src/tests/CMakeLists.txt`：
+
+```cmake
+add_executable(WinAudioTests
+    test_delayfifo.cpp
+    test_streamparams.cpp
+    test_smoke.cpp
+    test_audioformat.cpp
+    test_fft.cpp
+    test_ringbuffer.cpp
+    test_sampleconvert.cpp
+    test_wavfile.cpp
+    test_formatspec.cpp
+    test_scopebuffer.cpp
+    test_analysis.cpp
+    test_monitorengine.cpp
+    test_spectrogram.cpp
+    test_capabilities.cpp
+    test_log.cpp
+    test_loopback.cpp
+    test_cli_options.cpp
+    ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp
+)
+target_include_directories(WinAudioTests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src/gui
+    ${CMAKE_SOURCE_DIR}/src/cli
+)
+```
+
+运行：
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+```
+
+Expected: 编译失败，错误包含 `Cannot open include file: 'CliOptions.h'` 或 `parseLoopbackOptions` 未声明。
+
+- [ ] **Step 3: 实现 `LoopbackOptions`**
+
+在 `src/core/IAudioBackend.h` 的 `CaptureSource` 后添加：
+
+```cpp
+struct LoopbackOptions {
+    bool silentRender = true;
+};
+```
+
+- [ ] **Step 4: 实现 `src/cli/CliOptions.h`**
+
+创建 `src/cli/CliOptions.h`：
+
+```cpp
+#pragma once
+#include <cwchar>
+#include "IAudioBackend.h"
+
+namespace wa::cli {
+
+inline bool hasArg(int argc, wchar_t** argv, const wchar_t* key) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::wcscmp(argv[i], key) == 0) return true;
+    }
+    return false;
+}
+
+inline LoopbackOptions parseLoopbackOptions(int argc, wchar_t** argv) {
+    LoopbackOptions opts{};
+    opts.silentRender = !hasArg(argc, argv, L"--no-silent-render");
+    return opts;
+}
+
+} // namespace wa::cli
+```
+
+- [ ] **Step 5: 运行 focused 测试，确认通过**
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=CliOptions.*
+```
+
+Expected: `2 tests` 通过。
+
+- [ ] **Step 6: 提交 Task 1**
+
+```powershell
+git add src/core/IAudioBackend.h src/cli/CliOptions.h src/tests/test_cli_options.cpp src/tests/CMakeLists.txt
+git commit -m "feat(cli): add loopback silent render option parsing"
+```
+
+---
+
+### Task 2: 新增 WasapiSilentRenderStream
+
+**Files:**
+- Modify: `src/core/WasapiStream.h`
+- Modify: `src/core/WasapiStream.cpp`
+- Modify: `src/tests/test_loopback.cpp`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/tests/test_loopback.cpp` 末尾添加：
+
+```cpp
+TEST(WasapiSilentRenderStream, RejectsExclusiveInOpen) {
+    WasapiSilentRenderStream stream(WasapiMode::Exclusive, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, nullptr, StreamParams{});
+
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_NE(r.message.find("silent render"), std::string::npos);
+    EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}
+```
+
+- [ ] **Step 2: 运行测试，确认失败**
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+```
+
+Expected: 编译失败，错误包含 `WasapiSilentRenderStream` 未声明。
+
+- [ ] **Step 3: 声明 `WasapiSilentRenderStream`**
+
+在 `src/core/WasapiStream.h` 的 `WasapiRenderStream` 后添加：
+
+```cpp
+class WasapiSilentRenderStream : public WasapiStream {
+public:
+    WasapiSilentRenderStream(WasapiMode mode, const AudioFormat* requested);
+    ~WasapiSilentRenderStream() override;
+    Result open(const DeviceId& id, const AudioFormat& fmt, RingBuffer* ring,
+                const StreamParams& params) override;
+protected:
+    EDataFlow dataFlow() const override { return eRender; }
+    Result createService() override;
+    void   preRoll() override;
+    void   runLoop() override;
+    void   resetService() override { render_.Reset(); }
+private:
+    ComPtr<IAudioRenderClient> render_;
+};
+```
+
+- [ ] **Step 4: 实现构造、析构、open 和 createService**
+
+在 `src/core/WasapiStream.cpp` 的 `WasapiRenderStream` 实现后添加：
+
+```cpp
+WasapiSilentRenderStream::WasapiSilentRenderStream(WasapiMode mode,
+                                                   const AudioFormat* requested)
+    : WasapiStream(mode, requested) {}
+
+WasapiSilentRenderStream::~WasapiSilentRenderStream() { close(); }
+
+Result WasapiSilentRenderStream::open(const DeviceId& id, const AudioFormat& fmt,
+                                      RingBuffer* ring, const StreamParams& params) {
+    if (isExclusive()) {
+        return Result::Fail(-1, "WasapiSilentRenderStream: silent render requires WASAPI-Shared");
+    }
+    return WasapiStream::open(id, fmt, ring, params);
+}
+
+Result WasapiSilentRenderStream::createService() {
+    HRESULT hr = client_->GetService(__uuidof(IAudioRenderClient),
+        reinterpret_cast<void**>(render_.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream",
+           "GetService(IAudioRenderClient)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "WasapiSilentRenderStream",
+               "GetService(IAudioRenderClient)", "", wa::log::hrName(hr));
+        return HrToResult(hr, "WasapiSilentRenderStream: GetService");
+    }
+    return Result::Ok();
+}
+```
+
+- [ ] **Step 5: 实现 silent pre-roll 和 run loop**
+
+在同一实现块继续添加：
+
+```cpp
+void WasapiSilentRenderStream::preRoll() {
+    BYTE* buf = nullptr;
+    HRESULT hrPre = render_->GetBuffer(bufferFrames_, &buf);
+    WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream", "GetBuffer(preRoll)",
+           "frames=" + std::to_string(bufferFrames_), wa::log::hrName(hrPre));
+    if (SUCCEEDED(hrPre)) {
+        HRESULT hrRel = render_->ReleaseBuffer(bufferFrames_, AUDCLNT_BUFFERFLAGS_SILENT);
+        WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream",
+               "ReleaseBuffer(preRoll)", "", wa::log::hrName(hrRel));
+    }
+}
+
+void WasapiSilentRenderStream::runLoop() {
+    wa::log::setThreadName("silR");
+    WA_LOG(wa::log::Level::Info, "WasapiSilentRenderStream", "runLoop",
+           "silent render loop started", "");
+    while (running_.load()) {
+        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
+        wa::log::emitTrace("WasapiSilentRenderStream", "WaitForSingleObject", 0, waitRc, 0);
+        if (!running_.load()) break;
+
+        UINT32 padding = 0;
+        HRESULT hrPad = client_->GetCurrentPadding(&padding);
+        wa::log::emitTrace("WasapiSilentRenderStream", "GetCurrentPadding", padding, 0,
+                           static_cast<long>(hrPad));
+        if (FAILED(hrPad)) break;
+
+        UINT32 frames = bufferFrames_ - padding;
+        if (frames == 0) continue;
+
+        BYTE* buf = nullptr;
+        HRESULT hrGB = render_->GetBuffer(frames, &buf);
+        wa::log::emitTrace("WasapiSilentRenderStream", "GetBuffer", frames, 0,
+                           static_cast<long>(hrGB));
+        if (FAILED(hrGB)) break;
+
+        HRESULT hrRB = render_->ReleaseBuffer(frames, AUDCLNT_BUFFERFLAGS_SILENT);
+        wa::log::emitTrace("WasapiSilentRenderStream", "ReleaseBuffer", frames,
+                           AUDCLNT_BUFFERFLAGS_SILENT, static_cast<long>(hrRB));
+        if (FAILED(hrRB)) break;
+    }
+}
+```
+
+- [ ] **Step 6: 运行 loopback focused 测试**
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=WasapiSystemLoopbackCaptureStream.*:WasapiSilentRenderStream.*
+```
+
+Expected: `WasapiSilentRenderStream.RejectsExclusiveInOpen` 和现有 loopback helper 测试通过。
+
+- [ ] **Step 7: 提交 Task 2**
+
+```powershell
+git add src/core/WasapiStream.h src/core/WasapiStream.cpp src/tests/test_loopback.cpp
+git commit -m "feat(core): add silent render stream"
+```
+
+---
+
+### Task 3: MonitorEngine silent render helper
+
+**Files:**
+- Modify: `src/core/MonitorEngine.h`
+- Modify: `src/core/MonitorEngine.cpp`
+- Modify: `src/tests/test_monitorengine.cpp`
+
+- [ ] **Step 1: 写失败测试：默认开启 helper**
+
+在 `FakeRig` 中新增字段和 factory 之前，先添加测试让编译失败：
+
+```cpp
+TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+
+    EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Running);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LoopbackCanDisableSilentRender) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+    LoopbackOptions opts{};
+    opts.silentRender = false;
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false,
+                          {}, {}, nullptr, opts));
+
+    EXPECT_EQ(rig.silentOpenCount.load(), 0);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
+    eng.stop();
+}
+
+TEST(MonitorEngine, SilentRenderFailureDoesNotFailLoopbackCapture) {
+    FakeRig rig;
+    rig.silentFailStart = true;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"", 50, false);
+
+    EXPECT_TRUE(r);
+    EXPECT_EQ(rig.capOpenCount.load(), 1);
+    EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    EXPECT_EQ(eng.poll().overall, StreamState::Running);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Error);
+    eng.stop();
+}
+```
+
+- [ ] **Step 2: 扩展 FakeRig 让测试可编译到缺少产品签名处**
+
+在 `FakeRig` 中添加字段：
+
+```cpp
+    bool              silentFailStart = false;
+    std::atomic<bool> silentStopped{false};
+    std::atomic<int>  silentOpenCount{0};
+    FakeBackend*      silentPtr = nullptr;
+```
+
+在 `FakeRig` 中添加 factory：
+
+```cpp
+    MonitorEngine::SilentRenderFactory silentFactory() {
+        return [this](const AudioFormat* req) -> std::unique_ptr<IAudioBackend> {
+            silentOpenCount.fetch_add(1, std::memory_order_relaxed);
+            auto b = std::make_unique<FakeBackend>(renderFmt, silentFailStart, &silentStopped);
+            silentPtr = b.get();
+            if (req) { b->lastRequested_ = *req; b->sawRequested_ = true; }
+            return b;
+        };
+    }
+```
+
+运行：
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+```
+
+Expected: 编译失败，错误包含 `SilentRenderFactory`、`silentRenderState` 或新 `start(...)` 参数未声明。
+
+- [ ] **Step 3: 扩展 `MonitorStatus`、factory seam 和 start 签名**
+
+在 `src/core/MonitorEngine.h` 的 `MonitorStatus` 中添加：
+
+```cpp
+    StreamState silentRenderState = StreamState::Idle;
+```
+
+在 `MonitorEngine` public 区添加 factory alias，并更新构造函数：
+
+```cpp
+    using SilentRenderFactory =
+        std::function<std::unique_ptr<IAudioBackend>(const AudioFormat*)>;
+
+    explicit MonitorEngine(BackendFactory factory = {},
+                           SilentRenderFactory silentFactory = {});
+```
+
+更新 `start` 签名：
+
+```cpp
+    Result start(BackendKind kind, const CaptureSource& capSource, const DeviceId& renderId,
+                 uint32_t delayMs, bool playbackEnabled = true,
+                 const StreamParams& capParams = {}, const StreamParams& renderParams = {},
+                 const AudioFormat* capFormat = nullptr,
+                 const LoopbackOptions& loopbackOptions = {});
+```
+
+更新 legacy overload：
+
+```cpp
+        return start(kind, CaptureSource{CaptureSourceKind::Endpoint, capId}, renderId,
+                     delayMs, playbackEnabled, capParams, renderParams, capFormat, {});
+```
+
+在 private 区添加：
+
+```cpp
+    std::unique_ptr<IAudioBackend> makeSilentRenderBackend(const AudioFormat* requested);
+    Result startSilentRenderIfNeeded();
+    void   stopSilentRender();
+```
+
+在成员区添加：
+
+```cpp
+    SilentRenderFactory silentFactory_;
+    LoopbackOptions loopbackOptions_{};
+    std::unique_ptr<IAudioBackend> silentRenderBackend_;
+    std::atomic<StreamState> silentRenderState_{StreamState::Idle};
+```
+
+- [ ] **Step 4: 实现 MonitorEngine helper**
+
+在 `src/core/MonitorEngine.cpp` 更新构造函数：
+
+```cpp
+MonitorEngine::MonitorEngine(BackendFactory factory, SilentRenderFactory silentFactory)
+    : factory_(std::move(factory)), silentFactory_(std::move(silentFactory)) {}
+```
+
+添加 helper：
+
+```cpp
+std::unique_ptr<IAudioBackend> MonitorEngine::makeSilentRenderBackend(
+    const AudioFormat* requested) {
+    if (silentFactory_) return silentFactory_(requested);
+    return std::make_unique<WasapiSilentRenderStream>(WasapiMode::Shared, requested);
+}
+
+Result MonitorEngine::startSilentRenderIfNeeded() {
+    silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
+    if (capSource_.kind != CaptureSourceKind::SystemLoopback || !loopbackOptions_.silentRender)
+        return Result::Ok();
+
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.start",
+           "dev=" + wa::narrowAscii(capSource_.deviceId), "requested");
+
+    silentRenderBackend_ = makeSilentRenderBackend(nullptr);
+    if (!silentRenderBackend_) {
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return Result::Fail(-1, "MonitorEngine: silent render factory null");
+    }
+
+    Result r = silentRenderBackend_->open(capSource_.deviceId, AudioFormat{}, nullptr, {});
+    if (!r) {
+        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.open", "", r.message);
+        silentRenderBackend_.reset();
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return r;
+    }
+
+    r = silentRenderBackend_->start();
+    if (!r) {
+        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.start", "", r.message);
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return r;
+    }
+
+    silentRenderState_.store(StreamState::Running, std::memory_order_relaxed);
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.started", "", "ok");
+    return Result::Ok();
+}
+
+void MonitorEngine::stopSilentRender() {
+    if (silentRenderBackend_) {
+        WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.stop", "", "");
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+    }
+    if (silentRenderState_.load(std::memory_order_relaxed) == StreamState::Running)
+        silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
+}
+```
+
+- [ ] **Step 5: 接入 start、teardown 和 poll**
+
+在 `start(...)` 开头状态 reset 区添加：
+
+```cpp
+    silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
+```
+
+在 session 参数赋值处改成：
+
+```cpp
+    kind_ = kind;
+    capSource_ = capSource;
+    renderId_ = renderId;
+    delayMs_ = delayMs;
+    loopbackOptions_ = loopbackOptions;
+```
+
+在 capture started、`capFmt_` 已经有效之后，启动 helper；失败只记录不 rollback：
+
+```cpp
+    if (Result sr = startSilentRenderIfNeeded(); !sr) {
+        WA_LOG(wa::log::Level::Warn, "MonitorEngine", "silentRender.unavailable",
+               "", sr.message);
+    }
+```
+
+在 `teardown()` 中，pump join 后、停止 capture/render 前添加：
+
+```cpp
+    stopSilentRender();
+```
+
+在 `poll()` 中添加：
+
+```cpp
+    s.silentRenderState = silentRenderState_.load(std::memory_order_relaxed);
+```
+
+- [ ] **Step 6: 运行 focused 测试**
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=MonitorEngine.LoopbackStartsSilentRenderByDefault:MonitorEngine.LoopbackCanDisableSilentRender:MonitorEngine.SilentRenderFailureDoesNotFailLoopbackCapture:MonitorEngine.LoopbackCaptureSourceReachesFactory
+```
+
+Expected: 4 个测试通过。旧 `LoopbackCaptureSourceReachesFactory` 需要保留 `renderOpenCount == 0`，因为 silent helper 不应复用 playback render factory。
+
+- [ ] **Step 7: 提交 Task 3**
+
+```powershell
+git add src/core/MonitorEngine.h src/core/MonitorEngine.cpp src/tests/test_monitorengine.cpp
+git commit -m "feat(core): wire silent render into loopback monitor"
+```
+
+---
+
+### Task 4: Engine 与 CLI 接入 silent render options
+
+**Files:**
+- Modify: `src/core/Engine.h`
+- Modify: `src/core/Engine.cpp`
+- Modify: `src/cli/main.cpp`
+
+- [ ] **Step 1: 扩展 Engine API**
+
+在 `src/core/Engine.h` 中更新 `startCapture`：
+
+```cpp
+    Result startCapture(BackendKind kind, const CaptureSource& source, const std::wstring& wavPath,
+                        const AudioFormat* requested = nullptr,
+                        const LoopbackOptions& loopbackOptions = {});
+    Result startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
+                        const AudioFormat* requested = nullptr) {
+        return startCapture(kind, CaptureSource{CaptureSourceKind::Endpoint, id}, wavPath,
+                            requested, {});
+    }
+```
+
+在 private 区添加：
+
+```cpp
+    Result startSilentRenderForLoopback(const CaptureSource& source,
+                                        const LoopbackOptions& loopbackOptions);
+    void   stopSilentRender();
+```
+
+在成员区添加：
+
+```cpp
+    std::unique_ptr<IAudioBackend> silentRenderBackend_;
+```
+
+- [ ] **Step 2: 实现 Engine helper**
+
+在 `src/core/Engine.cpp` 中更新 `startCapture` 签名，并在 capture backend start 成功后、设置 `running_` 前插入：
+
+```cpp
+        if (Result sr = startSilentRenderForLoopback(source, loopbackOptions); !sr) {
+            WA_LOG(wa::log::Level::Warn, "Engine", "silentRender.unavailable",
+                   "", sr.message);
+        }
+```
+
+添加 helper：
+
+```cpp
+Result Engine::startSilentRenderForLoopback(const CaptureSource& source,
+                                            const LoopbackOptions& loopbackOptions) {
+    if (source.kind != CaptureSourceKind::SystemLoopback || !loopbackOptions.silentRender)
+        return Result::Ok();
+
+    WA_LOG(wa::log::Level::Info, "Engine", "silentRender.start",
+           "dev=" + (source.deviceId.empty() ? std::string("(default)")
+                                             : wa::narrowAscii(source.deviceId)),
+           "requested");
+
+    silentRenderBackend_ = std::make_unique<WasapiSilentRenderStream>(WasapiMode::Shared, nullptr);
+    Result r = silentRenderBackend_->open(source.deviceId, AudioFormat{}, nullptr, {});
+    if (!r) {
+        silentRenderBackend_.reset();
+        return r;
+    }
+    r = silentRenderBackend_->start();
+    if (!r) {
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+        return r;
+    }
+    WA_LOG(wa::log::Level::Info, "Engine", "silentRender.started", "", "ok");
+    return Result::Ok();
+}
+
+void Engine::stopSilentRender() {
+    if (silentRenderBackend_) {
+        WA_LOG(wa::log::Level::Info, "Engine", "silentRender.stop", "", "");
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+    }
+}
+```
+
+在 `Engine::stop()` 中，join pump 后、停止 main backend 前添加：
+
+```cpp
+    stopSilentRender();
+```
+
+- [ ] **Step 3: 接入 CLI usage 与参数传递**
+
+在 `src/cli/main.cpp` 添加 include：
+
+```cpp
+#include "CliOptions.h"
+```
+
+更新 usage 中 capture/monitor 行：
+
+```cpp
+        "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N] [--loopback]\n"
+        "                    [--no-silent-render] [--backend wasapi-shared|wasapi-exclusive]\n"
+        "                    [--format 48000/16/2] (both backends)\n"
+```
+
+```cpp
+        "WinAudioCli monitor [--loopback] [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N]\n"
+        "                    [--no-silent-render] [--backend wasapi-shared|wasapi-exclusive]\n"
+        "                    [--format R/B/C[f]]\n"
+```
+
+在 `capture` 命令中创建 options 并传给 `Engine`：
+
+```cpp
+        LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
+        CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint, id};
+        Result r = eng.startCapture(kind, source, out, haveFmt ? &fmt : nullptr,
+                                    loopbackOptions);
+```
+
+在 `monitor` 命令中传给 `MonitorEngine`：
+
+```cpp
+        LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
+        wa::Result r = mon.start(kind, source, renderId, delayMs,
+                                 true, {}, {}, haveFmt ? &capFmt : nullptr,
+                                 loopbackOptions);
+```
+
+- [ ] **Step 4: 构建 CLI**
+
+```powershell
+cmake --build build --config Debug --target WinAudioCli -j
+.\build\bin\Debug\WinAudioCli.exe
+```
+
+Expected: 构建通过；无参数运行打印 usage，usage 包含 `--no-silent-render`。
+
+- [ ] **Step 5: 运行 core focused 测试**
+
+```powershell
+cmake --build build --config Debug --target WinAudioTests -j
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=CliOptions.*:WasapiSilentRenderStream.*:MonitorEngine.Loopback*
+```
+
+Expected: focused tests 通过。
+
+- [ ] **Step 6: 提交 Task 4**
+
+```powershell
+git add src/core/Engine.h src/core/Engine.cpp src/cli/main.cpp
+git commit -m "feat(loopback): expose silent render in CLI capture"
+```
+
+---
+
+### Task 5: GUI Loopback checkbox 与状态展示
+
+**Files:**
+- Modify: `src/gui/AppUi.h`
+- Modify: `src/gui/AppUi.cpp`
+
+- [ ] **Step 1: 添加 GUI 状态字段**
+
+在 `src/gui/AppUi.h` 的 loopback state 附近添加：
+
+```cpp
+    bool                        loopbackSilentRender_ = true;
+```
+
+- [ ] **Step 2: 更新 Loopback Start 调用**
+
+在 `drawLoopbackLeftPanel()` 的 Start 分支中，把 `loopback_.start(...)` 调用替换为：
+
+```cpp
+            wa::LoopbackOptions loopbackOptions{};
+            loopbackOptions.silentRender = loopbackSilentRender_;
+            wa::Result r = loopback_.start(wa::BackendKind::WasapiShared, source, L"", 0,
+                                           false, {}, {}, nullptr, loopbackOptions);
+```
+
+- [ ] **Step 3: 绘制 checkbox 和状态文本**
+
+在 `drawLoopbackLeftPanel()` 的 `Control` 区 Start/Stop 按钮之后添加：
+
+```cpp
+    if (!loopbackStarted_) {
+        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
+    } else {
+        ImGui::BeginDisabled();
+        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
+        ImGui::EndDisabled();
+    }
+```
+
+在 `Status` 区 `ProgressBar` 前添加：
+
+```cpp
+    ImGui::Text("silent render=%s",
+        ss[(int)loopbackMs_.silentRenderState]);
+```
+
+- [ ] **Step 4: 构建 GUI**
+
+```powershell
+cmake --build build --config Debug --target WinAudioGui -j
+```
+
+Expected: 构建通过。
+
+- [ ] **Step 5: 提交 Task 5**
+
+```powershell
+git add src/gui/AppUi.h src/gui/AppUi.cpp
+git commit -m "feat(gui): expose loopback silent render"
+```
+
+---
+
+### Task 6: 两个 tab 底部全宽日志布局
+
+**Files:**
+- Modify: `src/gui/AppUi.cpp`
+
+- [ ] **Step 1: 修改 `drawMonitorPage()` 布局**
+
+把 `drawMonitorPage()` 替换为：
+
+```cpp
+void AppUi::drawMonitorPage() {
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("monitorTop", ImVec2(0, topHeight), false);
+    ImGui::BeginChild("left", ImVec2(360, 0), true);
+    drawLeftPanel();
+    ImGui::EndChild();
+
+    ImGui::SameLine();
+
+    ImGui::BeginChild("charts", ImVec2(0, 0), true);
+    drawChartsColumn(monitor_, ms_, monitorViz_);
+    ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("monitorLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("log", true);
+    ImGui::EndChild();
+}
+```
+
+- [ ] **Step 2: 修改 `drawLoopbackPage()` 布局**
+
+把 `drawLoopbackPage()` 替换为：
+
+```cpp
+void AppUi::drawLoopbackPage() {
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("loopbackTop", ImVec2(0, topHeight), false);
+    ImGui::BeginChild("loopbackLeft", ImVec2(320, 0), true);
+    drawLoopbackLeftPanel();
+    ImGui::EndChild();
+
+    ImGui::SameLine();
+
+    ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
+    const uint32_t sr = loopbackMs_.sampleRate;
+    const bool overallRunning = (loopbackMs_.overall == wa::StreamState::Running && sr > 0);
+    const uint32_t hz = (sr > 0) ? sr : 48000u;
+    if (loopbackViz_.xLink1 <= 0.0)
+        loopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)hz;
+    if (overallRunning) {
+        if (sr != loopbackViz_.waveSr) {
+            loopbackViz_.waveSr = sr;
+            loopbackViz_.waveN = (int)(kSpecCols * kFftHop);
+            loopbackViz_.capWave.assign((size_t)loopbackViz_.waveN, 0.f);
+            loopbackViz_.xLink0 = 0.0;
+            loopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)sr;
+        }
+        if (sr != loopbackViz_.specSr) {
+            loopbackViz_.specSr = sr;
+            loopbackViz_.workCap.resize(kFftWin);
+            loopbackViz_.specWin.resize(kFftWin);
+            loopbackViz_.capSpec = std::make_unique<wa::Spectrogram>(kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
+        }
+    }
+    ImGui::TextUnformatted("System audio waveform + spectrogram");
+    drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
+    ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("loopbackLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("loopbackLog", false);
+    ImGui::EndChild();
+}
+```
+
+- [ ] **Step 3: 从左侧 panel 删除旧日志区**
+
+在 `drawLeftPanel()` 删除：
+
+```cpp
+    // --- Log (fills remaining height) ---
+    ImGui::SeparatorText("Log");
+    drawLogPanel("log", true);
+```
+
+在 `drawLoopbackLeftPanel()` 删除：
+
+```cpp
+    ImGui::SeparatorText("Log");
+    drawLogPanel("loopbackLog", false);
+```
+
+- [ ] **Step 4: 构建 GUI**
+
+```powershell
+cmake --build build --config Debug --target WinAudioGui -j
+```
+
+Expected: 构建通过。
+
+- [ ] **Step 5: 手动 UI smoke**
+
+运行：
+
+```powershell
+.\build\bin\Debug\WinAudioGui.exe
+```
+
+Expected: `Monitor` 和 `Loopback` tab 都显示底部全宽日志；左侧栏只显示设备、控制、状态；图表仍在右侧。
+
+- [ ] **Step 6: 提交 Task 6**
+
+```powershell
+git add src/gui/AppUi.cpp
+git commit -m "feat(gui): move logs to tab bottom"
+```
+
+---
+
+### Task 7: 完整验证
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: 跑完整 Debug 构建**
+
+```powershell
+cmake --build build --config Debug -j
+```
+
+Expected: 构建通过，无新增 `/W4` 警告导致失败。
+
+- [ ] **Step 2: 跑完整测试**
+
+```powershell
+ctest --test-dir build -C Debug --output-on-failure
+```
+
+Expected: 全部测试通过。
+
+- [ ] **Step 3: 跑 focused 测试复核**
+
+```powershell
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=CliOptions.*:WasapiSilentRenderStream.*:WasapiSystemLoopbackCaptureStream.*:MonitorEngine.Loopback*:MonitorEngine.SilentRenderFailureDoesNotFailLoopbackCapture
+```
+
+Expected: focused tests 全部通过。
+
+- [ ] **Step 4: GUI smoke**
+
+如果仓库当前 `tools\run_gui_smoke.ps1` 可用，运行：
+
+```powershell
+tools\run_gui_smoke.ps1 -Config Debug -BuildDir build
+```
+
+Expected: smoke 脚本完成并输出成功状态。
+
+如果脚本不可用，记录实际错误，并用手动打开 `.\build\bin\Debug\WinAudioGui.exe` 的方式完成视觉确认。
+
+- [ ] **Step 5: 手动 loopback 验证**
+
+在目标 Windows 机器上执行：
+
+```powershell
+.\build\bin\Debug\WinAudioCli.exe capture --loopback --out loopback-silent-on.wav --seconds 3 --log-level debug
+.\build\bin\Debug\WinAudioCli.exe capture --loopback --out loopback-silent-off.wav --seconds 3 --no-silent-render --log-level debug
+```
+
+Expected:
+
+- 第一条日志包含 `silentRender.started`。
+- 第二条不启动 silent render。
+- 两条命令都能正常退出并写出 WAV 文件。
+
+- [ ] **Step 6: 最终状态检查**
+
+```powershell
+git status --short --branch
+git log --oneline --decorate -8
+```
+
+Expected: 工作区只剩用户已知的未跟踪 `.codegraph/` 和 `AGENTS.md`，实现提交在当前分支顶部。
+
+---
+
+## 自审结果
+
+- Spec 覆盖：底部全宽日志由 Task 6 实现；silent render 默认开启、可关闭、可观察由 Task 1、3、4、5 实现；idle zero-fill 保留由 Task 2 和 Task 7 focused 测试保护；实机验证由 Task 7 覆盖。
+- 范围控制：没有拆分日志历史、没有 draggable splitter、没有 application/process loopback、没有改变 Monitor tab playback 语义。
+- 类型一致性：`LoopbackOptions` 在 `IAudioBackend.h` 定义；CLI parser、`Engine::startCapture`、`MonitorEngine::start`、GUI Start 调用使用同一类型；`silentRenderState` 使用现有 `StreamState`。
+- 风险：`Engine` 没有现成 fake factory seam，Task 4 依靠构建、CLI smoke 和 real WASAPI helper 行为验证；`MonitorEngine` 的 helper 生命周期通过 fake seam 做自动化覆盖。

--- a/docs/superpowers/specs/2026-07-10-winaudio-loopback-ui-adjustments-design.md
+++ b/docs/superpowers/specs/2026-07-10-winaudio-loopback-ui-adjustments-design.md
@@ -1,0 +1,139 @@
+# WinAudio Loopback UI 调整设计
+
+## 范围
+
+本阶段只做两个聚焦调整：
+
+- 将 `Monitor` 和 `Loopback` 两个 tab 内的日志面板从左侧控制栏移动到当前 tab
+  底部，让日志使用整个 tab 宽度。
+- 将 System Loopback 的 silent render 辅助链路暴露为可见 demo 控件，默认开启，
+  同时保留现有 idle zero-fill 兜底。
+
+本设计不拆分每个 tab 的独立日志，不增加可拖拽 splitter，不改变普通 Monitor
+capture/render 监听链路。
+
+## 当前上下文
+
+GUI 当前把每个 tab 画成左右两个横向 child：
+
+- `Monitor`：`left` 固定 360 px，`charts` 占剩余宽度。
+- `Loopback`：`loopbackLeft` 固定 320 px，`loopbackCharts` 占剩余宽度。
+
+两个左侧面板都会调用 `drawLogPanel(...)`，所以日志历史被限制在很窄的控制栏里。
+`logLines_` 是 GUI 全局日志历史，当前由两个 tab 共用。
+
+System Loopback 现在使用 `WasapiSystemLoopbackCaptureStream`，在 render endpoint 上用
+`AUDCLNT_STREAMFLAGS_LOOPBACK` 打开 capture client。当前实现还会在 capture 等待超时后
+向 ring 写零帧，让 UI 在没有 packet 到达时仍能继续推进。
+
+## WASAPI 事实依据
+
+Microsoft 文档把 loopback recording 描述为从 render endpoint 的 output stream 捕获系统混音，
+并说明针对较旧 Windows 行为，应用可以通过初始化一个 render stream，并使用 render stream
+的事件通知来规避 event-driven loopback 信号问题。
+
+`IAudioRenderClient::ReleaseBuffer` 支持 `AUDCLNT_BUFFERFLAGS_SILENT`，用于告诉 audio
+engine 将提交的 render packet 视为静音。这是创建 silent render stream 的合适基础，
+可以保持 render path 活跃而不产生可听样本。
+
+参考：
+
+- https://learn.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording
+- https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudiorenderclient-releasebuffer
+
+endpoint mute、system mute、没有活跃应用播放、不同驱动 endpoint 的具体行为仍需要在目标
+Windows 机器上实机验证。
+
+## UI 布局设计
+
+每个 tab 改成纵向页面结构：
+
+1. 上方内容区：占用除日志区外的剩余高度。
+2. 底部日志区：全宽显示日志。
+
+上方内容区继续保留现有左右两列：
+
+- 左列保留控制和状态。
+- 右列保留 waveform/spectrogram 图表。
+
+`drawLeftPanel()` 和 `drawLoopbackLeftPanel()` 不再绘制日志，只保留设备选择、控制和状态。
+`drawMonitorPage()` 与 `drawLoopbackPage()` 负责 tab 级纵向布局，并在上方内容 row 之后调用
+`drawLogPanel()`。
+
+底部日志高度先使用固定值 200 px。这样改动小且行为可预测。可拖拽高度调整本阶段不做。
+
+日志历史继续共享。切换 tab 只切换页面内容，不切换底层日志 buffer。
+
+## Silent Render 设计
+
+System Loopback 增加一个可见 silent render 控件：
+
+- GUI：`Loopback` 页放一个 checkbox，默认开启。
+- CLI：`--loopback` 默认开启 silent render；新增 `--no-silent-render` 用于关闭。
+
+这个控件需要暴露出来，因为 WinAudio 是 demo 工具。用户应能对比开启和关闭 helper render
+stream 后的 loopback 行为差异。
+
+System Loopback 启动时，如果 silent render 开启，WinAudio 会在同一个 loopback render
+endpoint 上启动一个 shared-mode render stream，并用 `AUDCLNT_BUFFERFLAGS_SILENT` 提交静音
+buffer。该 stream 跟随 loopback session 一起停止和关闭。
+
+Silent render 只作用于 System Loopback capture，不改变普通 endpoint capture、普通 playback，
+也不改变 Monitor tab 的延迟播放路径。
+
+UI 和日志需要让状态可观察：
+
+- 是否请求 silent render。
+- silent render 是否启动成功。
+- silent render 启动失败原因。
+- idle zero-fill fallback 是否发生过。
+
+## Idle Zero-Fill 兜底
+
+现有 idle zero-fill 路径保留，但角色收窄：
+
+- Silent render 是保持 WASAPI render path 活跃的主要机制。
+- Idle zero-fill 只是没有 capture packet 到达时的 UI 连续性兜底。
+
+这个区分对 demo 很重要。Silent render 展示 Windows audio 链路保活做法；idle zero-fill 只是在
+capture 侧空闲或平台行为不同的时候避免可视化完全冻结。
+
+## 错误处理
+
+如果 silent render 开启但启动失败，只要 loopback capture stream 本身启动成功，System Loopback
+仍允许继续运行。失败需要体现在日志或状态中，因为这是 demo 细节，不是 capture 的致命错误。
+
+如果 loopback capture stream 启动失败，沿用现有 fatal start failure 行为。
+
+如果 silent render 关闭，则不创建 helper render stream。用户可以观察当前 idle/no-packet 行为，
+但现有 zero-fill fallback 仍保留。
+
+## 测试与验证
+
+自动化检查覆盖：
+
+- CLI 解析：loopback 默认开启 silent render，`--no-silent-render` 能关闭。
+- 核心链路：System Loopback 启动时，开启状态会请求 silent render，关闭状态不会请求。
+- 失败行为：helper render 启动失败会被记录或暴露，但不会让成功的 capture start 失败。
+- 现有 idle zero-fill helper 测试继续有效。
+
+GUI 验证覆盖：
+
+- Debug 构建 `WinAudioGui`。
+- 可用时运行现有 GUI smoke。
+- 手动确认两个 tab 都显示底部全宽日志区，上方内容仍保持现有左右两列结构。
+
+手动音频验证覆盖：
+
+- 有正常系统播放时启动 System Loopback。
+- 没有活跃播放时开启 silent render 启动 System Loopback。
+- 没有活跃播放时关闭 silent render 启动 System Loopback。
+- 在目标 Windows 机器上验证 endpoint mute 和 system mute 场景。
+
+## 非目标
+
+- 每个 tab 独立日志历史。
+- 可拖拽日志高度或持久化布局设置。
+- Application/process loopback。
+- 改变 Monitor tab playback 语义。
+- 把 silent render 隐藏成纯内部默认行为。

--- a/src/cli/CliOptions.h
+++ b/src/cli/CliOptions.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cwchar>
+#include "IAudioBackend.h"
+
+namespace wa::cli {
+
+inline bool hasArg(int argc, wchar_t** argv, const wchar_t* key) {
+    for (int i = 1; i < argc; ++i) {
+        if (std::wcscmp(argv[i], key) == 0) return true;
+    }
+    return false;
+}
+
+inline LoopbackOptions parseLoopbackOptions(int argc, wchar_t** argv) {
+    LoopbackOptions opts{};
+    opts.silentRender = !hasArg(argc, argv, L"--no-silent-render");
+    return opts;
+}
+
+} // namespace wa::cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -5,6 +5,7 @@
 #include "Engine.h"
 #include "DeviceEnumerator.h"
 #include "ComUtil.h"
+#include "CliOptions.h"
 #include "FormatSpec.h"
 #include "MonitorEngine.h"
 #include "Capabilities.h"
@@ -16,13 +17,15 @@ static void usage() {
     std::printf(
         "WinAudioCli list  [--render|--capture]\n"
         "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N] [--loopback]\n"
-        "                    [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2] (both backends)\n"
+        "                    [--no-silent-render] [--backend wasapi-shared|wasapi-exclusive]\n"
+        "                    [--format 48000/16/2] (both backends)\n"
         "WinAudioCli play    --in  <file.wav> [--device <id>]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
         "WinAudioCli probe   --format 48000/16/2 [--device <id>] [--render|--capture]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
         "WinAudioCli monitor [--loopback] [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N]\n"
-        "                    [--backend wasapi-shared|wasapi-exclusive] [--format R/B/C[f]]\n"
+        "                    [--no-silent-render] [--backend wasapi-shared|wasapi-exclusive]\n"
+        "                    [--format R/B/C[f]]\n"
         "  (shared: WASAPI engine bridges sample rate on render side;\n"
         "   exclusive: render device must support capture format)\n"
         "  --loopback uses render endpoint ids for capture --device / monitor --cap.\n"
@@ -127,8 +130,10 @@ int wmain(int argc, wchar_t** argv) {
             std::printf("capture: --loopback requires --backend wasapi-shared\n");
             return 2;
         }
+        LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
         CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint, id};
-        Result r = eng.startCapture(kind, source, out, haveFmt ? &fmt : nullptr);
+        Result r = eng.startCapture(kind, source, out, haveFmt ? &fmt : nullptr,
+                                    loopbackOptions);
         if (!r) { std::printf("capture start failed: %s\n", r.message.c_str()); return 2; }
         for (int i = 0; i < seconds * 10; ++i) {
             Sleep(100);
@@ -220,10 +225,12 @@ int wmain(int argc, wchar_t** argv) {
         }
         CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint,
                              capId};
+        LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
 
         wa::MonitorEngine mon;
         wa::Result r = mon.start(kind, source, renderId, delayMs,
-                                 true, {}, {}, haveFmt ? &capFmt : nullptr);
+                                 true, {}, {}, haveFmt ? &capFmt : nullptr,
+                                 loopbackOptions);
         if (!r) { std::printf("monitor start failed: %s\n", r.message.c_str()); return 2; }
         for (int i = 0; i < seconds * 5; ++i) {
             Sleep(200);

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -136,7 +136,8 @@ Result Engine::probeFormat(BackendKind kind, DataFlow flow, const DeviceId& id,
 }
 
 Result Engine::startCapture(BackendKind kind, const CaptureSource& source,
-                            const std::wstring& wavPath, const AudioFormat* requested) {
+                            const std::wstring& wavPath, const AudioFormat* requested,
+                            const LoopbackOptions& loopbackOptions) {
     stop();
     WA_LOG(wa::log::Level::Info, "Engine", "startCapture",
         "source=" + std::string(captureSourceName(source.kind))
@@ -155,6 +156,10 @@ Result Engine::startCapture(BackendKind kind, const CaptureSource& source,
         if (!r) {
             WA_LOG(wa::log::Level::Err, "Engine", "startCapture", "start", r.message);
             return r;
+        }
+        if (Result sr = startSilentRenderForLoopback(source, loopbackOptions); !sr) {
+            WA_LOG(wa::log::Level::Warn, "Engine", "silentRender.unavailable",
+                   "", sr.message);
         }
         running_.store(true);
         startTick_ = GetTickCount64();
@@ -220,9 +225,44 @@ Result Engine::startPlayback(BackendKind kind, const DeviceId& id, const std::ws
     }
 }
 
+Result Engine::startSilentRenderForLoopback(const CaptureSource& source,
+                                            const LoopbackOptions& loopbackOptions) {
+    if (source.kind != CaptureSourceKind::SystemLoopback || !loopbackOptions.silentRender)
+        return Result::Ok();
+
+    WA_LOG(wa::log::Level::Info, "Engine", "silentRender.start",
+           "dev=" + (source.deviceId.empty() ? std::string("(default)")
+                                             : wa::narrowAscii(source.deviceId)),
+           "requested");
+
+    silentRenderBackend_ = std::make_unique<WasapiSilentRenderStream>(WasapiMode::Shared, nullptr);
+    Result r = silentRenderBackend_->open(source.deviceId, AudioFormat{}, nullptr, {});
+    if (!r) {
+        silentRenderBackend_.reset();
+        return r;
+    }
+    r = silentRenderBackend_->start();
+    if (!r) {
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+        return r;
+    }
+    WA_LOG(wa::log::Level::Info, "Engine", "silentRender.started", "", "ok");
+    return Result::Ok();
+}
+
+void Engine::stopSilentRender() {
+    if (silentRenderBackend_) {
+        WA_LOG(wa::log::Level::Info, "Engine", "silentRender.stop", "", "");
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+    }
+}
+
 void Engine::stop() {
     running_.store(false);
     if (pump_.joinable()) pump_.join();
+    stopSilentRender();
     if (backend_) backend_->stop();
     backend_.reset();
     ring_.reset();

--- a/src/core/Engine.h
+++ b/src/core/Engine.h
@@ -34,10 +34,12 @@ public:
 
     std::vector<DeviceInfo> enumerate(DataFlow flow);
     Result startCapture(BackendKind kind, const CaptureSource& source, const std::wstring& wavPath,
-                        const AudioFormat* requested = nullptr);
+                        const AudioFormat* requested = nullptr,
+                        const LoopbackOptions& loopbackOptions = {});
     Result startCapture(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
                         const AudioFormat* requested = nullptr) {
-        return startCapture(kind, CaptureSource{CaptureSourceKind::Endpoint, id}, wavPath, requested);
+        return startCapture(kind, CaptureSource{CaptureSourceKind::Endpoint, id}, wavPath,
+                            requested, {});
     }
     Result startPlayback(BackendKind kind, const DeviceId& id, const std::wstring& wavPath,
                          const AudioFormat* requested = nullptr);
@@ -49,8 +51,12 @@ public:
 private:
     void captureLoop(std::wstring wavPath);
     void playbackLoop(std::wstring wavPath);
+    Result startSilentRenderForLoopback(const CaptureSource& source,
+                                        const LoopbackOptions& loopbackOptions);
+    void   stopSilentRender();
 
     std::unique_ptr<IAudioBackend> backend_;
+    std::unique_ptr<IAudioBackend> silentRenderBackend_;
     std::unique_ptr<RingBuffer>    ring_;
     std::thread                    pump_;
     std::atomic<bool>              running_{false};

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -41,6 +41,8 @@ struct BackendStats {
     uint32_t    bufferFrames = 0;
     uint64_t    overruns = 0;
     uint64_t    underruns = 0;
+    uint64_t    idleSilenceFrames = 0;
+    uint64_t    silentPacketFrames = 0;
 };
 
 class IAudioBackend {

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -22,6 +22,10 @@ struct CaptureSource {
     DeviceId deviceId; // Endpoint: capture endpoint; SystemLoopback: render endpoint
 };
 
+struct LoopbackOptions {
+    bool silentRender = true;
+};
+
 struct DeviceInfo {
     DeviceId     id;
     std::wstring name;

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -63,7 +63,8 @@ Result sameRenderEndpoint(const DeviceId& a, const DeviceId& b, bool& same) {
 }
 } // namespace
 
-MonitorEngine::MonitorEngine(BackendFactory factory) : factory_(std::move(factory)) {}
+MonitorEngine::MonitorEngine(BackendFactory factory, SilentRenderFactory silentFactory)
+    : factory_(std::move(factory)), silentFactory_(std::move(silentFactory)) {}
 MonitorEngine::~MonitorEngine() { teardown(); }
 
 std::unique_ptr<IAudioBackend> MonitorEngine::makeBackend(DataFlow flow, BackendKind kind,
@@ -78,6 +79,58 @@ std::unique_ptr<IAudioBackend> MonitorEngine::makeBackend(DataFlow flow, Backend
         return std::make_unique<WasapiCaptureStream>(mode, requested);
     }
     return std::make_unique<WasapiRenderStream>(mode, requested);
+}
+
+std::unique_ptr<IAudioBackend> MonitorEngine::makeSilentRenderBackend(
+    const AudioFormat* requested) {
+    if (silentFactory_) return silentFactory_(requested);
+    return std::make_unique<WasapiSilentRenderStream>(WasapiMode::Shared, requested);
+}
+
+Result MonitorEngine::startSilentRenderIfNeeded() {
+    silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
+    if (capSource_.kind != CaptureSourceKind::SystemLoopback || !loopbackOptions_.silentRender)
+        return Result::Ok();
+
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.start",
+           "dev=" + wa::narrowAscii(capSource_.deviceId), "requested");
+
+    silentRenderBackend_ = makeSilentRenderBackend(nullptr);
+    if (!silentRenderBackend_) {
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return Result::Fail(-1, "MonitorEngine: silent render factory null");
+    }
+
+    Result r = silentRenderBackend_->open(capSource_.deviceId, AudioFormat{}, nullptr, {});
+    if (!r) {
+        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.open", "", r.message);
+        silentRenderBackend_.reset();
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return r;
+    }
+
+    r = silentRenderBackend_->start();
+    if (!r) {
+        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.start", "", r.message);
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+        silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
+        return r;
+    }
+
+    silentRenderState_.store(StreamState::Running, std::memory_order_relaxed);
+    WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.started", "", "ok");
+    return Result::Ok();
+}
+
+void MonitorEngine::stopSilentRender() {
+    if (silentRenderBackend_) {
+        WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.stop", "", "");
+        silentRenderBackend_->stop();
+        silentRenderBackend_.reset();
+    }
+    if (silentRenderState_.load(std::memory_order_relaxed) == StreamState::Running)
+        silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
 }
 
 Result MonitorEngine::rollback(StreamState finalState, MonitorError err, long code,
@@ -104,12 +157,14 @@ Result MonitorEngine::guardLoopbackFeedback() {
 Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
                             const DeviceId& renderId, uint32_t delayMs, bool playbackEnabled,
                             const StreamParams& capParams, const StreamParams& renderParams,
-                            const AudioFormat* capFormat) {
+                            const AudioFormat* capFormat,
+                            const LoopbackOptions& loopbackOptions) {
     teardown();
     // Fresh status slate.
     overall_.store(StreamState::Idle, std::memory_order_relaxed);
     capState_.store(StreamState::Idle, std::memory_order_relaxed);
     renderState_.store(StreamState::Idle, std::memory_order_relaxed);
+    silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
     errorCode_.store(0, std::memory_order_relaxed);
     fifoFillMs_.store(0.f, std::memory_order_relaxed);
     driftFixes_.store(0, std::memory_order_relaxed);
@@ -128,7 +183,11 @@ Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
                         static_cast<long>(MonitorError::InvalidDelay),
                         "MonitorEngine: delayMs exceeds maximum (10000 ms)");
 
-    kind_ = kind; capSource_ = capSource; renderId_ = renderId; delayMs_ = delayMs;
+    kind_ = kind;
+    capSource_ = capSource;
+    renderId_ = renderId;
+    delayMs_ = delayMs;
+    loopbackOptions_ = loopbackOptions;
     if (playbackEnabled) {
         if (Result r = guardLoopbackFeedback(); !r)
             return rollback(StreamState::Error, MonitorError::LoopbackFeedback, r.code, r.message);
@@ -172,6 +231,11 @@ Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
     capFrameBytes_ = capFmt_.blockAlign();
     if (sr == 0 || capFrameBytes_ == 0)
         return rollback(StreamState::Error, MonitorError::CaptureStart, -1, "MonitorEngine: invalid capture format");
+
+    if (Result silent = startSilentRenderIfNeeded(); !silent) {
+        WA_LOG(wa::log::Level::Warn, "MonitorEngine", "silentRender.unavailable",
+               "", silent.message);
+    }
 
     // --- Session-lifetime buffers (allocated once; freed only in teardown) ---
     // Floor of 1M so snapshotLatest's n<=cap/2 contract covers the GUI's spectrogram-history
@@ -404,6 +468,7 @@ void MonitorEngine::teardown() {
     if (pump_.joinable()) pump_.join();
 
     // Pump is gone -> safe to stop devices and free buffers (spec order: cap, then render).
+    stopSilentRender();
     if (capBackend_)    capBackend_->stop();
     if (renderBackend_) renderBackend_->stop();
     capBackend_.reset();
@@ -430,6 +495,7 @@ MonitorStatus MonitorEngine::poll() {
     s.overall     = overall_.load(std::memory_order_relaxed);
     s.capState    = capState_.load(std::memory_order_relaxed);
     s.renderState = renderState_.load(std::memory_order_relaxed);
+    s.silentRenderState = silentRenderState_.load(std::memory_order_relaxed);
     s.sampleRate  = sampleRate_.load(std::memory_order_relaxed);
     s.delayMs     = delayMsAtomic_.load(std::memory_order_relaxed);
     s.fifoFillMs  = fifoFillMs_.load(std::memory_order_relaxed);

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -103,7 +103,7 @@ Result MonitorEngine::startSilentRenderIfNeeded() {
 
     Result r = silentRenderBackend_->open(capSource_.deviceId, AudioFormat{}, nullptr, {});
     if (!r) {
-        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.open", "", r.message);
+        WA_LOG(wa::log::Level::Warn, "MonitorEngine", "silentRender.open", "", r.message);
         silentRenderBackend_.reset();
         silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
         return r;
@@ -111,7 +111,7 @@ Result MonitorEngine::startSilentRenderIfNeeded() {
 
     r = silentRenderBackend_->start();
     if (!r) {
-        WA_LOG(wa::log::Level::Err, "MonitorEngine", "silentRender.start", "", r.message);
+        WA_LOG(wa::log::Level::Warn, "MonitorEngine", "silentRender.start", "", r.message);
         silentRenderBackend_->stop();
         silentRenderBackend_.reset();
         silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -129,8 +129,7 @@ void MonitorEngine::stopSilentRender() {
         silentRenderBackend_->stop();
         silentRenderBackend_.reset();
     }
-    if (silentRenderState_.load(std::memory_order_relaxed) == StreamState::Running)
-        silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
+    silentRenderState_.store(StreamState::Idle, std::memory_order_relaxed);
 }
 
 Result MonitorEngine::rollback(StreamState finalState, MonitorError err, long code,
@@ -467,7 +466,7 @@ void MonitorEngine::teardown() {
     }
     if (pump_.joinable()) pump_.join();
 
-    // Pump is gone -> safe to stop devices and free buffers (spec order: cap, then render).
+    // Pump is gone -> safe to stop helper/devices and free buffers.
     stopSilentRender();
     if (capBackend_)    capBackend_->stop();
     if (renderBackend_) renderBackend_->stop();

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -95,7 +95,7 @@ Result MonitorEngine::startSilentRenderIfNeeded() {
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "silentRender.start",
            "dev=" + wa::narrowAscii(capSource_.deviceId), "requested");
 
-    silentRenderBackend_ = makeSilentRenderBackend(nullptr);
+    silentRenderBackend_ = makeSilentRenderBackend(&capFmt_);
     if (!silentRenderBackend_) {
         silentRenderState_.store(StreamState::Error, std::memory_order_relaxed);
         return Result::Fail(-1, "MonitorEngine: silent render factory null");

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -502,6 +502,13 @@ MonitorStatus MonitorEngine::poll() {
     s.driftFixes  = driftFixes_.load(std::memory_order_relaxed);
     s.capXruns    = capXruns_.load(std::memory_order_relaxed);
     s.renderXruns = renderXruns_.load(std::memory_order_relaxed);
+    s.capWrittenFrames = capWritten();
+    s.renderWrittenFrames = renderWritten();
+    if (capBackend_) {
+        const BackendStats stats = capBackend_->stats();
+        s.loopbackIdleSilenceFrames = stats.idleSilenceFrames;
+        s.loopbackSilentPacketFrames = stats.silentPacketFrames;
+    }
     s.capLevel    = capLevel_.load(std::memory_order_relaxed);
     s.renderLevel = renderLevel_.load(std::memory_order_relaxed);
     s.errorCode   = errorCode_.load(std::memory_order_relaxed);

--- a/src/core/MonitorEngine.h
+++ b/src/core/MonitorEngine.h
@@ -48,6 +48,10 @@ struct MonitorStatus {
     uint64_t    driftFixes  = 0;
     uint64_t    capXruns    = 0;
     uint64_t    renderXruns = 0;     // = renderRing overruns (not counted during prefill)
+    uint64_t    capWrittenFrames = 0;
+    uint64_t    renderWrittenFrames = 0;
+    uint64_t    loopbackIdleSilenceFrames = 0;
+    uint64_t    loopbackSilentPacketFrames = 0;
     float       capLevel    = 0.f;
     float       renderLevel = 0.f;
     uint32_t    errorCode   = 0;     // MonitorError

--- a/src/core/MonitorEngine.h
+++ b/src/core/MonitorEngine.h
@@ -40,6 +40,7 @@ struct MonitorStatus {
     StreamState overall     = StreamState::Idle;
     StreamState capState    = StreamState::Idle;
     StreamState renderState = StreamState::Idle;
+    StreamState silentRenderState = StreamState::Idle;
     uint32_t    sampleRate  = 0;
     uint32_t    delayMs     = 0;
     float       fifoFillMs  = 0.f;   // EMA-smoothed DelayFifo occupancy in ms
@@ -64,8 +65,11 @@ public:
     using BackendFactory =
         std::function<std::unique_ptr<IAudioBackend>(DataFlow, const CaptureSource*,
                                                      const AudioFormat*)>;
+    using SilentRenderFactory =
+        std::function<std::unique_ptr<IAudioBackend>(const AudioFormat*)>;
 
-    explicit MonitorEngine(BackendFactory factory = {}); // empty => real WASAPI streams
+    explicit MonitorEngine(BackendFactory factory = {},
+                           SilentRenderFactory silentFactory = {});
     ~MonitorEngine();
 
     MonitorEngine(const MonitorEngine&)            = delete;
@@ -74,13 +78,14 @@ public:
     Result start(BackendKind kind, const CaptureSource& capSource, const DeviceId& renderId,
                  uint32_t delayMs, bool playbackEnabled = true,
                  const StreamParams& capParams = {}, const StreamParams& renderParams = {},
-                 const AudioFormat* capFormat = nullptr);
+                 const AudioFormat* capFormat = nullptr,
+                 const LoopbackOptions& loopbackOptions = {});
     Result start(BackendKind kind, const DeviceId& capId, const DeviceId& renderId,
                  uint32_t delayMs, bool playbackEnabled = true,
                  const StreamParams& capParams = {}, const StreamParams& renderParams = {},
                  const AudioFormat* capFormat = nullptr) {
         return start(kind, CaptureSource{CaptureSourceKind::Endpoint, capId}, renderId,
-                     delayMs, playbackEnabled, capParams, renderParams, capFormat);
+                     delayMs, playbackEnabled, capParams, renderParams, capFormat, {});
     }
     void   stop();
     MonitorStatus poll();
@@ -101,16 +106,21 @@ private:
     std::unique_ptr<IAudioBackend> makeBackend(DataFlow flow, BackendKind kind,
                                                const CaptureSource* source,
                                                const AudioFormat* requested);
+    std::unique_ptr<IAudioBackend> makeSilentRenderBackend(const AudioFormat* requested);
+    Result startSilentRenderIfNeeded();
+    void   stopSilentRender();
     Result engageRender();      // pump 前(start) 或 pump 线程调用；开渲染+校验+建 FIFO/刮擦；失败原子(全关渲染)
     void   disengageRender();   // 停+关渲染、释放设备、reset renderRing_/delayFifo_；不动 renderScope_
 
     BackendFactory factory_; // empty => build real WASAPI streams
+    SilentRenderFactory silentFactory_;
 
     // Run-const session parameters (set in start(), consumed in engageRender()).
     BackendKind kind_{BackendKind::WasapiShared};
     CaptureSource capSource_{};
     DeviceId    renderId_{};
     uint32_t    delayMs_ = 0;
+    LoopbackOptions loopbackOptions_{};
     std::atomic<bool> wantPlayback_{false};
     StreamParams capParams_{};      // start 时消费(采集参数改动需 Stop/Start)
     StreamParams renderParams_{};   // paramsMtx_ 保护;engageRender 取快照
@@ -120,6 +130,7 @@ private:
 
     std::unique_ptr<IAudioBackend> capBackend_;
     std::unique_ptr<IAudioBackend> renderBackend_;
+    std::unique_ptr<IAudioBackend> silentRenderBackend_;
     std::unique_ptr<RingBuffer>    captureRing_;
     std::unique_ptr<RingBuffer>    renderRing_;
     std::unique_ptr<ScopeBuffer>   captureScope_;
@@ -145,6 +156,7 @@ private:
     std::atomic<StreamState> overall_{StreamState::Idle};
     std::atomic<StreamState> capState_{StreamState::Idle};
     std::atomic<StreamState> renderState_{StreamState::Idle};
+    std::atomic<StreamState> silentRenderState_{StreamState::Idle};
     std::atomic<uint32_t>    sampleRate_{0};
     std::atomic<uint32_t>    delayMsAtomic_{0};
     std::atomic<uint32_t>    renderBufMs_{0};

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -34,13 +34,24 @@ AUDCLNT_STREAMOPTIONS mapStreamOption(StreamOption o) {
 }
 
 uint32_t loopbackSilenceFramesForTimeout(uint32_t sampleRate, uint32_t timeoutMs) {
-    if (sampleRate == 0 || timeoutMs == 0) return 0;
-    return static_cast<uint32_t>((static_cast<uint64_t>(sampleRate) * timeoutMs) / 1000u);
+    return loopbackSilenceFramesForElapsed(sampleRate, timeoutMs, timeoutMs);
+}
+
+uint32_t loopbackSilenceFramesForElapsed(uint32_t sampleRate, uint64_t elapsedMs,
+                                         uint32_t maxMs) {
+    if (sampleRate == 0 || elapsedMs == 0 || maxMs == 0) return 0;
+    const uint64_t boundedMs = elapsedMs < maxMs ? elapsedMs : maxMs;
+    return static_cast<uint32_t>((static_cast<uint64_t>(sampleRate) * boundedMs) / 1000u);
+}
+
+uint32_t captureSilentPacketFrames(uint32_t frames, unsigned flags) {
+    return (flags & AUDCLNT_BUFFERFLAGS_SILENT) ? frames : 0u;
 }
 
 bool shouldWriteLoopbackIdleSilence(unsigned waitResult, long packetStatus,
                                     bool sawPacket, bool wroteFrames) {
-    return waitResult == WAIT_TIMEOUT && SUCCEEDED(static_cast<HRESULT>(packetStatus)) &&
+    return (waitResult == WAIT_TIMEOUT || waitResult == WAIT_OBJECT_0) &&
+           SUCCEEDED(static_cast<HRESULT>(packetStatus)) &&
            !sawPacket && !wroteFrames;
 }
 
@@ -62,6 +73,8 @@ Result WasapiStream::open(const DeviceId& id, const AudioFormat& /*fmt*/, RingBu
     deviceId_ = id;
     ring_ = ring;
     params_ = params;
+    idleSilenceFrames_.store(0, std::memory_order_relaxed);
+    silentPacketFrames_.store(0, std::memory_order_relaxed);
     return Result::Ok(); // real activation happens on the worker thread (its own COM apt)
 }
 
@@ -117,6 +130,8 @@ BackendStats WasapiStream::stats() const {
     BackendStats s{};
     s.actualFormat = actualFormat_;
     s.bufferFrames = bufferFrames_;
+    s.idleSilenceFrames = idleSilenceFrames_.load(std::memory_order_relaxed);
+    s.silentPacketFrames = silentPacketFrames_.load(std::memory_order_relaxed);
     if (ring_) { s.overruns = ring_->overruns(); s.underruns = ring_->underruns(); }
     return s;
 }
@@ -369,6 +384,7 @@ void WasapiCaptureStream::runLoop() {
     wa::log::setThreadName("capW");
     WA_LOG(wa::log::Level::Info, "WasapiStream", "runLoop", "capture loop started", "");
     constexpr DWORD kCaptureWaitMs = 200;
+    ULONGLONG lastWriteMs = GetTickCount64();
     while (running_.load()) {
         DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), kCaptureWaitMs);
         wa::log::emitTrace("WasapiStream", "WaitForSingleObject", 0, waitRc, 0);
@@ -390,22 +406,32 @@ void WasapiCaptureStream::runLoop() {
                 static thread_local std::vector<uint8_t> zeros;
                 zeros.assign(bytes, 0);
                 ring_->write(zeros.data(), bytes);
+                silentPacketFrames_.fetch_add(captureSilentPacketFrames(frames, flags),
+                                              std::memory_order_relaxed);
                 wroteFrames = true;
+                lastWriteMs = GetTickCount64();
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             } else if (data) {
                 ring_->write(data, bytes);
                 wroteFrames = true;
+                lastWriteMs = GetTickCount64();
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             }
             HRESULT hrRB = capture_->ReleaseBuffer(frames);
             wa::log::emitTrace("WasapiStream", "ReleaseBuffer", frames, 0, (long)hrRB);
         }
         if (shouldWriteLoopbackIdleSilence(waitRc, static_cast<long>(hrNP), sawPacket, wroteFrames)) {
-            const uint32_t frames = idleSilenceFrames(kCaptureWaitMs);
+            const ULONGLONG nowMs = GetTickCount64();
+            const uint32_t frames = idleSilenceFrames(
+                static_cast<uint32_t>(nowMs - lastWriteMs < kCaptureWaitMs
+                                          ? nowMs - lastWriteMs
+                                          : kCaptureWaitMs));
             if (frames > 0 && frameBytes_ > 0) {
                 static thread_local std::vector<uint8_t> zeros;
                 zeros.assign(static_cast<size_t>(frames) * frameBytes_, 0);
                 ring_->write(zeros.data(), zeros.size());
+                idleSilenceFrames_.fetch_add(frames, std::memory_order_relaxed);
+                lastWriteMs = nowMs;
                 if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
             }
         }

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -493,4 +493,74 @@ void WasapiRenderStream::runLoop() {
     }
 }
 
+WasapiSilentRenderStream::WasapiSilentRenderStream(WasapiMode mode,
+                                                   const AudioFormat* requested)
+    : WasapiStream(mode, requested) {}
+
+WasapiSilentRenderStream::~WasapiSilentRenderStream() { close(); }
+
+Result WasapiSilentRenderStream::open(const DeviceId& id, const AudioFormat& fmt,
+                                      RingBuffer* ring, const StreamParams& params) {
+    if (isExclusive()) {
+        return Result::Fail(-1, "WasapiSilentRenderStream: silent render requires WASAPI-Shared");
+    }
+    return WasapiStream::open(id, fmt, ring, params);
+}
+
+Result WasapiSilentRenderStream::createService() {
+    HRESULT hr = client_->GetService(__uuidof(IAudioRenderClient),
+        reinterpret_cast<void**>(render_.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream",
+           "GetService(IAudioRenderClient)", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "WasapiSilentRenderStream",
+               "GetService(IAudioRenderClient)", "", wa::log::hrName(hr));
+        return HrToResult(hr, "WasapiSilentRenderStream: GetService");
+    }
+    return Result::Ok();
+}
+
+void WasapiSilentRenderStream::preRoll() {
+    BYTE* buf = nullptr;
+    HRESULT hrPre = render_->GetBuffer(bufferFrames_, &buf);
+    WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream", "GetBuffer(preRoll)",
+           "frames=" + std::to_string(bufferFrames_), wa::log::hrName(hrPre));
+    if (SUCCEEDED(hrPre)) {
+        HRESULT hrRel = render_->ReleaseBuffer(bufferFrames_, AUDCLNT_BUFFERFLAGS_SILENT);
+        WA_LOG(wa::log::Level::Debug, "WasapiSilentRenderStream",
+               "ReleaseBuffer(preRoll)", "", wa::log::hrName(hrRel));
+    }
+}
+
+void WasapiSilentRenderStream::runLoop() {
+    wa::log::setThreadName("silR");
+    WA_LOG(wa::log::Level::Info, "WasapiSilentRenderStream", "runLoop",
+           "silent render loop started", "");
+    while (running_.load()) {
+        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), 200);
+        wa::log::emitTrace("WasapiSilentRenderStream", "WaitForSingleObject", 0, waitRc, 0);
+        if (!running_.load()) break;
+
+        UINT32 padding = 0;
+        HRESULT hrPad = client_->GetCurrentPadding(&padding);
+        wa::log::emitTrace("WasapiSilentRenderStream", "GetCurrentPadding", padding, 0,
+                           static_cast<long>(hrPad));
+        if (FAILED(hrPad)) break;
+
+        UINT32 frames = bufferFrames_ - padding;
+        if (frames == 0) continue;
+
+        BYTE* buf = nullptr;
+        HRESULT hrGB = render_->GetBuffer(frames, &buf);
+        wa::log::emitTrace("WasapiSilentRenderStream", "GetBuffer", frames, 0,
+                           static_cast<long>(hrGB));
+        if (FAILED(hrGB)) break;
+
+        HRESULT hrRB = render_->ReleaseBuffer(frames, AUDCLNT_BUFFERFLAGS_SILENT);
+        wa::log::emitTrace("WasapiSilentRenderStream", "ReleaseBuffer", frames,
+                           AUDCLNT_BUFFERFLAGS_SILENT, static_cast<long>(hrRB));
+        if (FAILED(hrRB)) break;
+    }
+}
+
 } // namespace wa

--- a/src/core/WasapiStream.h
+++ b/src/core/WasapiStream.h
@@ -19,6 +19,9 @@ enum class WasapiMode { Shared, Exclusive };
 AUDIO_STREAM_CATEGORY mapCategory(AudioCategory c);
 AUDCLNT_STREAMOPTIONS mapStreamOption(StreamOption o);
 uint32_t loopbackSilenceFramesForTimeout(uint32_t sampleRate, uint32_t timeoutMs);
+uint32_t loopbackSilenceFramesForElapsed(uint32_t sampleRate, uint64_t elapsedMs,
+                                         uint32_t maxMs);
+uint32_t captureSilentPacketFrames(uint32_t frames, unsigned flags);
 bool shouldWriteLoopbackIdleSilence(unsigned waitResult, long packetStatus,
                                     bool sawPacket, bool wroteFrames);
 
@@ -50,6 +53,8 @@ protected:
     uint32_t    bufferFrames_ = 0;
     uint32_t    frameBytes_ = 0;
     std::atomic<bool> running_{false};
+    std::atomic<uint64_t> idleSilenceFrames_{0};
+    std::atomic<uint64_t> silentPacketFrames_{0};
     void*       hEvent_ = nullptr;        // HANDLE
     ComPtr<IAudioClient> client_;
 

--- a/src/core/WasapiStream.h
+++ b/src/core/WasapiStream.h
@@ -118,4 +118,20 @@ private:
     ComPtr<IAudioRenderClient> render_;
 };
 
+class WasapiSilentRenderStream : public WasapiStream {
+public:
+    WasapiSilentRenderStream(WasapiMode mode, const AudioFormat* requested);
+    ~WasapiSilentRenderStream() override;
+    Result open(const DeviceId& id, const AudioFormat& fmt, RingBuffer* ring,
+                const StreamParams& params) override;
+protected:
+    EDataFlow dataFlow() const override { return eRender; }
+    Result createService() override;
+    void   preRoll() override;
+    void   runLoop() override;
+    void   resetService() override { render_.Reset(); }
+private:
+    ComPtr<IAudioRenderClient> render_;
+};
+
 } // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -286,6 +286,11 @@ void AppUi::draw() {
 }
 
 void AppUi::drawMonitorPage() {
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("monitorTop", ImVec2(0, topHeight), false);
     ImGui::BeginChild("left", ImVec2(360, 0), true);
     drawLeftPanel();
     ImGui::EndChild();
@@ -295,9 +300,20 @@ void AppUi::drawMonitorPage() {
     ImGui::BeginChild("charts", ImVec2(0, 0), true);
     drawChartsColumn(monitor_, ms_, monitorViz_);
     ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("monitorLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("log", true);
+    ImGui::EndChild();
 }
 
 void AppUi::drawLoopbackPage() {
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("loopbackTop", ImVec2(0, topHeight), false);
     ImGui::BeginChild("loopbackLeft", ImVec2(320, 0), true);
     drawLoopbackLeftPanel();
     ImGui::EndChild();
@@ -327,6 +343,12 @@ void AppUi::drawLoopbackPage() {
     }
     ImGui::TextUnformatted("System audio waveform + spectrogram");
     drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
+    ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("loopbackLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("loopbackLog", false);
     ImGui::EndChild();
 }
 
@@ -392,8 +414,6 @@ void AppUi::drawLoopbackLeftPanel() {
         ss[(int)loopbackMs_.silentRenderState]);
     ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
 
-    ImGui::SeparatorText("Log");
-    drawLogPanel("loopbackLog", false);
 }
 
 void AppUi::drawLeftPanel() {
@@ -487,9 +507,6 @@ void AppUi::drawLeftPanel() {
     ImGui::ProgressBar(ms_.capLevel,    ImVec2(-1, 0), "cap");
     ImGui::ProgressBar(ms_.renderLevel, ImVec2(-1, 0), "ren");
 
-    // --- Log (fills remaining height) ---
-    ImGui::SeparatorText("Log");
-    drawLogPanel("log", true);
 }
 
 void AppUi::drawLogPanel(const char* childId, bool showLevelFilter) {

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -410,6 +410,10 @@ void AppUi::drawLoopbackLeftPanel() {
     ImGui::Text("overall=%s  cap=%s  sr=%u",
         ss[(int)loopbackMs_.overall], ss[(int)loopbackMs_.capState], loopbackMs_.sampleRate);
     ImGui::Text("xrun=%llu", (unsigned long long)loopbackMs_.capXruns);
+    ImGui::Text("frames=%llu", (unsigned long long)loopbackMs_.capWrittenFrames);
+    ImGui::Text("silent-packet=%llu  idle-fill=%llu",
+        (unsigned long long)loopbackMs_.loopbackSilentPacketFrames,
+        (unsigned long long)loopbackMs_.loopbackIdleSilenceFrames);
     ImGui::Text("silent render=%s",
         ss[(int)loopbackMs_.silentRenderState]);
     ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
@@ -504,6 +508,9 @@ void AppUi::drawLeftPanel() {
         (unsigned long long)ms_.driftFixes,
         (unsigned long long)ms_.capXruns,
         (unsigned long long)ms_.renderXruns);
+    ImGui::Text("frames c/r=%llu/%llu",
+        (unsigned long long)ms_.capWrittenFrames,
+        (unsigned long long)ms_.renderWrittenFrames);
     ImGui::ProgressBar(ms_.capLevel,    ImVec2(-1, 0), "cap");
     ImGui::ProgressBar(ms_.renderLevel, ImVec2(-1, 0), "ren");
 

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -357,8 +357,10 @@ void AppUi::drawLoopbackLeftPanel() {
         if (ImGui::Button("Start", ctrlBtn)) {
             wa::DeviceId id = renderDevices_.empty() ? L"" : renderDevices_[(size_t)loopbackDevIdx_].id;
             wa::CaptureSource source{wa::CaptureSourceKind::SystemLoopback, id};
+            wa::LoopbackOptions loopbackOptions{};
+            loopbackOptions.silentRender = loopbackSilentRender_;
             wa::Result r = loopback_.start(wa::BackendKind::WasapiShared, source, L"", 0,
-                                           false);
+                                           false, {}, {}, nullptr, loopbackOptions);
             logLines_.push_back(r ? "loopback started" : ("loopback error: " + r.message));
             if (r) {
                 loopbackStarted_ = true;
@@ -373,12 +375,21 @@ void AppUi::drawLoopbackLeftPanel() {
             logLines_.push_back("loopback stopped");
         }
     }
+    if (!loopbackStarted_) {
+        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
+    } else {
+        ImGui::BeginDisabled();
+        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
+        ImGui::EndDisabled();
+    }
 
     ImGui::SeparatorText("Status");
     const char* ss[] = {"Idle", "Running", "Error"};
     ImGui::Text("overall=%s  cap=%s  sr=%u",
         ss[(int)loopbackMs_.overall], ss[(int)loopbackMs_.capState], loopbackMs_.sampleRate);
     ImGui::Text("xrun=%llu", (unsigned long long)loopbackMs_.capXruns);
+    ImGui::Text("silent render=%s",
+        ss[(int)loopbackMs_.silentRenderState]);
     ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
 
     ImGui::SeparatorText("Log");

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -77,6 +77,7 @@ private:
     int                         delayMs_      = 100;
     bool                        monitorStarted_ = false;
     bool                        loopbackStarted_ = false;
+    bool                        loopbackSilentRender_ = true;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,10 +15,12 @@ add_executable(WinAudioTests
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp
+    test_cli_options.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
 )
 target_include_directories(WinAudioTests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src/cli
     ${CMAKE_SOURCE_DIR}/src/gui                   # for Spectrogram.h
 )
 target_link_libraries(WinAudioTests PRIVATE WinAudioCore gtest_main)

--- a/src/tests/test_cli_options.cpp
+++ b/src/tests/test_cli_options.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "CliOptions.h"
+
+TEST(CliOptions, LoopbackSilentRenderDefaultsEnabled) {
+    const wchar_t* argv[] = {L"WinAudioCli", L"capture", L"--loopback"};
+
+    wa::LoopbackOptions opts =
+        wa::cli::parseLoopbackOptions(3, const_cast<wchar_t**>(argv));
+
+    EXPECT_TRUE(opts.silentRender);
+}
+
+TEST(CliOptions, NoSilentRenderDisablesHelper) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"monitor", L"--loopback", L"--no-silent-render"
+    };
+
+    wa::LoopbackOptions opts =
+        wa::cli::parseLoopbackOptions(4, const_cast<wchar_t**>(argv));
+
+    EXPECT_FALSE(opts.silentRender);
+}

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -36,13 +36,25 @@ TEST(WasapiSystemLoopbackCaptureStream, IdleTimeoutSilenceKeepsWallClockCadence)
     EXPECT_EQ(loopbackSilenceFramesForTimeout(0, 200), 0u);
 }
 
-TEST(WasapiSystemLoopbackCaptureStream, IdleSilenceOnlyWhenTimeoutHasNoPackets) {
+TEST(WasapiSystemLoopbackCaptureStream, IdleSilenceWhenWakeHasNoPackets) {
     EXPECT_TRUE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, false, false));
-    EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_OBJECT_0, S_OK, false, false));
+    EXPECT_TRUE(shouldWriteLoopbackIdleSilence(WAIT_OBJECT_0, S_OK, false, false));
     EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, true, false));
     EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, S_OK, false, true));
     EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, AUDCLNT_E_DEVICE_INVALIDATED,
                                                false, false));
+}
+
+TEST(WasapiSystemLoopbackCaptureStream, IdleSilenceUsesElapsedTimeWithTimeoutCap) {
+    EXPECT_EQ(loopbackSilenceFramesForElapsed(48000, 10, 200), 480u);
+    EXPECT_EQ(loopbackSilenceFramesForElapsed(48000, 250, 200), 9600u);
+    EXPECT_EQ(loopbackSilenceFramesForElapsed(48000, 0, 200), 0u);
+    EXPECT_EQ(loopbackSilenceFramesForElapsed(0, 10, 200), 0u);
+}
+
+TEST(WasapiSystemLoopbackCaptureStream, SilentPacketFramesComeFromWasapiFlag) {
+    EXPECT_EQ(captureSilentPacketFrames(480, AUDCLNT_BUFFERFLAGS_SILENT), 480u);
+    EXPECT_EQ(captureSilentPacketFrames(480, 0), 0u);
 }
 
 TEST(WasapiSilentRenderStream, RejectsExclusiveInOpen) {

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -44,3 +44,13 @@ TEST(WasapiSystemLoopbackCaptureStream, IdleSilenceOnlyWhenTimeoutHasNoPackets) 
     EXPECT_FALSE(shouldWriteLoopbackIdleSilence(WAIT_TIMEOUT, AUDCLNT_E_DEVICE_INVALIDATED,
                                                false, false));
 }
+
+TEST(WasapiSilentRenderStream, RejectsExclusiveInOpen) {
+    WasapiSilentRenderStream stream(WasapiMode::Exclusive, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, nullptr, StreamParams{});
+
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_NE(r.message.find("silent render"), std::string::npos);
+    EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -58,6 +58,8 @@ public:
         BackendStats s{};
         s.actualFormat = fmt_;
         s.bufferFrames = bufferFrames_;
+        s.idleSilenceFrames = idleSilenceFrames_;
+        s.silentPacketFrames = silentPacketFrames_;
         return s;
     }
     void* dataReadyEvent() const override { return evt_; }
@@ -75,6 +77,8 @@ public:
     bool               failOpen_    = false;
     std::atomic<bool>  started_{false};
     uint32_t          bufferFrames_ = 0;
+    uint64_t          idleSilenceFrames_ = 0;
+    uint64_t          silentPacketFrames_ = 0;
     StreamParams      lastOpenParams_{};
     RingBuffer*       ring_ = nullptr;
     HANDLE            evt_  = nullptr;
@@ -531,6 +535,27 @@ TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
     eng.stop();
     EXPECT_TRUE(rig.silentStopped.load());
     EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
+}
+
+TEST(MonitorEngine, PollExposesCaptureProgressAndLoopbackSilenceFrames) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+    ASSERT_NE(rig.capPtr, nullptr);
+
+    rig.capPtr->idleSilenceFrames_ = 9600;
+    rig.capPtr->silentPacketFrames_ = 4800;
+    auto pcm = makeRampPcm({0, 0, 0, 0}, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+
+    ASSERT_TRUE(waitFor([&] { return eng.capWritten() >= 4; }));
+    MonitorStatus st = eng.poll();
+    EXPECT_GE(st.capWrittenFrames, 4u);
+    EXPECT_EQ(st.loopbackIdleSilenceFrames, 9600u);
+    EXPECT_EQ(st.loopbackSilentPacketFrames, 4800u);
+    eng.stop();
 }
 
 TEST(MonitorEngine, LoopbackCanDisableSilentRender) {

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -27,8 +27,9 @@ namespace {
 class FakeBackend : public IAudioBackend {
 public:
     FakeBackend(AudioFormat fmt, bool failStart, std::atomic<bool>* stoppedOut,
-                std::atomic<int>* openDoneOut = nullptr)
-        : fmt_(fmt), failStart_(failStart), stoppedOut_(stoppedOut), openDoneOut_(openDoneOut) {
+                std::atomic<int>* openDoneOut = nullptr, bool failOpen = false)
+        : fmt_(fmt), failStart_(failStart), stoppedOut_(stoppedOut),
+          openDoneOut_(openDoneOut), failOpen_(failOpen) {
         evt_ = CreateEventW(nullptr, /*manualReset*/ FALSE, /*initial*/ FALSE, nullptr);
     }
     ~FakeBackend() override {
@@ -37,6 +38,7 @@ public:
 
     Result open(const DeviceId&, const AudioFormat&, RingBuffer* ring,
                 const StreamParams& params) override {
+        if (failOpen_) return Result::Fail(122, "fake: open failed");
         ring_ = ring;
         lastOpenParams_ = params;
         if (openDoneOut_) openDoneOut_->fetch_add(1, std::memory_order_release);
@@ -70,6 +72,7 @@ public:
     bool               failStart_   = false;
     std::atomic<bool>* stoppedOut_  = nullptr;
     std::atomic<int>*  openDoneOut_ = nullptr;
+    bool               failOpen_    = false;
     std::atomic<bool>  started_{false};
     uint32_t          bufferFrames_ = 0;
     StreamParams      lastOpenParams_{};
@@ -85,6 +88,7 @@ struct FakeRig {
     AudioFormat capFmt{48000, 2, 16, false};
     AudioFormat renderFmt{48000, 2, 16, false};
     bool        renderFailStart = false;
+    bool        silentFailOpen = false;
     bool        silentFailStart = false;
 
     std::atomic<bool> capStopped{false};
@@ -122,7 +126,8 @@ struct FakeRig {
     MonitorEngine::SilentRenderFactory silentFactory() {
         return [this](const AudioFormat* req) -> std::unique_ptr<IAudioBackend> {
             silentOpenCount.fetch_add(1, std::memory_order_relaxed);
-            auto b = std::make_unique<FakeBackend>(renderFmt, silentFailStart, &silentStopped);
+            auto b = std::make_unique<FakeBackend>(renderFmt, silentFailStart, &silentStopped,
+                                                   nullptr, silentFailOpen);
             silentPtr = b.get();
             if (req) { b->lastRequested_ = *req; b->sawRequested_ = true; }
             return b;
@@ -524,6 +529,8 @@ TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
     EXPECT_EQ(rig.silentPtr->lastRequested_, rig.capFmt);
     EXPECT_EQ(eng.poll().silentRenderState, StreamState::Running);
     eng.stop();
+    EXPECT_TRUE(rig.silentStopped.load());
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
 }
 
 TEST(MonitorEngine, LoopbackCanDisableSilentRender) {
@@ -558,6 +565,25 @@ TEST(MonitorEngine, SilentRenderFailureDoesNotFailLoopbackCapture) {
     EXPECT_EQ(eng.poll().capState, StreamState::Running);
     EXPECT_EQ(eng.poll().silentRenderState, StreamState::Error);
     eng.stop();
+}
+
+TEST(MonitorEngine, SilentRenderOpenFailureDoesNotFailLoopbackCapture) {
+    FakeRig rig;
+    rig.silentFailOpen = true;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"", 50, false);
+
+    EXPECT_TRUE(r);
+    ASSERT_NE(rig.capPtr, nullptr);
+    EXPECT_TRUE(rig.capPtr->started_.load());
+    EXPECT_EQ(eng.poll().capState, StreamState::Running);
+    EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    EXPECT_EQ(eng.poll().overall, StreamState::Running);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Error);
+    eng.stop();
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
 }
 
 TEST(MonitorEngine, LoopbackPlaybackRejectsSameRenderDevice) {

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -85,14 +85,18 @@ struct FakeRig {
     AudioFormat capFmt{48000, 2, 16, false};
     AudioFormat renderFmt{48000, 2, 16, false};
     bool        renderFailStart = false;
+    bool        silentFailStart = false;
 
     std::atomic<bool> capStopped{false};
     std::atomic<bool> renderStopped{false};
+    std::atomic<bool> silentStopped{false};
     std::atomic<int>  capOpenCount{0};
     std::atomic<int>  renderOpenCount{0};  // increments each time render factory is called
+    std::atomic<int>  silentOpenCount{0};
     std::atomic<int>  renderOpenDone{0};   // release-incremented inside open() for race-free sync
     FakeBackend*      capPtr    = nullptr;
     FakeBackend*      renderPtr = nullptr;
+    FakeBackend*      silentPtr = nullptr;
     CaptureSource     lastCaptureSource{};
     bool              sawCaptureSource = false;
 
@@ -111,6 +115,16 @@ struct FakeRig {
             renderStopped.store(false, std::memory_order_relaxed); // reset for each new backend
             auto b    = std::make_unique<FakeBackend>(renderFmt, renderFailStart, &renderStopped, &renderOpenDone);
             renderPtr = b.get();
+            return b;
+        };
+    }
+
+    MonitorEngine::SilentRenderFactory silentFactory() {
+        return [this](const AudioFormat* req) -> std::unique_ptr<IAudioBackend> {
+            silentOpenCount.fetch_add(1, std::memory_order_relaxed);
+            auto b = std::make_unique<FakeBackend>(renderFmt, silentFailStart, &silentStopped);
+            silentPtr = b.get();
+            if (req) { b->lastRequested_ = *req; b->sawRequested_ = true; }
             return b;
         };
     }
@@ -483,7 +497,7 @@ TEST(MonitorEngine, LegacyStartUsesEndpointCaptureSource) {
 
 TEST(MonitorEngine, LoopbackCaptureSourceReachesFactory) {
     FakeRig rig;
-    MonitorEngine eng(rig.factory());
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
     CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
 
     ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"playback-render-id", 50,
@@ -494,6 +508,49 @@ TEST(MonitorEngine, LoopbackCaptureSourceReachesFactory) {
     EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::SystemLoopback);
     EXPECT_EQ(rig.lastCaptureSource.deviceId, L"loopback-render-id");
     EXPECT_EQ(rig.renderOpenCount.load(), 0);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+
+    EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Running);
+    eng.stop();
+}
+
+TEST(MonitorEngine, LoopbackCanDisableSilentRender) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+    LoopbackOptions opts{};
+    opts.silentRender = false;
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false,
+                          {}, {}, nullptr, opts));
+
+    EXPECT_EQ(rig.silentOpenCount.load(), 0);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
+    eng.stop();
+}
+
+TEST(MonitorEngine, SilentRenderFailureDoesNotFailLoopbackCapture) {
+    FakeRig rig;
+    rig.silentFailStart = true;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::SystemLoopback, L"loopback-render-id"};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"", 50, false);
+
+    EXPECT_TRUE(r);
+    EXPECT_EQ(rig.capOpenCount.load(), 1);
+    EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    EXPECT_EQ(eng.poll().overall, StreamState::Running);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Error);
     eng.stop();
 }
 
@@ -529,7 +586,7 @@ TEST(MonitorEngine, LoopbackPlaybackRejectsBothDefaultRenderDevices) {
 
 TEST(MonitorEngine, LoopbackRuntimePlaybackRejectsSameRenderDevice) {
     FakeRig rig;
-    MonitorEngine eng(rig.factory());
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
     CaptureSource source{CaptureSourceKind::SystemLoopback, L"same-render-id"};
 
     ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"same-render-id", 50,

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -519,6 +519,9 @@ TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
     ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
 
     EXPECT_EQ(rig.silentOpenCount.load(), 1);
+    ASSERT_NE(rig.silentPtr, nullptr);
+    EXPECT_TRUE(rig.silentPtr->sawRequested_);
+    EXPECT_EQ(rig.silentPtr->lastRequested_, rig.capFmt);
     EXPECT_EQ(eng.poll().silentRenderState, StreamState::Running);
     eng.stop();
 }
@@ -548,8 +551,11 @@ TEST(MonitorEngine, SilentRenderFailureDoesNotFailLoopbackCapture) {
 
     EXPECT_TRUE(r);
     EXPECT_EQ(rig.capOpenCount.load(), 1);
+    ASSERT_NE(rig.capPtr, nullptr);
+    EXPECT_TRUE(rig.capPtr->started_.load());
     EXPECT_EQ(rig.silentOpenCount.load(), 1);
     EXPECT_EQ(eng.poll().overall, StreamState::Running);
+    EXPECT_EQ(eng.poll().capState, StreamState::Running);
     EXPECT_EQ(eng.poll().silentRenderState, StreamState::Error);
     eng.stop();
 }


### PR DESCRIPTION
## Summary
- Move Monitor and System Loopback logs into full-width bottom regions so charts and logs have more usable space.
- Add a default-enabled silent render keepalive for system loopback, wired through GUI, CLI, monitor engine, and WASAPI backend.
- Expose loopback diagnostics separately for capture frames, WASAPI silent-packet frames, and idle fallback zero-fill frames.

## Test Plan
- [x] cmake --build build --config Debug -j
- [x] ctest --test-dir build -C Debug --output-on-failure
- [x] git diff --check (CRLF warnings only)