### PR TITLE
Add Application Loopback capture tab

### DIFF
--- a/src/core/ApplicationLoopbackCapture.cpp
+++ b/src/core/ApplicationLoopbackCapture.cpp
@@ -1,0 +1,360 @@
+#include "ApplicationLoopbackCapture.h"
+#if defined(__has_include)
+#if __has_include(<audioclientactivationparams.h>)
+#define WA_HAS_AUDIOCLIENT_ACTIVATION_PARAMS 1
+#include <audioclientactivationparams.h>
+#endif
+#endif
+#ifndef WA_HAS_AUDIOCLIENT_ACTIVATION_PARAMS
+#define WA_HAS_AUDIOCLIENT_ACTIVATION_PARAMS 0
+#endif
+#include <memory>
+#include <propidl.h>
+#include <wrl/implements.h>
+#include "AudioFormat.h"
+#include "AudioFormatStr.h"
+#include "FormatSpec.h"
+#include "Log.h"
+#include "RingBuffer.h"
+
+namespace wa {
+namespace {
+
+struct ActivationEvent {
+    ActivationEvent() : handle(CreateEventW(nullptr, FALSE, FALSE, nullptr)) {}
+    ~ActivationEvent() { if (handle) CloseHandle(handle); }
+    HANDLE handle = nullptr;
+};
+
+class ActivationHandler
+    : public Microsoft::WRL::RuntimeClass<
+          Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>,
+          Microsoft::WRL::FtmBase,
+          IActivateAudioInterfaceCompletionHandler> {
+public:
+    explicit ActivationHandler(std::shared_ptr<ActivationEvent> done) : done_(std::move(done)) {}
+
+    HRESULT STDMETHODCALLTYPE ActivateCompleted(
+        IActivateAudioInterfaceAsyncOperation* operation) override {
+        Microsoft::WRL::ComPtr<IUnknown> activated;
+        HRESULT activateResult = E_UNEXPECTED;
+        HRESULT hr = operation ? operation->GetActivateResult(&activateResult,
+                                                              activated.GetAddressOf())
+                               : E_POINTER;
+        result_ = FAILED(hr) ? hr : activateResult;
+        if (SUCCEEDED(result_)) activated_ = activated;
+        if (done_ && done_->handle) SetEvent(done_->handle);
+        return S_OK;
+    }
+
+    HRESULT copyClientTo(ComPtr<IAudioClient>& client) const {
+        if (FAILED(result_)) return result_;
+        if (!activated_) return E_POINTER;
+        return activated_.As(&client);
+    }
+
+private:
+    std::shared_ptr<ActivationEvent> done_;
+    HRESULT result_ = E_UNEXPECTED;
+    Microsoft::WRL::ComPtr<IUnknown> activated_;
+};
+
+Result activateProcessLoopbackClient(uint32_t processId, ComPtr<IAudioClient>& client) {
+#if WA_HAS_AUDIOCLIENT_ACTIVATION_PARAMS && defined(VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK)
+    auto done = std::make_shared<ActivationEvent>();
+    if (!done->handle) {
+        return Result::Fail(static_cast<long>(GetLastError()),
+                            "ApplicationLoopbackCaptureStream: CreateEventW failed");
+    }
+
+    AUDIOCLIENT_ACTIVATION_PARAMS activationParams{};
+    activationParams.ActivationType = AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK;
+    activationParams.ProcessLoopbackParams.TargetProcessId = processId;
+    activationParams.ProcessLoopbackParams.ProcessLoopbackMode =
+        PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE;
+
+    PROPVARIANT prop{};
+    prop.vt = VT_BLOB;
+    prop.blob.cbSize = sizeof(activationParams);
+    prop.blob.pBlobData = reinterpret_cast<BYTE*>(&activationParams);
+
+    auto handler = Microsoft::WRL::Make<ActivationHandler>(done);
+    if (!handler) {
+        return Result::Fail(E_OUTOFMEMORY, "ApplicationLoopbackCaptureStream: handler allocation failed");
+    }
+
+    ComPtr<IActivateAudioInterfaceAsyncOperation> op;
+    HRESULT hr = ActivateAudioInterfaceAsync(VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK,
+                                             __uuidof(IAudioClient), &prop, handler.Get(),
+                                             op.GetAddressOf());
+    if (SUCCEEDED(hr)) {
+        DWORD wait = WaitForSingleObject(done->handle, 10000);
+        if (wait == WAIT_OBJECT_0) {
+            hr = handler->copyClientTo(client);
+        } else if (wait == WAIT_TIMEOUT) {
+            hr = HRESULT_FROM_WIN32(WAIT_TIMEOUT);
+        } else {
+            hr = HRESULT_FROM_WIN32(GetLastError());
+        }
+    }
+
+    if (FAILED(hr)) {
+        return HrToResult(hr,
+            "ApplicationLoopbackCaptureStream: ActivateAudioInterfaceAsync "
+            "(requires Windows 10 build 20348 or later)");
+    }
+    return Result::Ok();
+#else
+    (void)processId;
+    (void)client;
+    return Result::Fail(-1,
+        "ApplicationLoopbackCaptureStream: Application Loopback requires Windows SDK 10.0.20348+");
+#endif
+}
+
+} // namespace
+
+ApplicationLoopbackCaptureStream::ApplicationLoopbackCaptureStream(
+    WasapiMode mode, uint32_t processId, const AudioFormat* requested)
+    : mode_(mode), processId_(processId), hasRequested_(requested != nullptr) {
+    if (requested) requestedFormat_ = *requested;
+}
+
+AudioFormat defaultApplicationLoopbackFormat() {
+    return AudioFormat{44100, 2, 16, false};
+}
+
+Result initializeApplicationLoopbackClient(ComPtr<IAudioClient>& client, const AudioFormat& fmt,
+                                           DWORD flags, REFERENCE_TIME dur,
+                                           const char* where) {
+    WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(fmt);
+    HRESULT hr = client->Initialize(
+        AUDCLNT_SHAREMODE_SHARED,
+        flags | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+            AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+        dur, 0, reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
+    if (FAILED(hr)) return HrToResult(hr, where);
+    return Result::Ok();
+}
+
+ApplicationLoopbackCaptureStream::~ApplicationLoopbackCaptureStream() { close(); }
+
+Result ApplicationLoopbackCaptureStream::open(const DeviceId&, const AudioFormat&,
+                                              RingBuffer* ring, const StreamParams& params) {
+    if (mode_ == WasapiMode::Exclusive) {
+        return Result::Fail(-1, "WASAPI application loopback requires Shared mode");
+    }
+    if (processId_ == 0) {
+        return Result::Fail(-1, "ApplicationLoopbackCaptureStream: target PID is required");
+    }
+    if (!ring) {
+        return Result::Fail(-1, "ApplicationLoopbackCaptureStream: capture ring is required");
+    }
+    ring_ = ring;
+    params_ = params;
+    idleSilenceFrames_.store(0, std::memory_order_relaxed);
+    silentPacketFrames_.store(0, std::memory_order_relaxed);
+    return Result::Ok();
+}
+
+Result ApplicationLoopbackCaptureStream::start() {
+    if (running_.exchange(true)) return Result::Ok();
+    if (hEvent_) { CloseHandle(static_cast<HANDLE>(hEvent_)); hEvent_ = nullptr; }
+    if (pumpEvent_) { CloseHandle(static_cast<HANDLE>(pumpEvent_)); pumpEvent_ = nullptr; }
+
+    hEvent_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    pumpEvent_ = CreateEventW(nullptr, FALSE, FALSE, nullptr);
+    if (!hEvent_ || !pumpEvent_) {
+        close();
+        return Result::Fail(static_cast<long>(GetLastError()),
+                            "ApplicationLoopbackCaptureStream::start: CreateEventW failed");
+    }
+
+    { std::lock_guard<std::mutex> lk(readyMtx_); ready_ = false; startResult_ = Result::Ok(); }
+    try {
+        thread_ = std::thread(&ApplicationLoopbackCaptureStream::threadMain, this);
+    } catch (const std::system_error& e) {
+        close();
+        return Result::Fail(static_cast<long>(e.code().value()),
+                            "ApplicationLoopbackCaptureStream::start: failed to launch thread");
+    }
+
+    Result r;
+    {
+        std::unique_lock<std::mutex> lk(readyMtx_);
+        readyCv_.wait(lk, [this] { return ready_; });
+        r = startResult_;
+    }
+    if (!r) stop();
+    return r;
+}
+
+void ApplicationLoopbackCaptureStream::stop() {
+    running_.store(false);
+    if (hEvent_) SetEvent(static_cast<HANDLE>(hEvent_));
+    if (thread_.joinable()) thread_.join();
+}
+
+void ApplicationLoopbackCaptureStream::close() {
+    stop();
+    if (hEvent_) { CloseHandle(static_cast<HANDLE>(hEvent_)); hEvent_ = nullptr; }
+    if (pumpEvent_) { CloseHandle(static_cast<HANDLE>(pumpEvent_)); pumpEvent_ = nullptr; }
+    capture_.Reset();
+    client_.Reset();
+}
+
+BackendStats ApplicationLoopbackCaptureStream::stats() const {
+    BackendStats s{};
+    s.actualFormat = actualFormat_;
+    s.bufferFrames = bufferFrames_;
+    s.idleSilenceFrames = idleSilenceFrames_.load(std::memory_order_relaxed);
+    s.silentPacketFrames = silentPacketFrames_.load(std::memory_order_relaxed);
+    if (ring_) { s.overruns = ring_->overruns(); s.underruns = ring_->underruns(); }
+    return s;
+}
+
+void ApplicationLoopbackCaptureStream::signalReady(Result res) {
+    { std::lock_guard<std::mutex> lk(readyMtx_); startResult_ = res; ready_ = true; }
+    if (!res) running_.store(false);
+    readyCv_.notify_one();
+}
+
+Result ApplicationLoopbackCaptureStream::activateClient() {
+    return activateProcessLoopbackClient(processId_, client_);
+}
+
+Result ApplicationLoopbackCaptureStream::initializeClient() {
+    REFERENCE_TIME dur = params_.bufferMs
+        ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10000
+        : 1000000; // 100 ms
+    DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK;
+
+    if (hasRequested_) {
+        actualFormat_ = requestedFormat_;
+        frameBytes_ = actualFormat_.blockAlign();
+        return initializeApplicationLoopbackClient(client_, actualFormat_, flags, dur,
+            "ApplicationLoopbackCaptureStream: Initialize(requested)");
+    }
+
+    WAVEFORMATEX* mix = nullptr;
+    HRESULT hr = client_->GetMixFormat(&mix);
+    if (SUCCEEDED(hr) && mix) {
+        actualFormat_ = fromWaveFormat(mix);
+        frameBytes_ = actualFormat_.blockAlign();
+        hr = client_->Initialize(AUDCLNT_SHAREMODE_SHARED, flags, dur, 0, mix, nullptr);
+        CoTaskMemFree(mix);
+        if (SUCCEEDED(hr)) return Result::Ok();
+    }
+    if (mix) CoTaskMemFree(mix);
+
+    actualFormat_ = defaultApplicationLoopbackFormat();
+    frameBytes_ = actualFormat_.blockAlign();
+    return initializeApplicationLoopbackClient(client_, actualFormat_, flags, dur,
+        "ApplicationLoopbackCaptureStream: Initialize(fallback)");
+}
+
+Result ApplicationLoopbackCaptureStream::createService() {
+    HRESULT hr = client_->GetService(__uuidof(IAudioCaptureClient),
+                                     reinterpret_cast<void**>(capture_.GetAddressOf()));
+    if (FAILED(hr)) return HrToResult(hr, "ApplicationLoopbackCaptureStream: GetService");
+    return Result::Ok();
+}
+
+void ApplicationLoopbackCaptureStream::threadMain() {
+    ComInitGuard com;
+    WA_LOG(wa::log::Level::Info, "ApplicationLoopbackCaptureStream", "threadMain",
+           "worker thread started", "");
+    if (!com.ok()) {
+        signalReady(HrToResult(com.hr, "ApplicationLoopbackCaptureStream: CoInitializeEx"));
+        return;
+    }
+
+    if (Result r = activateClient(); !r) { signalReady(r); return; }
+    if (Result r = initializeClient(); !r) { signalReady(r); return; }
+
+    HRESULT hr = client_->GetBufferSize(&bufferFrames_);
+    if (FAILED(hr)) {
+        signalReady(HrToResult(hr, "ApplicationLoopbackCaptureStream: GetBufferSize"));
+        return;
+    }
+    hr = client_->SetEventHandle(static_cast<HANDLE>(hEvent_));
+    if (FAILED(hr)) {
+        signalReady(HrToResult(hr, "ApplicationLoopbackCaptureStream: SetEventHandle"));
+        return;
+    }
+    if (Result r = createService(); !r) { signalReady(r); return; }
+
+    hr = client_->Start();
+    if (FAILED(hr)) {
+        signalReady(HrToResult(hr, "ApplicationLoopbackCaptureStream: Start"));
+        return;
+    }
+
+    WA_LOG(wa::log::Level::Info, "ApplicationLoopbackCaptureStream", "Start",
+           "pid=" + std::to_string(processId_) + " fmt=" + wa::formatAudio(actualFormat_),
+           "ok");
+    signalReady(Result::Ok());
+    runLoop();
+
+    HRESULT hrStop = client_->Stop();
+    WA_LOG(FAILED(hrStop) ? wa::log::Level::Err : wa::log::Level::Debug,
+           "ApplicationLoopbackCaptureStream", "Stop", "", wa::log::hrName(hrStop));
+}
+
+void ApplicationLoopbackCaptureStream::runLoop() {
+    wa::log::setThreadName("appL");
+    constexpr DWORD kCaptureWaitMs = 200;
+    ULONGLONG lastWriteMs = GetTickCount64();
+    while (running_.load()) {
+        DWORD waitRc = WaitForSingleObject(static_cast<HANDLE>(hEvent_), kCaptureWaitMs);
+        bool wroteFrames = false;
+        bool sawPacket = false;
+        UINT32 packet = 0;
+        HRESULT hrNP = S_OK;
+        while (hrNP = capture_->GetNextPacketSize(&packet),
+               SUCCEEDED(hrNP) && packet > 0) {
+            sawPacket = true;
+            BYTE* data = nullptr;
+            UINT32 frames = 0;
+            DWORD flags = 0;
+            HRESULT hrGB = capture_->GetBuffer(&data, &frames, &flags, nullptr, nullptr);
+            if (FAILED(hrGB)) break;
+            const size_t bytes = static_cast<size_t>(frames) * frameBytes_;
+            if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
+                static thread_local std::vector<uint8_t> zeros;
+                zeros.assign(bytes, 0);
+                ring_->write(zeros.data(), bytes);
+                silentPacketFrames_.fetch_add(captureSilentPacketFrames(frames, flags),
+                                              std::memory_order_relaxed);
+                wroteFrames = true;
+                lastWriteMs = GetTickCount64();
+                if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
+            } else if (data) {
+                ring_->write(data, bytes);
+                wroteFrames = true;
+                lastWriteMs = GetTickCount64();
+                if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
+            }
+            capture_->ReleaseBuffer(frames);
+        }
+
+        if (shouldWriteLoopbackIdleSilence(waitRc, static_cast<long>(hrNP), sawPacket,
+                                           wroteFrames)) {
+            const ULONGLONG nowMs = GetTickCount64();
+            const uint32_t elapsedMs = static_cast<uint32_t>(
+                nowMs - lastWriteMs < kCaptureWaitMs ? nowMs - lastWriteMs : kCaptureWaitMs);
+            const uint32_t frames = loopbackSilenceFramesForTimeout(actualFormat_.sampleRate,
+                                                                    elapsedMs);
+            if (frames > 0 && frameBytes_ > 0) {
+                static thread_local std::vector<uint8_t> zeros;
+                zeros.assign(static_cast<size_t>(frames) * frameBytes_, 0);
+                ring_->write(zeros.data(), zeros.size());
+                idleSilenceFrames_.fetch_add(frames, std::memory_order_relaxed);
+                lastWriteMs = nowMs;
+                if (pumpEvent_) SetEvent(static_cast<HANDLE>(pumpEvent_));
+            }
+        }
+    }
+}
+
+} // namespace wa

--- a/src/core/ApplicationLoopbackCapture.h
+++ b/src/core/ApplicationLoopbackCapture.h
@@ -1,0 +1,72 @@
+#pragma once
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <audioclient.h>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "ComUtil.h"
+#include "IAudioBackend.h"
+#include "WasapiStream.h"
+
+namespace wa {
+
+AudioFormat defaultApplicationLoopbackFormat();
+
+class ApplicationLoopbackCaptureStream : public IAudioBackend {
+public:
+    ApplicationLoopbackCaptureStream(WasapiMode mode, uint32_t processId,
+                                     const AudioFormat* requested);
+    ~ApplicationLoopbackCaptureStream() override;
+
+    Result open(const DeviceId& id, const AudioFormat& fmt, RingBuffer* ring,
+                const StreamParams& params) override;
+    Result start() override;
+    void   stop() override;
+    void   close() override;
+    BackendStats stats() const override;
+    void* dataReadyEvent() const override { return pumpEvent_; }
+
+private:
+    void threadMain();
+    void signalReady(Result res);
+    Result activateClient();
+    Result initializeClient();
+    Result createService();
+    void runLoop();
+
+    WasapiMode mode_;
+    uint32_t processId_ = 0;
+    bool hasRequested_ = false;
+    AudioFormat requestedFormat_{};
+    StreamParams params_{};
+    RingBuffer* ring_ = nullptr;
+
+    ComPtr<IAudioClient> client_;
+    ComPtr<IAudioCaptureClient> capture_;
+    AudioFormat actualFormat_{};
+    uint32_t bufferFrames_ = 0;
+    uint32_t frameBytes_ = 0;
+
+    std::atomic<bool> running_{false};
+    std::atomic<uint64_t> idleSilenceFrames_{0};
+    std::atomic<uint64_t> silentPacketFrames_{0};
+    void* hEvent_ = nullptr;
+    void* pumpEvent_ = nullptr;
+    std::thread thread_;
+
+    std::mutex readyMtx_;
+    std::condition_variable readyCv_;
+    bool ready_ = false;
+    Result startResult_ = Result::Ok();
+};
+
+} // namespace wa

--- a/src/core/AudioSessionEnumerator.cpp
+++ b/src/core/AudioSessionEnumerator.cpp
@@ -1,0 +1,157 @@
+#include "AudioSessionEnumerator.h"
+#include <algorithm>
+#include <cwchar>
+#include <mmdeviceapi.h>
+#include <audiopolicy.h>
+#include "ComUtil.h"
+#include "DeviceEnumerator.h"
+
+namespace wa {
+namespace {
+
+std::wstring basenameOfPath(const std::wstring& path) {
+    const size_t pos = path.find_last_of(L"\\/");
+    return (pos == std::wstring::npos) ? path : path.substr(pos + 1);
+}
+
+std::wstring processNameFromPid(uint32_t pid) {
+    HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!h) return L"pid-" + std::to_wstring(pid);
+
+    wchar_t path[MAX_PATH] = {};
+    DWORD n = static_cast<DWORD>(std::size(path));
+    std::wstring name;
+    if (QueryFullProcessImageNameW(h, 0, path, &n) && n > 0) {
+        name = basenameOfPath(std::wstring(path, n));
+    }
+    CloseHandle(h);
+    return name.empty() ? (L"pid-" + std::to_wstring(pid)) : name;
+}
+
+Result openRenderDevice(const DeviceId& id, ComPtr<IMMDevice>& dev) {
+    ComPtr<IMMDeviceEnumerator> e;
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                  __uuidof(IMMDeviceEnumerator),
+                                  reinterpret_cast<void**>(e.GetAddressOf()));
+    if (FAILED(hr)) return HrToResult(hr, "CoCreateInstance(MMDeviceEnumerator)");
+
+    hr = e->GetDevice(id.c_str(), dev.GetAddressOf());
+    if (FAILED(hr)) return HrToResult(hr, "IMMDeviceEnumerator::GetDevice");
+    return Result::Ok();
+}
+
+bool processNameLess(const AudioSessionProcess& a, const AudioSessionProcess& b) {
+    int cmp = _wcsicmp(a.processName.c_str(), b.processName.c_str());
+    if (cmp != 0) return cmp < 0;
+    if (a.processName != b.processName) return a.processName < b.processName;
+    return a.processId < b.processId;
+}
+
+} // namespace
+
+void sortAndDedupeAudioSessionProcesses(std::vector<AudioSessionProcess>& rows) {
+    rows.erase(std::remove_if(rows.begin(), rows.end(),
+                              [](const AudioSessionProcess& row) {
+                                  return row.processId == 0;
+                              }),
+               rows.end());
+
+    std::sort(rows.begin(), rows.end(),
+              [](const AudioSessionProcess& a, const AudioSessionProcess& b) {
+                  if (a.processId != b.processId) return a.processId < b.processId;
+                  return processNameLess(a, b);
+              });
+    rows.erase(std::unique(rows.begin(), rows.end(),
+                           [](const AudioSessionProcess& a, const AudioSessionProcess& b) {
+                               return a.processId == b.processId;
+                           }),
+               rows.end());
+
+    std::sort(rows.begin(), rows.end(), processNameLess);
+}
+
+bool parseApplicationLoopbackPid(const char* text, uint32_t& pidOut) {
+    if (!text) return false;
+    while (*text == ' ' || *text == '\t') ++text;
+    if (*text < '0' || *text > '9') return false;
+
+    unsigned long long value = 0;
+    while (*text >= '0' && *text <= '9') {
+        value = value * 10ull + static_cast<unsigned long long>(*text - '0');
+        if (value > static_cast<unsigned long long>(UINT32_MAX))
+            return false;
+        ++text;
+    }
+    while (*text == ' ' || *text == '\t') ++text;
+    if (*text != '\0' || value == 0) {
+        return false;
+    }
+    pidOut = static_cast<uint32_t>(value);
+    return true;
+}
+
+Result AudioSessionEnumerator::enumerate(std::vector<AudioSessionProcess>& out) {
+    out.clear();
+
+    ComInitGuard com;
+    if (!com.ok()) return HrToResult(com.hr, "AudioSessionEnumerator: CoInitializeEx");
+
+    DeviceEnumerator devices;
+    std::vector<DeviceInfo> renderDevices;
+    Result r = devices.enumerate(DataFlow::Render, renderDevices);
+    if (!r) return r;
+
+    Result lastFailure = Result::Ok();
+    bool sawSuccessfulGetCount = false;
+    for (const auto& info : renderDevices) {
+        ComPtr<IMMDevice> dev;
+        r = openRenderDevice(info.id, dev);
+        if (!r) { lastFailure = r; continue; }
+
+        ComPtr<IAudioSessionManager2> manager;
+        HRESULT hr = dev->Activate(__uuidof(IAudioSessionManager2), CLSCTX_ALL, nullptr,
+                                   reinterpret_cast<void**>(manager.GetAddressOf()));
+        if (FAILED(hr)) {
+            lastFailure = HrToResult(hr, "AudioSessionEnumerator: Activate(IAudioSessionManager2)");
+            continue;
+        }
+
+        ComPtr<IAudioSessionEnumerator> sessions;
+        hr = manager->GetSessionEnumerator(sessions.GetAddressOf());
+        if (FAILED(hr)) {
+            lastFailure = HrToResult(hr, "AudioSessionEnumerator: GetSessionEnumerator");
+            continue;
+        }
+        int count = 0;
+        hr = sessions->GetCount(&count);
+        if (FAILED(hr)) {
+            lastFailure = HrToResult(hr, "AudioSessionEnumerator: GetCount");
+            continue;
+        }
+        sawSuccessfulGetCount = true;
+
+        for (int i = 0; i < count; ++i) {
+            ComPtr<IAudioSessionControl> control;
+            hr = sessions->GetSession(i, control.GetAddressOf());
+            if (FAILED(hr) || !control) continue;
+
+            ComPtr<IAudioSessionControl2> control2;
+            hr = control.As(&control2);
+            if (FAILED(hr) || !control2) continue;
+
+            DWORD pid = 0;
+            hr = control2->GetProcessId(&pid);
+            if (FAILED(hr) || pid == 0) continue;
+
+            out.push_back(AudioSessionProcess{static_cast<uint32_t>(pid),
+                                              processNameFromPid(static_cast<uint32_t>(pid))});
+        }
+    }
+
+    sortAndDedupeAudioSessionProcesses(out);
+    if (!sawSuccessfulGetCount && !renderDevices.empty() && !lastFailure)
+        return lastFailure;
+    return Result::Ok();
+}
+
+} // namespace wa

--- a/src/core/AudioSessionEnumerator.h
+++ b/src/core/AudioSessionEnumerator.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "Result.h"
+
+namespace wa {
+
+struct AudioSessionProcess {
+    uint32_t processId = 0;
+    std::wstring processName;
+};
+
+void sortAndDedupeAudioSessionProcesses(std::vector<AudioSessionProcess>& rows);
+bool parseApplicationLoopbackPid(const char* text, uint32_t& pidOut);
+
+class AudioSessionEnumerator {
+public:
+    Result enumerate(std::vector<AudioSessionProcess>& out);
+};
+
+} // namespace wa

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(WinAudioCore STATIC
     RingBuffer.cpp
     SampleConvert.cpp
     WavFile.cpp
+    AudioSessionEnumerator.cpp
+    ApplicationLoopbackCapture.cpp
     DeviceEnumerator.cpp
     WasapiStream.cpp
     Engine.cpp
@@ -14,5 +16,5 @@ add_library(WinAudioCore STATIC
     Log.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 spdlog)
+target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi spdlog)
 wa_set_project_warnings(WinAudioCore)

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -15,11 +15,13 @@ using DeviceId = std::wstring;     // MMDevice id; empty string = default endpoi
 enum class CaptureSourceKind {
     Endpoint,
     SystemLoopback,
+    ApplicationLoopback,
 };
 
 struct CaptureSource {
     CaptureSourceKind kind = CaptureSourceKind::Endpoint;
     DeviceId deviceId; // Endpoint: capture endpoint; SystemLoopback: render endpoint
+    uint32_t processId = 0; // ApplicationLoopback target PID
 };
 
 struct LoopbackOptions {

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -11,6 +11,7 @@
 #define NOMINMAX
 #endif
 #include "MonitorEngine.h"
+#include "ApplicationLoopbackCapture.h"
 #include "ComUtil.h"
 #include "DelayFifo.h"
 #include "DeviceEnumerator.h"
@@ -76,6 +77,9 @@ std::unique_ptr<IAudioBackend> MonitorEngine::makeBackend(DataFlow flow, Backend
     if (flow == DataFlow::Capture) {
         if (source && source->kind == CaptureSourceKind::SystemLoopback)
             return std::make_unique<WasapiSystemLoopbackCaptureStream>(mode, requested);
+        if (source && source->kind == CaptureSourceKind::ApplicationLoopback)
+            return std::make_unique<ApplicationLoopbackCaptureStream>(mode, source->processId,
+                                                                      requested);
         return std::make_unique<WasapiCaptureStream>(mode, requested);
     }
     return std::make_unique<WasapiRenderStream>(mode, requested);
@@ -194,7 +198,9 @@ Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
 
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "start",
            "cap=" + wa::narrowAscii(capSource.deviceId) +
-           " source=" + std::string(capSource.kind == CaptureSourceKind::SystemLoopback ? "loopback" : "endpoint") +
+           " source=" + std::string(capSource.kind == CaptureSourceKind::SystemLoopback ? "loopback" :
+                                    capSource.kind == CaptureSourceKind::ApplicationLoopback ? "application-loopback" :
+                                    "endpoint") +
            " ren=" + wa::narrowAscii(renderId) +
            " delay=" + std::to_string(delayMs) + "ms" +
            " playback=" + (playbackEnabled ? "1" : "0"), "");

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -1,4 +1,6 @@
 #include "AppUi.h"
+#include "ApplicationLoopbackUiModel.h"
+#include "AppUiText.h"
 #include "ComUtil.h"
 #include "imgui.h"
 #include "implot.h"
@@ -87,8 +89,90 @@ void AppUi::refreshMonitorDevices() {
 }
 
 void AppUi::stopAll() {
+    if (appLoopbackStartPending_) {
+        if (appLoopbackStartThread_.joinable())
+            appLoopbackStartThread_.detach();
+        appLoopbackStartPending_ = false;
+        appLoopbackStartJob_.reset();
+    } else if (appLoopbackStartThread_.joinable()) {
+        appLoopbackStartThread_.join();
+    }
     monitor_.stop();
     loopback_.stop();
+    if (appLoopback_) appLoopback_->stop();
+}
+
+void AppUi::refreshApplicationLoopbackSessions() {
+    std::vector<wa::AudioSessionProcess> rows;
+    wa::Result r = sessionEnumerator_.enumerate(rows);
+    if (!r) {
+        wa::app_loopback_ui::applyRefreshResult(false, appLoopbackSessions_,
+                                                appLoopbackSessionsLoaded_,
+                                                appLoopbackSessionIdx_, {});
+        logLines_.push_back("application loopback refresh failed: " + r.message);
+        return;
+    }
+    wa::app_loopback_ui::applyRefreshResult(true, appLoopbackSessions_,
+                                            appLoopbackSessionsLoaded_,
+                                            appLoopbackSessionIdx_,
+                                            std::move(rows));
+}
+
+void AppUi::beginApplicationLoopbackStart(uint32_t pid) {
+    if (appLoopbackStartThread_.joinable())
+        appLoopbackStartThread_.join();
+
+    auto job = std::make_shared<AppLoopbackStartJob>();
+    appLoopbackStartJob_ = job;
+    appLoopbackStartPending_ = true;
+
+    appLoopbackStartThread_ = std::thread([job, pid] {
+        auto engine = std::make_unique<wa::MonitorEngine>();
+        wa::CaptureSource source{wa::CaptureSourceKind::ApplicationLoopback, L"", pid};
+        wa::Result r = engine->start(wa::BackendKind::WasapiShared, source, L"", 0,
+                                     false, {}, {}, nullptr, {});
+        std::lock_guard<std::mutex> lk(job->mtx);
+        job->result = std::move(r);
+        if (job->result)
+            job->engine = std::move(engine);
+        job->done = true;
+    });
+}
+
+void AppUi::drainApplicationLoopbackStart() {
+    if (!appLoopbackStartPending_ || !appLoopbackStartJob_)
+        return;
+
+    auto job = appLoopbackStartJob_;
+    wa::Result result = wa::Result::Ok();
+    std::unique_ptr<wa::MonitorEngine> startedEngine;
+    {
+        std::lock_guard<std::mutex> lk(job->mtx);
+        if (!job->done)
+            return;
+        result = job->result;
+        if (result)
+            startedEngine = std::move(job->engine);
+    }
+
+    if (appLoopbackStartThread_.joinable())
+        appLoopbackStartThread_.join();
+    appLoopbackStartPending_ = false;
+    appLoopbackStartJob_.reset();
+
+    if (result && startedEngine) {
+        if (appLoopback_)
+            appLoopback_->stop();
+        appLoopback_ = std::move(startedEngine);
+        appLoopbackStarted_ = true;
+        resetVisuals(appLoopbackViz_);
+        logLines_.push_back("application loopback started");
+    } else {
+        appLoopbackStarted_ = false;
+        logLines_.push_back("application loopback error: " +
+                            (result ? std::string("start completed without engine")
+                                    : result.message));
+    }
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -258,8 +342,11 @@ void AppUi::draw() {
                         logLines_.begin() + (logLines_.size() - kMaxLogLines));
 
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
+    drainApplicationLoopbackStart();
     ms_ = monitor_.poll();
     loopbackMs_ = loopback_.poll();
+    if (!appLoopbackStartPending_ && appLoopback_)
+        appLoopbackMs_ = appLoopback_->poll();
     const int curRenderState = (int)ms_.renderState;
     if (prevRenderState_ == (int)wa::StreamState::Running &&
         curRenderState  != (int)wa::StreamState::Running) {
@@ -277,6 +364,10 @@ void AppUi::draw() {
         }
         if (ImGui::BeginTabItem("Loopback")) {
             drawLoopbackPage();
+            ImGui::EndTabItem();
+        }
+        if (ImGui::BeginTabItem(wa::ui_text::kApplicationLoopbackTab)) {
+            drawApplicationLoopbackPage();
             ImGui::EndTabItem();
         }
         ImGui::EndTabBar();
@@ -352,6 +443,52 @@ void AppUi::drawLoopbackPage() {
     ImGui::EndChild();
 }
 
+void AppUi::drawApplicationLoopbackPage() {
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("appLoopbackTop", ImVec2(0, topHeight), false);
+    ImGui::BeginChild("appLoopbackLeft", ImVec2(340, 0), true);
+    drawApplicationLoopbackLeftPanel();
+    ImGui::EndChild();
+
+    ImGui::SameLine();
+
+    ImGui::BeginChild("appLoopbackCharts", ImVec2(0, 0), true);
+    const uint32_t sr = appLoopbackMs_.sampleRate;
+    const bool overallRunning = (appLoopbackMs_.overall == wa::StreamState::Running && sr > 0);
+    const uint32_t hz = (sr > 0) ? sr : 48000u;
+    if (appLoopbackViz_.xLink1 <= 0.0)
+        appLoopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)hz;
+    if (overallRunning) {
+        if (sr != appLoopbackViz_.waveSr) {
+            appLoopbackViz_.waveSr = sr;
+            appLoopbackViz_.waveN = (int)(kSpecCols * kFftHop);
+            appLoopbackViz_.capWave.assign((size_t)appLoopbackViz_.waveN, 0.f);
+            appLoopbackViz_.xLink0 = 0.0;
+            appLoopbackViz_.xLink1 = (double)(kSpecCols * kFftHop) / (double)sr;
+        }
+        if (sr != appLoopbackViz_.specSr) {
+            appLoopbackViz_.specSr = sr;
+            appLoopbackViz_.workCap.resize(kFftWin);
+            appLoopbackViz_.specWin.resize(kFftWin);
+            appLoopbackViz_.capSpec = std::make_unique<wa::Spectrogram>(
+                kSpecRows, kSpecCols, 20.0, (double)sr / 2.0, sr);
+        }
+    }
+    ImGui::TextUnformatted("Application audio waveform + spectrogram");
+    if (appLoopback_)
+        drawChartPanel(0, *appLoopback_, appLoopbackMs_, appLoopbackViz_);
+    ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("appLoopbackLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("appLoopbackLog", false);
+    ImGui::EndChild();
+}
+
 void AppUi::drawLoopbackLeftPanel() {
     if (!monitorDevicesLoaded_) refreshMonitorDevices();
 
@@ -418,6 +555,75 @@ void AppUi::drawLoopbackLeftPanel() {
         ss[(int)loopbackMs_.silentRenderState]);
     ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
 
+}
+
+void AppUi::drawApplicationLoopbackLeftPanel() {
+    if (!appLoopbackSessionsLoaded_)
+        refreshApplicationLoopbackSessions();
+
+    ImGui::SeparatorText(wa::ui_text::kApplicationLoopbackSessions);
+    if (ImGui::Button(wa::ui_text::kApplicationLoopbackRefresh))
+        refreshApplicationLoopbackSessions();
+
+    ImGui::BeginChild("appLoopbackSessionList", ImVec2(0, 170.0f), true);
+    if (appLoopbackSessions_.empty()) {
+        ImGui::TextUnformatted("(none)");
+    } else {
+        for (int i = 0; i < (int)appLoopbackSessions_.size(); ++i) {
+            const auto& row = appLoopbackSessions_[(size_t)i];
+            std::string label = wtou(row.processName) + "  " + std::to_string(row.processId) +
+                                "##appLoopbackSession" + std::to_string(i);
+            if (ImGui::Selectable(label.c_str(), appLoopbackSessionIdx_ == i)) {
+                appLoopbackSessionIdx_ = i;
+                wa::app_loopback_ui::copySessionPidToBuffer(appLoopbackSessions_, i,
+                                                            appLoopbackPid_,
+                                                            sizeof(appLoopbackPid_));
+            }
+        }
+    }
+    ImGui::EndChild();
+
+    ImGui::SeparatorText("Control");
+    ImGui::SetNextItemWidth(-1);
+    ImGui::InputText(wa::ui_text::kApplicationLoopbackPidLabel,
+                     appLoopbackPid_, sizeof(appLoopbackPid_));
+
+    const ImVec2 ctrlBtn(120.0f, ImGui::GetFrameHeight() * 1.3f);
+    bool startPending = appLoopbackStartPending_;
+    if (startPending) {
+        ImGui::BeginDisabled();
+        ImGui::Button("Starting...", ctrlBtn);
+        ImGui::EndDisabled();
+    } else if (!appLoopbackStarted_) {
+        if (ImGui::Button("Start", ctrlBtn)) {
+            uint32_t pid = 0;
+            if (!wa::parseApplicationLoopbackPid(appLoopbackPid_, pid)) {
+                logLines_.push_back("application loopback error: invalid PID");
+            } else {
+                logLines_.push_back("application loopback starting");
+                beginApplicationLoopbackStart(pid);
+            }
+        }
+    } else {
+        if (ImGui::Button("Stop", ctrlBtn)) {
+            if (appLoopback_) appLoopback_->stop();
+            appLoopbackStarted_ = false;
+            resetVisuals(appLoopbackViz_);
+            logLines_.push_back("application loopback stopped");
+        }
+    }
+
+    ImGui::SeparatorText("Status");
+    const char* ss[] = {"Idle", "Running", "Error"};
+    ImGui::Text("overall=%s  cap=%s  sr=%u",
+        ss[(int)appLoopbackMs_.overall], ss[(int)appLoopbackMs_.capState],
+        appLoopbackMs_.sampleRate);
+    ImGui::Text("xrun=%llu", (unsigned long long)appLoopbackMs_.capXruns);
+    ImGui::Text("frames=%llu", (unsigned long long)appLoopbackMs_.capWrittenFrames);
+    ImGui::Text("silent-packet=%llu  idle-fill=%llu",
+        (unsigned long long)appLoopbackMs_.loopbackSilentPacketFrames,
+        (unsigned long long)appLoopbackMs_.loopbackIdleSilenceFrames);
+    ImGui::ProgressBar(appLoopbackMs_.capLevel, ImVec2(-1, 0), "level");
 }
 
 void AppUi::drawLeftPanel() {

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -3,7 +3,9 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
+#include "AudioSessionEnumerator.h"
 #include "DeviceEnumerator.h"
 #include "MonitorEngine.h"
 #include "Spectrogram.h"
@@ -14,6 +16,13 @@ public:
     void stopAll();       // stop engines on shutdown (idempotent)
     void pushLog(int level, const std::string& line);  // thread-safe; called from the logging pump thread
 private:
+    struct AppLoopbackStartJob {
+        std::mutex mtx;
+        bool done = false;
+        wa::Result result = wa::Result::Ok();
+        std::unique_ptr<wa::MonitorEngine> engine;
+    };
+
     struct VisualState {
         std::vector<float> capWave, renderWave;
         uint32_t waveSr = 0;
@@ -34,9 +43,14 @@ private:
     };
 
     void refreshMonitorDevices();
+    void refreshApplicationLoopbackSessions();
+    void beginApplicationLoopbackStart(uint32_t pid);
+    void drainApplicationLoopbackStart();
     void drawMonitorPage();
     void drawLoopbackPage();
+    void drawApplicationLoopbackPage();
     void drawLoopbackLeftPanel();
+    void drawApplicationLoopbackLeftPanel();
     void drawLeftPanel();
     void drawAdvancedModal();
     void drawCapsModal();
@@ -54,9 +68,12 @@ private:
 
     wa::MonitorEngine    monitor_;
     wa::MonitorEngine    loopback_;
+    std::unique_ptr<wa::MonitorEngine> appLoopback_ = std::make_unique<wa::MonitorEngine>();
     wa::DeviceEnumerator enumerator_;
+    wa::AudioSessionEnumerator sessionEnumerator_;
     wa::MonitorStatus    ms_;   // polled once per frame in draw(); shared by helper methods
     wa::MonitorStatus    loopbackMs_;
+    wa::MonitorStatus    appLoopbackMs_;
 
     int  backendIdx_      = 0;
     bool playbackEnabled_ = false;
@@ -78,6 +95,14 @@ private:
     bool                        monitorStarted_ = false;
     bool                        loopbackStarted_ = false;
     bool                        loopbackSilentRender_ = true;
+    bool                        appLoopbackStarted_ = false;
+    bool                        appLoopbackStartPending_ = false;
+    bool                        appLoopbackSessionsLoaded_ = false;
+    std::vector<wa::AudioSessionProcess> appLoopbackSessions_;
+    int                         appLoopbackSessionIdx_ = -1;
+    char                        appLoopbackPid_[32] = "";
+    std::thread                 appLoopbackStartThread_;
+    std::shared_ptr<AppLoopbackStartJob> appLoopbackStartJob_;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};
@@ -93,4 +118,5 @@ private:
 
     VisualState monitorViz_;
     VisualState loopbackViz_;
+    VisualState appLoopbackViz_;
 };

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace wa::ui_text {
+
+inline constexpr const char* kApplicationLoopbackTab = "Application Loopback";
+inline constexpr const char* kApplicationLoopbackRefresh = "Refresh";
+inline constexpr const char* kApplicationLoopbackPidLabel = "PID";
+inline constexpr const char* kApplicationLoopbackSessions = "Sessions";
+
+} // namespace wa::ui_text

--- a/src/gui/ApplicationLoopbackUiModel.h
+++ b/src/gui/ApplicationLoopbackUiModel.h
@@ -1,0 +1,32 @@
+#pragma once
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+#include "AudioSessionEnumerator.h"
+
+namespace wa::app_loopback_ui {
+
+inline bool copySessionPidToBuffer(const std::vector<AudioSessionProcess>& rows,
+                                   int index, char* dst, size_t dstSize) {
+    if (!dst || dstSize == 0 || index < 0 || index >= static_cast<int>(rows.size()))
+        return false;
+    std::snprintf(dst, dstSize, "%u", rows[static_cast<size_t>(index)].processId);
+    return true;
+}
+
+inline void applyRefreshResult(bool ok, std::vector<AudioSessionProcess>& target,
+                               bool& loaded, int& selectedIndex,
+                               std::vector<AudioSessionProcess>&& rows) {
+    loaded = true;
+    if (!ok) {
+        target.clear();
+        selectedIndex = -1;
+        return;
+    }
+    target = std::move(rows);
+    if (selectedIndex >= static_cast<int>(target.size()))
+        selectedIndex = -1;
+}
+
+} // namespace wa::app_loopback_ui

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(WinAudioTests
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp
+    test_audio_session_enumerator.cpp
     test_cli_options.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
 )

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "AudioSessionEnumerator.h"
+#include "ApplicationLoopbackUiModel.h"
+#include "AppUiText.h"
+
+using namespace wa;
+
+TEST(AudioSessionEnumerator, SortsByProcessNameThenPid) {
+    std::vector<AudioSessionProcess> rows = {
+        {300u, L"zoom.exe"},
+        {200u, L"chrome.exe"},
+        {100u, L"chrome.exe"},
+    };
+
+    sortAndDedupeAudioSessionProcesses(rows);
+
+    ASSERT_EQ(rows.size(), 3u);
+    EXPECT_EQ(rows[0].processName, L"chrome.exe");
+    EXPECT_EQ(rows[0].processId, 100u);
+    EXPECT_EQ(rows[1].processName, L"chrome.exe");
+    EXPECT_EQ(rows[1].processId, 200u);
+    EXPECT_EQ(rows[2].processName, L"zoom.exe");
+    EXPECT_EQ(rows[2].processId, 300u);
+}
+
+TEST(AudioSessionEnumerator, DeduplicatesByPid) {
+    std::vector<AudioSessionProcess> rows = {
+        {200u, L"chrome.exe"},
+        {100u, L"msedge.exe"},
+        {200u, L"chrome.exe"},
+        {100u, L"msedge.exe"},
+    };
+
+    sortAndDedupeAudioSessionProcesses(rows);
+
+    ASSERT_EQ(rows.size(), 2u);
+    EXPECT_EQ(rows[0].processName, L"chrome.exe");
+    EXPECT_EQ(rows[0].processId, 200u);
+    EXPECT_EQ(rows[1].processName, L"msedge.exe");
+    EXPECT_EQ(rows[1].processId, 100u);
+}
+
+TEST(AppLoopbackPid, ParseAcceptsManualPid) {
+    uint32_t pid = 0;
+    EXPECT_TRUE(parseApplicationLoopbackPid("4242", pid));
+    EXPECT_EQ(pid, 4242u);
+}
+
+TEST(AppLoopbackPid, ParseRejectsZeroAndGarbage) {
+    uint32_t pid = 123u;
+
+    EXPECT_FALSE(parseApplicationLoopbackPid("0", pid));
+    EXPECT_EQ(pid, 123u);
+    EXPECT_FALSE(parseApplicationLoopbackPid("abc", pid));
+    EXPECT_EQ(pid, 123u);
+    EXPECT_FALSE(parseApplicationLoopbackPid("42x", pid));
+    EXPECT_EQ(pid, 123u);
+    EXPECT_FALSE(parseApplicationLoopbackPid("-1", pid));
+    EXPECT_EQ(pid, 123u);
+    EXPECT_FALSE(parseApplicationLoopbackPid("+1", pid));
+    EXPECT_EQ(pid, 123u);
+}
+
+TEST(AppLoopbackUiText, ExposesRequiredControls) {
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackTab, "Application Loopback");
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackRefresh, "Refresh");
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackPidLabel, "PID");
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackSessions, "Sessions");
+}
+
+TEST(AppLoopbackUiModel, SelectingRowCopiesPidIntoEditableBuffer) {
+    std::vector<AudioSessionProcess> rows = {
+        {111u, L"one.exe"},
+        {222u, L"two.exe"},
+    };
+    char pid[16] = "999";
+
+    EXPECT_TRUE(wa::app_loopback_ui::copySessionPidToBuffer(rows, 1, pid, sizeof(pid)));
+
+    EXPECT_STREQ(pid, "222");
+}
+
+TEST(AppLoopbackUiModel, InvalidSelectionDoesNotOverwriteManualPid) {
+    std::vector<AudioSessionProcess> rows = {{111u, L"one.exe"}};
+    char pid[16] = "999";
+
+    EXPECT_FALSE(wa::app_loopback_ui::copySessionPidToBuffer(rows, 3, pid, sizeof(pid)));
+
+    EXPECT_STREQ(pid, "999");
+}
+
+TEST(AppLoopbackUiModel, RefreshFailureStillMarksLoaded) {
+    std::vector<AudioSessionProcess> rows = {{111u, L"one.exe"}};
+    std::vector<AudioSessionProcess> refreshed = {{222u, L"two.exe"}};
+    bool loaded = false;
+    int selected = 0;
+
+    wa::app_loopback_ui::applyRefreshResult(false, rows, loaded, selected,
+                                            std::move(refreshed));
+
+    EXPECT_TRUE(loaded);
+    EXPECT_TRUE(rows.empty());
+    EXPECT_EQ(selected, -1);
+}

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <string>
+#include "ApplicationLoopbackCapture.h"
 #include "IAudioBackend.h"
 #include "RingBuffer.h"
 #include "WasapiStream.h"
@@ -17,6 +18,13 @@ TEST(CaptureSource, CanRepresentSystemLoopbackRenderDevice) {
     CaptureSource source{CaptureSourceKind::SystemLoopback, L"render-device-id"};
     EXPECT_EQ(source.kind, CaptureSourceKind::SystemLoopback);
     EXPECT_EQ(source.deviceId, L"render-device-id");
+}
+
+TEST(CaptureSource, CanRepresentApplicationLoopbackProcess) {
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 4242u};
+    EXPECT_EQ(source.kind, CaptureSourceKind::ApplicationLoopback);
+    EXPECT_TRUE(source.deviceId.empty());
+    EXPECT_EQ(source.processId, 4242u);
 }
 
 TEST(WasapiSystemLoopbackCaptureStream, RejectsExclusiveInOpen) {
@@ -65,4 +73,43 @@ TEST(WasapiSilentRenderStream, RejectsExclusiveInOpen) {
     EXPECT_FALSE(static_cast<bool>(r));
     EXPECT_NE(r.message.find("silent render"), std::string::npos);
     EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}
+
+TEST(ApplicationLoopbackCaptureStream, RejectsExclusiveInOpen) {
+    RingBuffer ring(4096);
+    ApplicationLoopbackCaptureStream stream(WasapiMode::Exclusive, 4242u, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, &ring, StreamParams{});
+
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_NE(r.message.find("application loopback"), std::string::npos);
+    EXPECT_NE(r.message.find("Shared"), std::string::npos);
+}
+
+TEST(ApplicationLoopbackCaptureStream, RejectsZeroPid) {
+    RingBuffer ring(4096);
+    ApplicationLoopbackCaptureStream stream(WasapiMode::Shared, 0u, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, &ring, StreamParams{});
+
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_NE(r.message.find("PID"), std::string::npos);
+}
+
+TEST(ApplicationLoopbackCaptureStream, AcceptsSharedOpenWithValidPid) {
+    RingBuffer ring(4096);
+    ApplicationLoopbackCaptureStream stream(WasapiMode::Shared, 4242u, nullptr);
+
+    Result r = stream.open(L"", AudioFormat{}, &ring, StreamParams{});
+
+    EXPECT_TRUE(static_cast<bool>(r));
+}
+
+TEST(ApplicationLoopbackCaptureStream, DefaultFormatMatchesProcessLoopbackSampleFallback) {
+    AudioFormat fmt = defaultApplicationLoopbackFormat();
+
+    EXPECT_EQ(fmt.sampleRate, 44100u);
+    EXPECT_EQ(fmt.channels, 2u);
+    EXPECT_EQ(fmt.bitsPerSample, 16u);
+    EXPECT_FALSE(fmt.isFloat);
 }

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -520,6 +520,46 @@ TEST(MonitorEngine, LoopbackCaptureSourceReachesFactory) {
     eng.stop();
 }
 
+TEST(MonitorEngine, ApplicationLoopbackCaptureSourceReachesFactory) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 4242u};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+
+    EXPECT_EQ(rig.capOpenCount.load(), 1);
+    EXPECT_TRUE(rig.sawCaptureSource);
+    EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::ApplicationLoopback);
+    EXPECT_TRUE(rig.lastCaptureSource.deviceId.empty());
+    EXPECT_EQ(rig.lastCaptureSource.processId, 4242u);
+    EXPECT_EQ(rig.renderOpenCount.load(), 0);
+    eng.stop();
+}
+
+TEST(MonitorEngine, ApplicationLoopbackDoesNotStartSilentRender) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 4242u};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+
+    EXPECT_EQ(rig.silentOpenCount.load(), 0);
+    EXPECT_EQ(eng.poll().silentRenderState, StreamState::Idle);
+    eng.stop();
+}
+
+TEST(MonitorEngine, ApplicationLoopbackDefaultFactoryRejectsZeroPid) {
+    MonitorEngine eng;
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 0u};
+
+    Result r = eng.start(BackendKind::WasapiShared, source, L"", 50, false);
+
+    EXPECT_FALSE(r);
+    MonitorStatus st = eng.poll();
+    EXPECT_NE(st.overall, StreamState::Running);
+    EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::CaptureOpen));
+}
+
 TEST(MonitorEngine, LoopbackStartsSilentRenderByDefault) {
     FakeRig rig;
     MonitorEngine eng(rig.factory(), rig.silentFactory());


### PR DESCRIPTION
## Summary
- Add an Application Loopback tab with WASAPI audio-session process discovery, Refresh, selectable process rows, and editable PID input.
- Add a real Windows process-loopback capture backend using ActivateAudioInterfaceAsync and VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK.
- Wire ApplicationLoopback through MonitorEngine and add focused tests for capture source, backend guardrails, PID parsing, session ordering, and UI helper behavior.

## Test Plan
- cmake --build build --config Debug --target WinAudioTests WinAudioGui -j
- .\build\bin\Debug\WinAudioTests.exe --gtest_filter=ApplicationLoopbackCaptureStream.*:MonitorEngine.ApplicationLoopback*:AudioSessionEnumerator.*:AppLoopbackPid.*:AppLoopbackUi*
- .\test.bat Debug
- git diff --check
- WinAudioGui hidden smoke launch for 3 seconds