### PR TITLE
Refine WASAPI options and project docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+PR title: Conventional Commits format, e.g. "feat(gui): add application loopback capture".
+The title goes verbatim into GitHub Release notes (generate_release_notes) — keep it user-readable.
+Full rules: CLAUDE.md, section "Commit 与 PR 规范".
+-->
+
+## What / Why
+
+<!-- What changes and why. Link the issue (Closes #N) and/or the design doc under docs/superpowers/specs/. -->
+
+## How
+
+<!-- Key design decisions and trade-offs — a paragraph or two, not a diff walkthrough. -->
+
+## Testing
+
+<!-- What you ran and the results (paste test totals). For real-device behavior (latency, drift,
+     exclusive-format negotiation), state the device(s) used and the smoke outcome. -->
+
+## Checklist
+
+- [ ] Commits follow Conventional Commits and are atomic (each builds and passes tests)
+- [ ] `test.bat Debug` and `test.bat Release` pass locally
+- [ ] New core logic has gtest coverage that runs without real audio devices
+- [ ] GUI changes: screenshots attached
+- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ x64/
 *.wav
 # Dear ImGui runtime layout state
 imgui.ini
+*.codegraph

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+本仓库的协作与项目指南统一维护在 [CLAUDE.md](CLAUDE.md)。
+
+请阅读并遵循 `CLAUDE.md`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ cmake --build build --config Release -j
 #   - 选择不同后端或采集设备时，下拉自动重算默认值
 #
 # Control 区：
-#   - "Options" 弹窗可配置高级流参数 (category / stream option(RAW=绕过 APO)/ offload / ducking / buffer ms)
-#   - 默认全部"跟随系统"(不注入任何覆盖);category/option/offload/ducking 仅 WASAPI-Shared(offload/ducking 仅 render)
+#   - "Options" 弹窗可配置高级流参数 (SetClientProperties 总开关 / category / offload / stream option / ducking / buffer ms)
+#   - capture/render 各自用总开关控制是否调用 SetClientProperties；启用时 category 默认 Communications、offload 默认 false、Options 默认 NONE；ducking 仅 render
 #   - "同步播放" checkbox：勾选 → 启动 render 流实时直通（采样率须与采集设备一致）；取消勾选 → 停止 render 流并释放设备
 #   - 弹窗在监听运行中只读(仅 Start 前可改)
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,166 +2,90 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## 项目状态
+## 这是什么项目
 
-WinAudio 是一个小巧的 Windows 音频测试工具，用于对系统音频设备做采集、播放等测试。
+WinAudio：Windows 音频测试工具（WASAPI 采集/播放、系统与应用 loopback、双流延迟监听、波形/声谱图可视化）。C++17 + CMake（MSVC v143，仅 x64），4 个 target：`WinAudioCore` 静态库（`src/core`）、`WinAudioCli`（`src/cli`）、`WinAudioGui`（ImGui + DX11，`src/gui`，首选前端）、`WinAudioTests`（gtest，`src/tests`）。
 
-**Phase 3 已完成。** 当前代码库包含 4 个项目：
-- **WinAudioCore**（`src/core`）：纯 C++ 静态库（外部依赖仅 spdlog header-only submodule + Win32 + STL）；提供后端抽象（`IAudioBackend`）、设备枚举（`DeviceEnumerator`）、WASAPI-Shared/Exclusive 采集/播放、WAV 读写、环形缓冲区（RingBuffer）、引擎（Engine）、双流延迟监听（MonitorEngine、DelayFifo）、FFT 分析（Fft、SampleConvert、ScopeBuffer、Analysis）、详细接口调用日志（`wa::log`，spdlog 封装）。
-- **WinAudioCli**（`src/cli`）：最小化命令行前端，支持 `list` / `capture` / `play` / `probe` / `monitor` 子命令；均支持 `--log-level <trace|debug|info|warn|err>` / `--log-file <path>`（日志走 stderr，默认 info）。
-- **WinAudioGui**（`src/gui`）：Dear ImGui + DX11 GUI 前端，为首选交互方式；**恒监听**（monitor-only），两列布局（左列：设备/控制/状态/日志；右列：采集/播放各一个"波形+声谱图"合并单元，共享时间轴、可拖拽重排），"同步播放" checkbox 实时控制 render 流。
-- **WinAudioTests**（`src/tests`）：gtest 单元测试套件，覆盖核心模块（RingBuffer、AudioFormat、WAV、FormatSpec、WasapiStream 辅助函数、Fft、SampleConvert、ScopeBuffer、DelayFifo、Analysis、MonitorEngine、Spectrogram）。
+用户向文档（功能介绍、下载、CLI/GUI 完整用法、已知限制）见 `README.md`；历次功能的设计文档与实施计划在 `docs/superpowers/specs/`、`docs/superpowers/plans/`，大改某个子系统前先看对应 spec。
 
-Phase 1 实现了 **WASAPI-Shared 采集/播放**；Phase 2 新增了 **WASAPI-Exclusive（独占模式，低延迟）**；Phase 3 新增了**双流延迟监听直通（MonitorEngine）与实时 GUI 可视化（波形 + 声谱图）**。waveIn/waveOut 与格式转换/重采样留作后续阶段。
-
-**构建系统已迁移到 CMake（已完成）**：从手写 MSBuild（`.sln`/`.vcxproj`）迁移到 CMake（Visual Studio 17 2022 生成器，保留 MSVC；`build.bat`/`test.bat` 驱动，产物集中在 `build/`），零 C++ 源码改动。详见「技术选型」「构建与运行」。
-
-## 技术选型
-
-- 语言/构建：**C++ + CMake**（Visual Studio 17 2022 生成器，保留 MSVC v143）；工程文件（`.sln`/`.vcxproj`）由 CMake 生成到 `build/`，命令行/批处理（`build.bat`）驱动，不依赖 VS IDE。
-- 形态：**CLI + GUI**；ImGui + DX11 为主交互，CLI 为轻量辅助。
-- 能力范围（已实现）：
-  - **WASAPI-Shared**：`IAudioClient` 采集与播放，共享模式（多应用可并行使用设备，格式由设备混音格式决定）。
-  - **WASAPI-Exclusive**：独占模式（低延迟），通过 `IsFormatSupported` 探测可用格式；采集时支持 `--format` 指定目标格式；播放时格式从 WAV 文件头自动读取。
-  - **数据格式查询与能力矩阵**：三来源查询（Mix Format / Device Format / OEM Format）+ 能力矩阵（每候选格式在 Shared/Exclusive 上是否支持，用 `yes`/`-` 表示）；CLI `caps` 子命令查看设备能力；GUI 左栏格式区可选择当前模式支持的格式或自定义输入；采集/播放可按需改格式（Shared 经 WASAPI 引擎 AUTOCONVERTPCM 转换，无本工具重采样；Exclusive 要求硬件原生支持）。
-  - **格式探测**：`Engine::probeFormat` + CLI `probe` 子命令，可检测特定格式是否受设备支持；`probe` 支持两种后端，shared 反映 WASAPI 混音器转换能力，exclusive 反映硬件原生支持。
-  - **设备枚举**：`IMMDeviceEnumerator` 枚举、查询默认设备与端点属性。
-  - **WAV 读写**：采集落盘 / 播放读取，支持标准 RIFF WAVE 格式。
-  - **环形缓冲区**：SPSC 设计，线程安全，带 xrun 计数。
-  - **双流延迟监听直通**：`MonitorEngine`（capture → `DelayFifo` 漂移控制 → render，两路 scope tap）；CLI `monitor` 子命令打印 cap/ren 状态、sr、fifo ms、drift、xrun。
-  - **FFT 实时分析**：手写 radix-2 FFT（`Fft`，Hann 窗 + dBFS 标定 + 窗长归一化）；`SampleConvert`（多格式 PCM 解交织）；`ScopeBuffer`（seqlock 快照，无阻塞读取）；`Analysis`（采样计数节拍，驱动分析刷新）。
-  - **GUI Monitor 模式**：ImPlot 可视化，采集/播放两路各自的 dB 时域波形 + 滚动 log 频率声谱图（`Spectrogram` 做 log 频率热图重采样；波形与声谱图合并为一个单元、共享时间轴、中间分割线上下可调）；状态行显示 fifo/drift 以便观察漂移；左栏格式区显示当前将用格式与候选。
-  - **错误处理**：`Result` 类型、HRESULT 规范化、COM RAII 与线程安全。
-- 能力范围（后续阶段）：
-  - waveIn / waveOut（MME API 后端）。
-  - 格式转换/重采样（当前 Shared 模式要求输入 WAV 格式与设备混音格式一致；Exclusive 模式要求格式受设备支持；Exclusive monitor 仍要求渲染设备支持采集格式）。
-- **已知限制**：
-  - 分析为单声道降混（多声道信号取首声道或均值）。
-  - `monitor` Shared 模式由 WASAPI 引擎在渲染侧自动桥接采样率差异，采集/渲染可用不同采样率设备；Exclusive 模式仍要求渲染设备支持采集格式，采样率不匹配则 render 启动失败。
-  - 漂移补偿采用单帧丢/插 + crossfade，**无重采样器**；USB 麦 + HDMI 等跨时钟设备漂移率高，同接口 loopback 漂移很小。
-
-## 构建与运行
-
-本项目使用 **CMake**（Visual Studio 17 2022 生成器，保留 MSVC），命令行/批处理驱动，产物集中在 `build/`。
+## 常用命令
 
 ```powershell
-# 构建（默认 Release；可传 Debug；--clean 先清后建）
-.\build.bat Debug
-.\build.bat Release
-.\build.bat Release --clean
+git submodule update --init          # 首次 clone 后必须（third_party/spdlog）
 
-# 运行测试（ctest，78 个）
-.\test.bat Debug          # 或 .\test.bat Release
-# 也可直接跑测试 exe：
-.\build\bin\Debug\WinAudioTests.exe
-.\build\bin\Debug\WinAudioTests.exe --gtest_filter=MonitorEngine.*
-
-# 清理
+.\build.bat Debug                    # 构建（默认 Release；--clean 先删 build\ 再重建）
+.\test.bat Debug                     # ctest 全量（默认 Release）
+.\build\bin\Debug\WinAudioTests.exe --gtest_filter=MonitorEngine.*   # 单跑一组测试
 .\clean.bat
 
-# 也可直接用 CMake / preset：
+# 等价的原生 CMake 方式：
 cmake --preset vs2022
-cmake --build build --config Release -j
+cmake --build build --config Debug -j
 ```
 
-产物：`build\bin\<Config>\{WinAudioCli,WinAudioGui,WinAudioTests}.exe`、`build\lib\<Config>\WinAudioCore.lib`。构建使用**静态 CRT（`/MT`、`/MTd`，由顶层 `CMAKE_MSVC_RUNTIME_LIBRARY` 统一控制，gtest 等第三方一并继承）**，产出的 exe 自包含，分发无需安装 VC++ Redistributable。
-若 `cmake` 不在 PATH，用 VS 自带的：`D:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`。
+- `cmake` / `ctest` 若不在 PATH，用 VS 自带的：`D:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`。
+- 产物：`build\bin\<Config>\{WinAudioCli,WinAudioGui,WinAudioTests}.exe`、`build\lib\<Config>\WinAudioCore.lib`。
+- 手工冒烟：CLI 子命令 `list` / `caps` / `capture` / `play` / `probe` / `monitor`（参数解析与 usage 在 `src/cli/main.cpp`；`list` 不开音频流，最适合快速验证）；GUI 有 Monitor / Loopback / Application Loopback 三个 tab。日志调试：CLI 用 `--log-level trace --log-file <path>`（日志走 stderr，与 stdout 状态行分离）；GUI 默认写 `winaudio.log` 并带左栏日志面板。
 
-```powershell
-# ---- CLI 用法 ----
+## 架构
 
-# 枚举设备
-.\build\bin\Debug\WinAudioCli.exe list [--render|--capture]
+数据流主线（多数改动落在这条链上）：
 
-# 查看设备能力（三来源格式 + 能力矩阵）
-.\build\bin\Debug\WinAudioCli.exe caps [--device <id>] [--render|--capture]
-# 显示 Mix/Device/OEM 三来源格式，以及每个候选格式在 Shared/Exclusive 上的支持情况（yes/- 表示）。
-
-# 采集（Shared 默认用设备混音格式；可用 --format 指定，经引擎 AUTOCONVERTPCM 转换；Exclusive 可用 --format 指定，要求硬件原生支持）
-.\build\bin\Debug\WinAudioCli.exe capture --out <file.wav> [--seconds N] [--device <id>] [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2]
-# 注：--format 对两个后端都有效；Shared 使用 WASAPI 引擎转换（无本工具重采样），Exclusive 要求指定格式被硬件支持。
-
-# 播放（格式从 WAV 文件头读取；不接受 --format）
-.\build\bin\Debug\WinAudioCli.exe play --in <file.wav> [--device <id>] [--backend wasapi-shared|wasapi-exclusive]
-
-# 格式探测（检测设备是否支持指定格式）
-.\build\bin\Debug\WinAudioCli.exe probe --format 48000/16/2 [--device <id>] [--render|--capture] [--backend wasapi-shared|wasapi-exclusive]
-# 注：exclusive probe 精确反映硬件独占可用性；shared probe 反映 WASAPI 混音器能否转换该格式（反映工具采集/播放的实际可用性）。
-
-# 双流延迟监听（capture → delay → render，打印 cap/ren 状态、sr、fifo ms、drift、xrun；可指定采集格式）
-.\build\bin\Debug\WinAudioCli.exe monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [--format 48000/16/2] [--backend wasapi-shared|wasapi-exclusive]
-# 注：Shared 模式由 WASAPI 引擎在渲染侧桥接采样率，--cap 与 --render 可用不同采样率设备；Exclusive 模式仍要求渲染设备支持采集格式，采样率不匹配则 render 启动失败；--format 仅影响采集端。
-
-# ---- GUI（首选） ----
-.\build\bin\Debug\WinAudioGui.exe
-# GUI 为恒监听（monitor-only），无 Capture/Playback/Monitor 模式切换。
-# 两列布局：左列 = 设备 / 控制（含格式区、"同步播放" checkbox）/ 状态 / 日志；
-#           右列 = 采集/播放各一个"波形+声谱图"合并单元（共享时间轴，可拖拽重排）。
-# 
-# Devices 区：
-#   - 采集设备选择器（下拉框，默认系统默认设备）
-#   - "Capture caps…" 按钮 → 弹窗显示该设备的三来源格式（Mix/Device/OEM）+ 能力矩阵（Shared/Exclusive 支持情况）
-#   - 后端选择（Shared / Exclusive，或跟随系统）
-#   - Start 按钮
-#
-# Format 区：
-#   - 显示当前将用格式（如 "48000 Hz, 16-bit, 2-ch"）
-#   - 候选下拉：第一项 "System default"，随后列出当前后端支持的候选格式，末项 Custom 允许手输
-#   - Shared 模式下默认用设备混音格式；Exclusive 默认为探测确认的可用格式
-#   - 选择不同后端或采集设备时，下拉自动重算默认值
-#
-# Control 区：
-#   - "Options" 弹窗可配置高级流参数 (SetClientProperties 总开关 / category / offload / stream option / ducking / buffer ms)
-#   - capture/render 各自用总开关控制是否调用 SetClientProperties；启用时 category 默认 Communications、offload 默认 false、Options 默认 NONE；ducking 仅 render
-#   - "同步播放" checkbox：勾选 → 启动 render 流实时直通（采样率须与采集设备一致）；取消勾选 → 停止 render 流并释放设备
-#   - 弹窗在监听运行中只读(仅 Start 前可改)
-#
-# 选择采集设备后点击 Start，实时显示 dB 时域波形、滚动 log 频率声谱图（二者共享时间轴）；
-# 状态行实时显示 fifo ms / drift，方便观察跨设备时钟漂移情况。
+```
+capture source（endpoint | system loopback | application loopback(PID)）
+  ├─ Engine：单流。采集→WAV / WAV→render 播放 / probeFormat 格式探测
+  └─ MonitorEngine：双流直通。capture → DelayFifo（固定延迟+漂移补偿）→ render
+                    ├─ ScopeBuffer tap ×2（cap/ren 两路）
+                    └─ Analysis（采样计数节拍）→ Fft → GUI 波形/Spectrogram
 ```
 
-## CI / 发布（GitHub Actions）
+- **分层**：前端把 `BackendKind`（`WasapiShared` / `WasapiExclusive`）传给 Engine/MonitorEngine，同一上层流程可切后端做对比测试；流生命周期统一为 open → start → poll → stop → close（`IAudioBackend.h`）。
+- **`src/core/WasapiStream.{h,cpp}` 是 WASAPI 心脏**：基类做模式感知格式协商（Shared = `GetMixFormat` + `AUTOCONVERTPCM`；Exclusive = `IsFormatSupported` + `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` 对齐重试）、事件驱动线程模型、同步启动握手；派生出 capture / render / system-loopback / silent-render 各流。按 PID 的 process loopback 在 `ApplicationLoopbackCapture.*`（Shared-only）。
+- **跨线程原语**（音频线程 ↔ GUI/控制线程的唯一通道）：`RingBuffer`（SPSC + xrun 计数）、`ScopeBuffer`（seqlock 快照，读不阻塞写）、`DelayFifo`（单帧丢/插 + crossfade）、`Analysis`（采样计数节拍触发 FFT）。
+- **GUI**：逻辑集中在 `src/gui/AppUi.*`；用户可见文案集中在 `AppUiText.h`（有对应文案测试）；`Spectrogram.*` 纯 STL、可脱离 GUI 单测。ImGui / ImPlot / googletest 是 `third_party/` 内的 vendored 副本；spdlog 是唯一 git submodule。
 
-- **`.github/workflows/ci.yml`**：push / PR 到 `main` 时，在 `windows-2022` 上以 **Debug + Release 双配置**（`windows-latest` 现已预装 VS 2026，与 `Visual Studio 17 2022` generator 不匹配，故 pin） 跑 `cmake --preset vs2022` → build → `ctest`，并上传 `WinAudioGui.exe` / `WinAudioCli.exe` 产物（artifact 名 `WinAudio-<config>`）。
-- **`.github/workflows/release.yml`**：推送 `v*` tag（如 `v0.1.0`）时，构建 Release + `ctest`，打包 `WinAudio-<tag>-win-x64.zip` 并创建 GitHub Release（`generate_release_notes`）；需仓库 Actions 具备写权限。
+## 硬性约束（改代码前必读）
 
-## 架构（多后端抽象）
+- **音频热路径（capture/render 线程回调）禁止堆分配与阻塞锁**；跨线程通信只用上面列的原语或原子量。
+- **core「never prints」**：错误经 `Result`（HRESULT 规范化）向上传；日志经 `wa::log`（spdlog 薄封装），sink 由前端注册，core 不选输出目的地。
+- **凡新增/改动 WASAPI/COM/Win32 调用，必须按现有模式加 `wa::log` 插桩**：Info = 生命周期（open/close/start/stop、选中设备、最终格式）；Debug = 控制路径参数+返回值（HRESULT 过 `hrName` 译成符号名）；Trace = 音频热路径逐帧（无堆分配路径）；Warn = 被容忍/被忽略的返回值。插桩纯观测，不得改控制流、返回值或时序。
+- **core 只依赖 Win32 + STL + spdlog**；GUI 专用第三方库进 `third_party/`，不进 core。
+- **构建约定**：静态 CRT（/MT、/MTd）由顶层 `CMAKE_MSVC_RUNTIME_LIBRARY` 统一控制，新 target 不要自行设置 runtime；自有 target 用 `wa_set_project_warnings(<target>)` 挂 `/W4 /permissive- /utf-8 /sdl`，保持零警告。
+- **领域边界**：本工具没有重采样器（Shared 靠 WASAPI 引擎转格式，Exclusive 要求硬件原生支持，漂移补偿只有单帧丢/插+crossfade）；系统/应用 loopback 均 Shared-only；分析路径为单声道降混；waveIn/waveOut 未实现。
+- **新增核心逻辑配套 gtest**（`src/tests/test_*.cpp`，一模块一文件），且必须能脱离真实音频设备运行（CI runner 无音频硬件）。
 
-分层设计确保"同一上层流程，可切换不同后端做对比测试"：
+## 测试与 CI
 
-- **核心库（WinAudioCore）**
-  - `IAudioBackend` 接口：统一的采集/播放生命周期（open → start → poll → stop → close）。
-  - `AudioFormat`：统一的 PCM 格式（采样率、位深、声道）与 `WAVEFORMATEX` 转换。
-  - `DeviceEnumerator`：基于 `IMMDeviceEnumerator`，枚举设备、查询默认端点。
-  - `WasapiStream`（基类）：WASAPI 公共脚手架，含模式感知的格式协商（Shared=`GetMixFormat`，Exclusive=`IsFormatSupported` + 对齐重试 `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED`）、事件驱动线程模型、同步启动握手。
-    - `WasapiCaptureStream`：继承 `WasapiStream`，实现 `IAudioCaptureClient` 数据拉取循环。
-    - `WasapiRenderStream`：继承 `WasapiStream`，实现 `IAudioRenderClient` 数据推送循环与静音预填充。
-  - `RingBuffer`：SPSC 设计，原子操作，xrun 计数。
-  - `WavReader` / `WavWriter`：标准 RIFF WAVE 格式支持，错误处理（坏头部检测）。
-  - `Engine`：高层驱动，汇总设备 + 后端 + 数据源/汇，poll() 生成快照（电平、xrun、状态）。支持 `startCapture`、`startPlayback`、`probeFormat`。
-  - `FormatSpec`：`parseFormatSpec`（解析 `R/B/C[f]` 字符串）、`defaultExclusiveCaptureCandidates`（常用独占格式候选列表）、`selectSupportedFormat`（遍历候选调用探测谓词）、`alignedBufferDuration100ns`（缓冲对齐辅助）。
-  - `MonitorEngine`：双流监听引擎，capture → `DelayFifo` → render，两路 `ScopeBuffer` tap 供 GUI/分析读取，`Analysis` 驱动 FFT 刷新节拍。
-  - `Fft`：手写 radix-2 FFT，Hann 窗，dBFS 标定（窗长归一化），纯 STL 无外部依赖。
-  - `SampleConvert`：多格式 PCM（int16/int32/float32）解交织到 float，供 Fft 消费。
-  - `ScopeBuffer`：seqlock 快照，GUI 线程无锁读取最新波形帧，音频线程写入不阻塞。
-  - `DelayFifo`：固定延迟 FIFO，单帧丢/插 + crossfade 漂移补偿，无重采样。
-  - `Analysis`：采样计数节拍，跨线程触发 FFT 计算，解耦音频回调与分析频率。
-- **GUI 第三方库**（GUI 专用，不污染核心库）：
-  - `third_party/implot`：ImPlot（Dear ImGui 的绘图扩展），提供波形与声谱图热图渲染。
-  - `src/gui/Spectrogram.*`：纯 STL 辅助类，将线性 FFT bin 重采样到 log 频率网格，生成热图列；有独立 gtest。
-- **BackendKind**：`WasapiShared` / `WasapiExclusive`，由 CLI `--backend` 参数或 GUI 选择器决定，传入 `Engine`。
-- **COM 与线程安全**：`CoInitializeEx` 包装（RAII）；WASAPI 线程模型约定；原子操作与互斥锁。
-- **错误处理**：`Result` 类型，HRESULT 到 string 映射，用户友好报错。
+- CI（`.github/workflows/ci.yml`）：push / PR 到 `main`，Debug + Release 双配置 build + ctest。**runner 必须 pin `windows-2022`**（`windows-latest` 已预装 VS 2026，`Visual Studio 17 2022` generator 找不到工具链）；checkout 必须 `submodules: recursive`。
+- 发布：推 `v*` tag → `release.yml` 构建、打包 zip、创建 GitHub Release。
+- 涉及真实设备的行为（延迟、漂移、独占格式协商）单测覆盖不到，相关改动合并前需人工冒烟（CLI `monitor` 或 GUI）。
 
-## 日志（详细接口调用日志）
+## Commit 与 PR 规范
 
-core 通过 `wa::log`（`src/core/Log.{h,cpp}`）——对 **spdlog**（`third_party/spdlog`，git submodule 固定 v1.15.3，header-only）的薄封装——记录**一切 WASAPI/COM/Win32 接口调用的参数与返回值**。`Result.h` 的「never prints」精神保留：core 不选输出目的地，由上层注册 sink；未注册 sink 时零输出。
+### Commit（Conventional Commits 1.0.0，英文）
 
-- **级别**：`Error / Warn / Info / Debug / Trace`，**默认 Info**，运行时可切。Info=生命周期（open/close/start/stop、选中设备、最终格式）；Debug=**所有控制路径调用**的参数+返回值（HRESULT 经 `hrName` 译成符号名，如 `AUDCLNT_E_DEVICE_INVALIDATED`）；Trace=音频热路径逐帧（`GetBuffer`/`ReleaseBuffer`/`GetCurrentPadding` 等）；Warn=可容忍异常 + 补齐现状被忽略的返回值。
-- **双路径 / 实时性**：控制路径同步记录；音频热路径经 spdlog async logger（`overrun_oldest` 非阻塞、队满丢最旧）。`emitTrace` 在音频线程**无堆分配**（inline stack buffer），但 spdlog async 队列 enqueue 会取一个**极短的 mpmc mutex 锁**——Trace 是诊断用途，开启时可能对被测音频有轻微扰动。
-- **输出（sink，可并存）**：`rotating_file_sink`（文件轮转）、stderr、自定义 callback（GUI 面板）。行格式 `时间戳 级别 [线程] Module::Call args:… ret:…`，线程短名 main/pump/capW/renW/cap/play。
-- **前端**：CLI `--log-level`/`--log-file`（日志走 stderr，与状态行 stdout 分离）；GUI 默认写 exe 目录 `winaudio.log` + 左栏日志面板（级别下拉运行时切、清空、自动滚动、5000 行环形上限）。
-- **插桩纯观测**：只读现有变量/HRESULT 记录，不改任何控制流/返回值/时序。
+格式：`<type>(<scope>): <subject>`，正文与 footer 可选。
+
+- **type**：`feat` / `fix` / `docs` / `test` / `refactor` / `perf` / `build` / `ci` / `chore` / `revert`。
+- **scope**：按改动子系统，本仓库在用：`core`、`gui`、`cli`、`log`、`loopback`、`audio`、`build`；跨子系统或不适用时可省略（如 `docs: …`、`ci: …`）。
+- **subject**：祈使句、小写开头、结尾不加句号、≤ 72 字符（尽量 ≤ 50）；说清"这个 commit 做了什么"。
+- **body**（改动动机不自明时必写，空行隔开）：写 what/why（动机、取舍），不逐行复述 diff；每行 ≤ 72 字符。
+- **footer**：破坏性变更用 `BREAKING CHANGE: <说明>`；关联 issue 用 `Closes #N` / `Refs #N`。
+- **原子性**：一个 commit 只做一件事，且每个 commit 都能独立构建、测试通过（保持可 `git bisect`）；格式化/重构不与功能、修复混在同一 commit。
+- **分层提交**（本仓库惯例）：一个功能按 `core → cli/gui → docs` 自底向上拆成多个 commit，每层自洽。
+
+### 分支与 PR
+
+- 分支名：`<type>/<kebab-topic>`，如 `feat/system-loopback`、`fix/loopback-silence`；从 `main` 切出，PR 回 `main`。
+- **PR 标题**同 Conventional Commits 格式。注意：`release.yml` 开了 `generate_release_notes`，PR 标题会原样进入 Release Notes，要让用户读得懂。
+- **PR 描述**必含三部分（开 PR 时自动带出模板 `.github/PULL_REQUEST_TEMPLATE.md`，按模板填写）：
+  1. **What / Why**：改了什么、为什么；关联 issue 或 `docs/superpowers/specs/` 里的设计文档。
+  2. **How**：关键设计取舍，一两段即可。
+  3. **Testing**：`test.bat` Debug + Release 结果；涉及真实设备的改动附人工冒烟结论（CLI `monitor` 或 GUI）；GUI 界面改动附截图。
+- 一个 PR 聚焦一个主题，控制体量（数百行级，重构和功能分开提）；未完成的开 Draft PR。
+- 合并前提：CI（Debug + Release）全绿。合并方式为 merge commit（保留分支上的分层提交历史），所以分支上每个 commit 都须符合上述规范，不要依赖 squash 兜底。
+
 ## 约定
 
-- 回答默认用中文；代码、命令、API 标识符等保持英文原文。
+- 回答用中文；代码、注释、日志文本、API 标识符保持英文。
+- `AGENTS.md` 只是指向本文件的指针；agent 规则统一维护在这里。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# WinAudio
+
+[![CI](https://github.com/peilinok/winaudio/actions/workflows/ci.yml/badge.svg)](https://github.com/peilinok/winaudio/actions/workflows/ci.yml)
+
+小巧的 Windows 音频测试工具：对系统音频设备做采集、播放、回环（loopback）与延迟监听测试，带实时波形 / 声谱图可视化。GUI（Dear ImGui + DX11）为首选交互方式，另有轻量 CLI。
+
+## 功能
+
+- **WASAPI 双后端**：Shared（共享模式）与 Exclusive（独占模式、低延迟），同一流程可切换后端做对比测试。
+- **采集 / 播放**：采集落盘 WAV，播放标准 RIFF WAV；可用 `--format` 指定目标格式（Shared 经 WASAPI 引擎 `AUTOCONVERTPCM` 转换；Exclusive 要求硬件原生支持）。
+- **系统 loopback**：以 render endpoint 为采集源回采系统输出，可选静音 render keepalive 保持时钟推进。
+- **Application Loopback**：按 PID 回采指定进程及其子进程树的音频（Shared-only；需要 Windows 10 build 20348 及以上）。
+- **双流延迟监听**：capture → 固定延迟 FIFO（漂移补偿）→ render 实时直通，显示 fifo 水位 / drift / xrun。
+- **设备能力查询**：Mix / Device / OEM 三来源格式 + 候选格式在 Shared/Exclusive 下的支持矩阵。
+- **格式探测**：检测设备是否支持指定格式（shared 反映 WASAPI 混音器转换能力，exclusive 反映硬件独占可用性）。
+- **实时分析**：dB 时域波形 + 滚动 log 频率声谱图（自带 radix-2 FFT，Hann 窗，dBFS 标定）。
+- **详细接口调用日志**：所有 WASAPI/COM/Win32 调用的参数与返回值可观测（基于 spdlog，级别运行时可调）。
+
+## 下载与运行
+
+- 从 [Releases](https://github.com/peilinok/winaudio/releases) 下载 `WinAudio-<版本>-win-x64.zip`，解压即用。
+- exe 使用静态 CRT，自包含，**无需安装 VC++ Redistributable**。
+- 系统要求：Windows 10/11 x64；GUI 需要 Direct3D 11；Application Loopback 功能需要 Windows 10 build 20348 及以上（Windows 11 / Windows Server 2022+）。
+
+## 从源码构建
+
+依赖：Visual Studio 2022（v143 工具集 + Windows SDK）、CMake ≥ 3.21（VS 自带的即可）。
+
+```powershell
+git clone --recursive https://github.com/peilinok/winaudio.git   # spdlog 为 git submodule
+cd winaudio
+
+.\build.bat Release        # 默认 Release；可传 Debug；--clean 先清后建
+.\test.bat Release         # 运行测试套件（ctest / gtest）
+```
+
+产物在 `build\bin\<Config>\`：`WinAudioGui.exe`、`WinAudioCli.exe`、`WinAudioTests.exe`。
+
+- 若 `cmake` / `ctest` 不在 PATH，可用 VS 自带的（`<VS 安装目录>\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`）。
+- 也可直接用 CMake preset：`cmake --preset vs2022`，然后 `cmake --build build --config Release -j`。
+- Windows SDK 低于 10.0.20348 时仍可构建，但 Application Loopback 功能会被编译为不可用（运行时报错提示）。
+
+## GUI 使用（首选）
+
+运行 `WinAudioGui.exe`，包含 **Monitor** / **Loopback** / **Application Loopback** 三个 tab。日志默认写运行目录下的 `winaudio.log`（双击启动即 exe 目录），左栏日志面板可运行时切换级别、清空、自动滚动。
+
+### Monitor（双流延迟监听）
+
+两列布局：左列为设备 / 控制 / 状态 / 日志，右列为采集、播放两路各一个「波形 + 声谱图」合并单元（共享时间轴，中间分割线可上下调节，单元可拖拽重排）。
+
+- **Devices**：选择采集设备（默认系统默认设备）与后端（Shared / Exclusive）；「Capture caps…」弹窗显示该设备的三来源格式与 Shared/Exclusive 能力矩阵。
+- **Format**：显示当前将用格式（如 `48000 Hz, 16-bit, 2-ch`）；候选下拉第一项为 System default，随后是当前后端支持的候选格式，末项 Custom 可手动输入；切换设备或后端时自动重算默认值。
+- **Control**：「Options」弹窗配置高级流参数——capture/render 各自的 `SetClientProperties` 总开关、category、offload、stream option（None / Raw / MatchFormat / Ambisonics / Post-volume loopback）、ducking（仅 render）、buffer ms；弹窗仅 Start 前可改。「同步播放」checkbox 实时启停 render 直通流（Exclusive 模式要求渲染设备支持采集格式）。
+- **Status**：实时显示 fifo ms / drift，方便观察跨设备时钟漂移。
+
+### Loopback（系统回采）
+
+选择一个 render device 作为回采源，Start 后实时显示系统输出的波形 + 声谱图。「Silent render keepalive」默认开启（用静音 render 保持 loopback 时钟推进），运行中不可改。
+
+### Application Loopback（按进程回采）
+
+打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举；点击列表行会把 PID 填入下方输入框，也可手动输入任意非零 PID（不要求出现在列表中）。Start 后以 WASAPI process loopback（Shared）采集该进程及其子进程的音频。
+
+## CLI 使用
+
+`WinAudioCli.exe <子命令> [参数]`，子命令：`list` / `caps` / `probe` / `capture` / `play` / `monitor`。
+
+### list — 枚举设备
+
+```powershell
+WinAudioCli list [--render|--capture]
+```
+
+默认列出 render 设备。`*` 标记系统默认设备，同时打印混音格式与设备 id（供 `--device` / `--cap` 使用）。
+
+### caps — 设备能力
+
+```powershell
+WinAudioCli caps [--device <id>] [--render|--capture]
+```
+
+显示 Mix / Device / OEM 三来源格式，以及每个候选格式在 Shared / Exclusive 下的支持情况（`yes` / `-`）。
+
+### probe — 格式探测
+
+```powershell
+WinAudioCli probe --format 48000/16/2 [--device <id>] [--render|--capture] [--backend wasapi-shared|wasapi-exclusive]
+```
+
+输出 `SUPPORTED` / `NOT SUPPORTED`（退出码 0 / 1）。exclusive 精确反映硬件独占可用性；shared 反映 WASAPI 混音器能否转换该格式（即本工具实际可用性）。
+
+### capture — 采集
+
+```powershell
+WinAudioCli capture --out <file.wav> [--seconds N] [--device <id>] [--loopback] [--no-silent-render]
+                    [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2]
+```
+
+- 默认采集 5 秒，实时打印 L/R 电平与 overrun/underrun 计数。
+- `--format` 两个后端均可用：Shared 经 WASAPI 引擎转换（无本工具重采样）；Exclusive 要求硬件原生支持。
+- `--loopback` 回采系统输出：此时 `--device` 填 render 设备 id；仅支持 Shared；默认启动静音 render keepalive，`--no-silent-render` 关闭。
+
+### play — 播放
+
+```powershell
+WinAudioCli play --in <file.wav> [--device <id>] [--backend wasapi-shared|wasapi-exclusive]
+```
+
+格式从 WAV 文件头读取，不接受 `--format`。Shared 下由 WASAPI 引擎转换到设备混音格式；Exclusive 要求设备原生支持 WAV 的格式。
+
+### monitor — 双流延迟监听
+
+```powershell
+WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [--loopback]
+                    [--no-silent-render] [--format 48000/16/2] [--backend wasapi-shared|wasapi-exclusive]
+```
+
+- capture → 固定延迟（默认 100 ms）→ render 直通，默认运行 5 秒；状态行实时打印 cap/ren 状态、采样率、fifo ms、drift、xrun。
+- `--format` 仅作用于采集端。
+- Shared：WASAPI 引擎在渲染侧桥接采样率，采集/渲染可用不同采样率的设备；Exclusive：渲染设备必须支持采集格式，否则 render 启动失败。
+- `--loopback` 以 render endpoint 为采集源（`--cap` 填 render 设备 id），仅支持 Shared；注意不要把同一个 render 设备既作 loopback 输入又作监听输出。
+
+### 通用参数
+
+- `--log-level <trace|debug|info|warn|err>`（默认 `info`）与 `--log-file <path>`：日志走 stderr，状态行走 stdout（互不干扰，方便重定向）；`--log-file` 额外写入文件。
+- `--format` 语法为 `采样率/位深/声道[f]`，如 `48000/16/2`、`48000/32/2f`（`f` 表示 float）。
+- 设备 id 通过 `list` 查询。
+
+## 日志
+
+- 级别：`Info`（默认，流生命周期：open/close/start/stop、选中设备、最终格式）；`Debug`（所有控制路径调用的参数 + 返回值，HRESULT 译成符号名，如 `AUDCLNT_E_DEVICE_INVALIDATED`）；`Trace`（音频热路径逐帧，诊断用，开启时可能对被测音频有轻微扰动）。
+- GUI：左栏日志面板（运行时切级别）+ 运行目录 `winaudio.log`（轮转文件）。
+- CLI：stderr 输出 + 可选 `--log-file`。
+
+## 已知限制
+
+- **无重采样器**：Shared 依赖 WASAPI 引擎转换格式；Exclusive 要求硬件原生支持；monitor 的 Exclusive 模式要求渲染设备支持采集格式（不匹配则 render 启动失败）。
+- **漂移补偿为单帧丢/插 + crossfade**：跨时钟域设备组合（如 USB 麦克风 + HDMI 输出）漂移率高；同接口 loopback 漂移很小。
+- 波形/频谱分析为单声道降混（多声道取首声道或均值）。
+- 系统 loopback 与 Application Loopback 仅支持 Shared 后端。
+- waveIn / waveOut（MME 后端）未实现。
+
+## 开发
+
+- 开发者指南（构建细节、架构、编码约束）见 [CLAUDE.md](CLAUDE.md)；历次功能的设计文档在 `docs/superpowers/specs/`，实施计划在 `docs/superpowers/plans/`。
+- CI：push / PR 到 `main` 自动以 Debug + Release 双配置构建并跑测试；推送 `v*` tag 自动发布 Release。

--- a/docs/superpowers/plans/2026-07-13-winaudio-application-loopback.md
+++ b/docs/superpowers/plans/2026-07-13-winaudio-application-loopback.md
@@ -1,0 +1,152 @@
+# WinAudio Application Loopback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fully working GUI Application Loopback tab that discovers active WASAPI audio-session processes, allows choosing or manually entering any PID, and captures that process tree through Windows process-loopback audio.
+
+**Architecture:** Keep system loopback behavior intact and add application loopback as a third capture source. Put process-loopback activation and audio-session discovery in focused core files; keep `AppUi` responsible for presentation and start/stop wiring only.
+
+**Tech Stack:** C++17, Win32 COM/WASAPI, `ActivateAudioInterfaceAsync`, `IAudioSessionManager2`, Dear ImGui, existing `MonitorEngine` visualization pipeline, gtest.
+
+---
+
+## Files
+
+- Modify: `src/core/IAudioBackend.h`
+  - Add `CaptureSourceKind::ApplicationLoopback`.
+  - Add a PID field to `CaptureSource`.
+- Create: `src/core/AudioSessionEnumerator.h`
+- Create: `src/core/AudioSessionEnumerator.cpp`
+  - Enumerate render endpoint audio sessions.
+  - Resolve each session PID to a process name.
+  - Sort by process name, then PID.
+- Create: `src/core/ApplicationLoopbackCapture.h`
+- Create: `src/core/ApplicationLoopbackCapture.cpp`
+  - Implement the process-loopback capture backend and activation helper.
+- Modify: `src/core/WasapiStream.h`
+  - Move reusable capture loop/service hooks only if needed; otherwise keep endpoint/system loopback unchanged.
+- Modify: `src/core/MonitorEngine.cpp`
+  - Factory creates `ApplicationLoopbackCaptureStream` when source kind is application loopback.
+- Modify: `src/core/CMakeLists.txt`
+  - Add new core source files and required Windows libraries if needed.
+- Modify: `src/gui/AppUi.h`
+  - Add application loopback engine/status/session-list/PID-input/visual state.
+- Modify: `src/gui/AppUi.cpp`
+  - Add the new tab, session refresh, PID selection/input, start/stop, charts, and status.
+- Modify: `src/tests/CMakeLists.txt`
+  - Add new tests.
+- Create: `src/tests/test_audio_session_enumerator.cpp`
+  - Pure sorting/dedup helpers where possible.
+- Modify: `src/tests/test_loopback.cpp`
+  - Capture source representation and shared-only backend behavior.
+- Modify: `src/tests/test_monitorengine.cpp`
+  - Application loopback source reaches the backend factory and does not trigger system-loopback feedback/silent-render behavior.
+
+## Requirements
+
+- Application Loopback tab is visible next to `Monitor` and `Loopback`.
+- On first draw/open, the tab refreshes the session process list automatically.
+- Refresh button re-enumerates active audio-session processes.
+- The process list is sorted by process name, then PID.
+- Selecting a list row copies that PID into an editable PID input field.
+- The PID input field accepts PIDs that are not in the session list.
+- Start uses the PID input field, not the selected row as hidden state.
+- Start rejects PID `0` and non-numeric text with a visible log/status message.
+- Capture uses Windows process-loopback activation for the target PID with include-process-tree mode.
+- The page reuses the existing waveform + spectrogram view.
+- Existing Monitor/System Loopback behavior and tests stay green.
+
+## Task 1: Failing Tests for Source Model and Monitor Wiring
+
+- [ ] Add tests that fail before `ApplicationLoopback` exists:
+  - `CaptureSource.CanRepresentApplicationLoopbackProcess`
+  - `MonitorEngine.ApplicationLoopbackCaptureSourceReachesFactory`
+  - `MonitorEngine.ApplicationLoopbackDoesNotStartSilentRender`
+- [ ] Run:
+  - `.\build\bin\Debug\WinAudioTests.exe --gtest_filter=CaptureSource.*:MonitorEngine.ApplicationLoopback*`
+- [ ] Expected red state:
+  - compile fails or tests fail because `ApplicationLoopback` / PID source fields do not exist.
+
+## Task 2: Implement Capture Source Model and Factory Wiring
+
+- [ ] Add `ApplicationLoopback` and `processId`.
+- [ ] Update `MonitorEngine::makeBackend` to select an application-loopback backend.
+- [ ] Add a temporary minimal backend class only as far as needed to compile the wiring test; real activation arrives in Task 4.
+- [ ] Run the focused tests from Task 1 and make them pass.
+
+## Task 3: Failing Tests for Session List Ordering and PID Selection Helpers
+
+- [ ] Add testable helpers for sorting/deduping session process rows and parsing PID text.
+- [ ] Tests:
+  - `AudioSessionEnumerator.SortsByProcessNameThenPid`
+  - `AudioSessionEnumerator.DeduplicatesByPid`
+  - `AppLoopbackPid.ParseAcceptsManualPid`
+  - `AppLoopbackPid.ParseRejectsZeroAndGarbage`
+- [ ] Run:
+  - `.\build\bin\Debug\WinAudioTests.exe --gtest_filter=AudioSessionEnumerator.*:AppLoopbackPid.*`
+- [ ] Expected red state:
+  - helpers/files do not exist.
+
+## Task 4: Implement Session Enumeration and PID Helpers
+
+- [ ] Implement `AudioSessionEnumerator`.
+- [ ] Use `IMMDeviceEnumerator` -> default/render endpoint -> `IAudioSessionManager2` -> session enumerator.
+- [ ] For each `IAudioSessionControl2`, call `GetProcessId`.
+- [ ] Resolve PID to process name with Win32 process APIs.
+- [ ] Sort/dedupe in a pure helper covered by tests.
+- [ ] Implement PID parse helper for GUI.
+- [ ] Run focused tests from Task 3.
+
+## Task 5: Failing Tests for Process Loopback Backend Guardrails
+
+- [ ] Add tests:
+  - `ApplicationLoopbackCaptureStream.RejectsExclusiveInOpen`
+  - `ApplicationLoopbackCaptureStream.RejectsZeroPid`
+  - a compile/link test proving the class is part of `WinAudioCore`.
+- [ ] Run:
+  - `.\build\bin\Debug\WinAudioTests.exe --gtest_filter=ApplicationLoopbackCaptureStream.*`
+- [ ] Expected red state:
+  - class/open behavior missing.
+
+## Task 6: Implement Process Loopback Capture Backend
+
+- [ ] Implement async activation helper around `ActivateAudioInterfaceAsync`.
+- [ ] Activate `IAudioClient` with `VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK`.
+- [ ] Fill `AUDIOCLIENT_ACTIVATION_PARAMS` with include-process-tree mode and target PID.
+- [ ] Initialize event-driven shared capture, set event handle, get `IAudioCaptureClient`, and reuse capture loop behavior.
+- [ ] Return clear runtime errors for unsupported OS/SDK/API failures.
+- [ ] Run focused backend tests.
+
+## Task 7: Failing GUI Tests / Text Gates
+
+- [ ] Add or extend GUI text/smoke coverage so it expects:
+  - `Application Loopback` tab text.
+  - `Refresh` button text.
+  - editable PID field label.
+  - list row semantics are accessible through static strings.
+- [ ] Run the focused GUI/text test command already used by this repo if present; otherwise build `WinAudioGui`.
+- [ ] Expected red state:
+  - strings/page are not present.
+
+## Task 8: Implement GUI Application Loopback Tab
+
+- [ ] Add third tab.
+- [ ] Add `wa::MonitorEngine appLoopback_`, status, visual state, session rows, selected row, PID buffer, started flag.
+- [ ] Auto-refresh once when the tab first draws.
+- [ ] Refresh button updates rows without overwriting manual PID input.
+- [ ] Clicking a row copies the row PID into the PID input field.
+- [ ] Start parses the PID input and calls `appLoopback_.start(WasapiShared, CaptureSource{ApplicationLoopback, ..., pid}, L"", 0, false)`.
+- [ ] Stop shuts only application loopback.
+- [ ] Reuse `drawChartPanel(0, appLoopback_, appLoopbackMs_, appLoopbackViz_)`.
+
+## Task 9: Full Verification and Agent Review
+
+- [ ] Run focused tests after each task.
+- [ ] Run:
+  - `.\test.bat Debug`
+  - `cmake --build build --config Debug --target WinAudioGui -j`
+- [ ] Run GUI smoke if available:
+  - `tools\run_gui_smoke.ps1 -Config Debug -BuildDir build`
+- [ ] Dispatch spec-compliance reviewer agent.
+- [ ] Dispatch code-quality reviewer agent.
+- [ ] Fix Critical/Important findings.

--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -50,13 +50,13 @@ Level fromSpd(spdlog::level::level_enum l) {
 
 const char* levelStr(Level l) {
     switch (l) {
-        case Level::Trace: return "TRACE";
-        case Level::Debug: return "DEBUG";
-        case Level::Info:  return "INFO";
-        case Level::Warn:  return "WARN";
-        case Level::Err:   return "ERROR";
+        case Level::Trace: return "[T]";
+        case Level::Debug: return "[D]";
+        case Level::Info:  return "[I]";
+        case Level::Warn:  return "[W]";
+        case Level::Err:   return "[E]";
     }
-    return "INFO";
+    return "[I]";
 }
 
 // Static table of the HRESULTs this tool actually encounters. Returns nullptr
@@ -182,7 +182,7 @@ void emit(Level lvl, const char* module, const char* call,
     if (!g_logger) return;
     const std::string modcall = std::string(module) + "::" + call;
     const std::string payload =
-        fmt::format("{:<5} [{:<4}] {:<46} args: {:<38} ret: {}", levelStr(lvl),
+        fmt::format("{} [{:<4}] {:<46} args: {:<38} ret: {}", levelStr(lvl),
                     t_threadName, modcall, args.empty() ? std::string("-") : args, ret);
     g_logger->log(toSpd(lvl), payload);
 }
@@ -197,7 +197,7 @@ void emitTrace(const char* module, const char* call,
     // is an mpmc_blocking_queue, so the enqueue takes a short mutex — Trace is a
     // diagnostic aid that may perturb the audio thread slightly (see spec).
     const char* sym = hrNameC(hr);
-    g_logger->trace("TRACE [{:<4}] {}::{} frames={} flags={:#x} hr={:#010x} {}",
+    g_logger->trace("[T] [{:<4}] {}::{} frames={} flags={:#x} hr={:#010x} {}",
                     t_threadName, module, call, frames, flags,
                     static_cast<unsigned long>(hr), sym ? sym : "");
 }

--- a/src/core/StreamParams.h
+++ b/src/core/StreamParams.h
@@ -2,26 +2,28 @@
 #include <cstdint>
 namespace wa {
 
-// Advanced WASAPI stream parameters. ALL defaults mean "follow system": when a field is
-// Default/0 the corresponding Windows call is NOT made at all, so StreamParams{} keeps the
-// open path byte-for-byte identical to the pre-StreamParams behavior.
-enum class AudioCategory : uint8_t { Default, Other, Communications, Media, Movie,
+// Advanced WASAPI stream parameters. SetClientProperties is all-or-nothing:
+// when clientProperties.enabled is false the call is skipped; when it is true
+// every AudioClientProperties field is populated from this struct.
+enum class AudioCategory : uint8_t { Other, Communications, Media, Movie,
                                      GameChat, Speech, SoundEffects, GameMedia };
-enum class StreamOption  : uint8_t { Default, Raw, MatchFormat };  // AUDCLNT_STREAMOPTIONS
-enum class OffloadMode   : uint8_t { Default, Force };             // render-only
+enum class StreamOption  : uint8_t { None, Raw, MatchFormat, Ambisonics,
+                                     PostVolumeLoopback };          // AUDCLNT_STREAMOPTIONS
 enum class DuckingMode   : uint8_t { Default, OptOut };            // render-only
 
-struct StreamParams {
-    AudioCategory category = AudioCategory::Default;  // Default = no SetClientProperties
-    StreamOption  option   = StreamOption::Default;
-    OffloadMode   offload  = OffloadMode::Default;
-    DuckingMode   ducking  = DuckingMode::Default;
-    uint32_t      bufferMs = 0;                       // 0 = current behavior (Shared 100 ms / Excl minPer)
+struct ClientProperties {
+    bool          enabled  = false;                          // false = do not call SetClientProperties
+    AudioCategory category = AudioCategory::Communications;   // AudioClientProperties::eCategory
+    bool          offload  = false;                          // AudioClientProperties::bIsOffload
+    StreamOption  option   = StreamOption::None;             // AudioClientProperties::Options
+};
 
-    bool anyClientProps() const {   // category/option/offload need IAudioClient2::SetClientProperties
-        return category != AudioCategory::Default || option != StreamOption::Default
-            || offload  != OffloadMode::Default;
-    }
+struct StreamParams {
+    ClientProperties clientProperties{};
+    DuckingMode      ducking  = DuckingMode::Default;
+    uint32_t         bufferMs = 0;                    // 0 = current behavior (Shared 100 ms / Excl minPer)
+
+    bool anyClientProps() const { return clientProperties.enabled; }
     bool isDefault() const {
         return !anyClientProps() && ducking == DuckingMode::Default && bufferMs == 0;
     }

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -19,17 +19,18 @@ AUDIO_STREAM_CATEGORY mapCategory(AudioCategory c) {
     case AudioCategory::SoundEffects:   return AudioCategory_SoundEffects;
     case AudioCategory::GameMedia:      return AudioCategory_GameMedia;
     case AudioCategory::Other:
-    case AudioCategory::Default:
     default:                            return AudioCategory_Other;
     }
 }
 
 AUDCLNT_STREAMOPTIONS mapStreamOption(StreamOption o) {
     switch (o) {
-    case StreamOption::Raw:         return AUDCLNT_STREAMOPTIONS_RAW;
-    case StreamOption::MatchFormat: return AUDCLNT_STREAMOPTIONS_MATCH_FORMAT;
-    case StreamOption::Default:
-    default:                        return AUDCLNT_STREAMOPTIONS_NONE;
+    case StreamOption::Raw:                return AUDCLNT_STREAMOPTIONS_RAW;
+    case StreamOption::MatchFormat:        return AUDCLNT_STREAMOPTIONS_MATCH_FORMAT;
+    case StreamOption::Ambisonics:         return AUDCLNT_STREAMOPTIONS_AMBISONICS;
+    case StreamOption::PostVolumeLoopback: return AUDCLNT_STREAMOPTIONS_POST_VOLUME_LOOPBACK;
+    case StreamOption::None:
+    default:                               return AUDCLNT_STREAMOPTIONS_NONE;
     }
 }
 
@@ -147,8 +148,9 @@ Result WasapiStream::applyClientProperties() {
         return HrToResult(FAILED(hr) ? hr : E_NOINTERFACE,
                           "WasapiStream: IAudioClient2 unavailable; cannot apply advanced stream params");
     }
-    const AUDIO_STREAM_CATEGORY cat = mapCategory(params_.category);
-    if (params_.offload == OffloadMode::Force) {
+    const ClientProperties& cp = params_.clientProperties;
+    const AUDIO_STREAM_CATEGORY cat = mapCategory(cp.category);
+    if (cp.offload) {
         BOOL capable = FALSE;
         hr = client2->IsOffloadCapable(cat, &capable);
         WA_LOG(wa::log::Level::Debug, "WasapiStream", "IsOffloadCapable", "", wa::log::hrName(hr));
@@ -158,9 +160,9 @@ Result WasapiStream::applyClientProperties() {
     }
     AudioClientProperties p{};
     p.cbSize     = sizeof(p);
-    p.bIsOffload = (params_.offload == OffloadMode::Force) ? TRUE : FALSE;
+    p.bIsOffload = cp.offload ? TRUE : FALSE;
     p.eCategory  = cat;
-    p.Options    = mapStreamOption(params_.option);
+    p.Options    = mapStreamOption(cp.option);
     hr = client2->SetClientProperties(&p);
     WA_LOG(wa::log::Level::Debug, "WasapiStream", "SetClientProperties", "", wa::log::hrName(hr));
     if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "SetClientProperties", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: SetClientProperties"); }

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -747,28 +747,35 @@ void AppUi::drawLogPanel(const char* childId, bool showLevelFilter) {
 void AppUi::drawAdvancedModal() {
     if (!ImGui::BeginPopupModal("Audio parameters (advanced)", nullptr,
                                 ImGuiWindowFlags_AlwaysAutoResize)) return;
-    ImGui::TextWrapped("All values default to system-recommended (no override is injected unless "
-                       "you change them). Category/option/offload/ducking require WASAPI-Shared; "
-                       "only Buffer applies to Exclusive. Offload and ducking are render-only "
-                       "(WASAPI has no capture offload).");
+    ImGui::TextWrapped("%s", wa::ui_text::kAdvancedOptionsHelp);
     if (monitorStarted_)
         ImGui::TextColored(ImVec4(1.00f, 0.80f, 0.30f, 1.00f),
                            "Running: parameters are read-only. Stop the monitor to change them.");
     ImGui::Separator();
-    static const char* kCats[] = {"System default", "Other", "Communications", "Media", "Movie",
+    static const char* kCats[] = {"Other", "Communications", "Media", "Movie",
                                   "Game chat", "Speech", "Sound effects", "Game media"};
-    static const char* kOpts[] = {"System default", "Raw (bypass APO)", "Match format"};
 
     ImGui::BeginDisabled(monitorStarted_);              // view-only while running
 
     ImGui::BeginGroup();                              // ---- Capture column
-    ImGui::SeparatorText("Capture");
+    ImGui::SeparatorText(wa::ui_text::kAdvancedCaptureSection);
     ImGui::PushID("capP");
     ImGui::PushItemWidth(190);
-    int v = (int)capParams_.category;
-    if (ImGui::Combo("Category", &v, kCats, 9)) capParams_.category = (wa::AudioCategory)v;
-    v = (int)capParams_.option;
-    if (ImGui::Combo("Stream option", &v, kOpts, 3)) capParams_.option = (wa::StreamOption)v;
+    bool capProps = capParams_.clientProperties.enabled;
+    if (ImGui::Checkbox(wa::ui_text::kAdvancedSetClientProperties, &capProps))
+        capParams_.clientProperties.enabled = capProps;
+    ImGui::BeginDisabled(!capParams_.clientProperties.enabled);
+    int v = (int)capParams_.clientProperties.category;
+    if (ImGui::Combo("Category", &v, kCats, IM_ARRAYSIZE(kCats)))
+        capParams_.clientProperties.category = (wa::AudioCategory)v;
+    bool capOff = capParams_.clientProperties.offload;
+    if (ImGui::Checkbox(wa::ui_text::kAdvancedHardwareOffload, &capOff))
+        capParams_.clientProperties.offload = capOff;
+    v = (int)capParams_.clientProperties.option;
+    if (ImGui::Combo("Stream option", &v, wa::ui_text::kAdvancedStreamOptions,
+                     wa::ui_text::kAdvancedStreamOptionCount))
+        capParams_.clientProperties.option = (wa::StreamOption)v;
+    ImGui::EndDisabled();
     v = (int)capParams_.bufferMs;
     if (ImGui::InputInt("Buffer (ms)", &v)) capParams_.bufferMs = (uint32_t)std::clamp(v, 0, 2000);
     if (ImGui::Button("Reset to system defaults")) capParams_ = wa::StreamParams{};
@@ -779,17 +786,26 @@ void AppUi::drawAdvancedModal() {
     ImGui::SameLine(0, 24);
 
     ImGui::BeginGroup();                              // ---- Render column
-    ImGui::SeparatorText("Render");
+    ImGui::SeparatorText(wa::ui_text::kAdvancedRenderSection);
     ImGui::PushID("renP");
     ImGui::PushItemWidth(190);
-    v = (int)renParams_.category;
-    if (ImGui::Combo("Category", &v, kCats, 9)) renParams_.category = (wa::AudioCategory)v;
-    v = (int)renParams_.option;
-    if (ImGui::Combo("Stream option", &v, kOpts, 3)) renParams_.option = (wa::StreamOption)v;
-    bool off = renParams_.offload == wa::OffloadMode::Force;
-    if (ImGui::Checkbox("Hardware offload", &off)) renParams_.offload = off ? wa::OffloadMode::Force : wa::OffloadMode::Default;
+    bool renProps = renParams_.clientProperties.enabled;
+    if (ImGui::Checkbox(wa::ui_text::kAdvancedSetClientProperties, &renProps))
+        renParams_.clientProperties.enabled = renProps;
+    ImGui::BeginDisabled(!renParams_.clientProperties.enabled);
+    v = (int)renParams_.clientProperties.category;
+    if (ImGui::Combo("Category", &v, kCats, IM_ARRAYSIZE(kCats)))
+        renParams_.clientProperties.category = (wa::AudioCategory)v;
+    bool off = renParams_.clientProperties.offload;
+    if (ImGui::Checkbox(wa::ui_text::kAdvancedHardwareOffload, &off))
+        renParams_.clientProperties.offload = off;
+    v = (int)renParams_.clientProperties.option;
+    if (ImGui::Combo("Stream option", &v, wa::ui_text::kAdvancedStreamOptions,
+                     wa::ui_text::kAdvancedStreamOptionCount))
+        renParams_.clientProperties.option = (wa::StreamOption)v;
+    ImGui::EndDisabled();
     bool duck = renParams_.ducking == wa::DuckingMode::OptOut;
-    if (ImGui::Checkbox("Ducking opt-out", &duck)) renParams_.ducking = duck ? wa::DuckingMode::OptOut : wa::DuckingMode::Default;
+    if (ImGui::Checkbox(wa::ui_text::kAdvancedDuckingOptOut, &duck)) renParams_.ducking = duck ? wa::DuckingMode::OptOut : wa::DuckingMode::Default;
     v = (int)renParams_.bufferMs;
     if (ImGui::InputInt("Buffer (ms)", &v)) renParams_.bufferMs = (uint32_t)std::clamp(v, 0, 2000);
     if (ImGui::Button("Reset to system defaults")) renParams_ = wa::StreamParams{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -7,4 +7,25 @@ inline constexpr const char* kApplicationLoopbackRefresh = "Refresh";
 inline constexpr const char* kApplicationLoopbackPidLabel = "PID";
 inline constexpr const char* kApplicationLoopbackSessions = "Sessions";
 
+inline constexpr const char* kAdvancedOptionsHelp =
+    "Client properties are sent only when enabled for that side. When enabled, "
+    "category defaults to Communications, offload defaults to false, and "
+    "stream option defaults to None. Client properties require WASAPI-Shared; "
+    "only Buffer applies to Exclusive. Ducking is render-only.";
+inline constexpr const char* kAdvancedCaptureSection = "Capture";
+inline constexpr const char* kAdvancedRenderSection = "Render";
+inline constexpr const char* kAdvancedSetClientProperties = "Set client properties";
+inline constexpr bool kAdvancedSetClientPropertiesDefault = false;
+inline constexpr const char* kAdvancedHardwareOffload = "Hardware offload";
+inline constexpr const char* kAdvancedStreamOptions[] = {
+    "None",
+    "Raw (bypass APO)",
+    "Match format",
+    "Ambisonics",
+    "Post-volume loopback",
+};
+inline constexpr int kAdvancedStreamOptionCount =
+    static_cast<int>(sizeof(kAdvancedStreamOptions) / sizeof(kAdvancedStreamOptions[0]));
+inline constexpr const char* kAdvancedDuckingOptOut = "Ducking opt-out";
+
 } // namespace wa::ui_text

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <string>
 #include <vector>
 #include "AudioSessionEnumerator.h"
 #include "ApplicationLoopbackUiModel.h"
@@ -67,6 +68,19 @@ TEST(AppLoopbackUiText, ExposesRequiredControls) {
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackRefresh, "Refresh");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackPidLabel, "PID");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackSessions, "Sessions");
+}
+
+TEST(AdvancedOptionsUiText, ExposesExplicitClientPropertiesControls) {
+    EXPECT_STREQ(wa::ui_text::kAdvancedCaptureSection, "Capture");
+    EXPECT_STREQ(wa::ui_text::kAdvancedRenderSection, "Render");
+    EXPECT_STREQ(wa::ui_text::kAdvancedSetClientProperties, "Set client properties");
+    EXPECT_FALSE(wa::ui_text::kAdvancedSetClientPropertiesDefault);
+    EXPECT_STREQ(wa::ui_text::kAdvancedHardwareOffload, "Hardware offload");
+    EXPECT_EQ(wa::ui_text::kAdvancedStreamOptionCount, 5);
+    EXPECT_STREQ(wa::ui_text::kAdvancedStreamOptions[0], "None");
+    EXPECT_STREQ(wa::ui_text::kAdvancedStreamOptions[4], "Post-volume loopback");
+    EXPECT_NE(std::string(wa::ui_text::kAdvancedOptionsHelp).find("only when enabled"),
+              std::string::npos);
 }
 
 TEST(AppLoopbackUiModel, SelectingRowCopiesPidIntoEditableBuffer) {

--- a/src/tests/test_log.cpp
+++ b/src/tests/test_log.cpp
@@ -55,3 +55,30 @@ TEST(Log, LevelFilterAndSinkDelivery) {
     EXPECT_EQ(got.size(), 2u);
     for (log::Level lv : got) EXPECT_NE(lv, log::Level::Debug);
 }
+
+TEST(Log, FormatsLevelAsShortMarker) {
+    std::mutex m;
+    std::vector<std::string> lines;
+    log::init();
+    log::setThreadName("test");
+    log::addCallbackSink([&](log::Level, const std::string& line) {
+        std::lock_guard<std::mutex> lk(m);
+        lines.push_back(line);
+    });
+    log::setLevel(log::Level::Info);
+    log::emit(log::Level::Info, "T", "inf", "", "");
+    log::emit(log::Level::Warn, "T", "warn", "", "");
+    log::emit(log::Level::Err, "T", "err", "", "");
+    log::shutdown();
+
+    std::lock_guard<std::mutex> lk(m);
+    ASSERT_EQ(lines.size(), 3u);
+    EXPECT_NE(lines[0].find("[I]"), std::string::npos);
+    EXPECT_NE(lines[1].find("[W]"), std::string::npos);
+    EXPECT_NE(lines[2].find("[E]"), std::string::npos);
+    for (const auto& line : lines) {
+        EXPECT_EQ(line.find("INFO"), std::string::npos);
+        EXPECT_EQ(line.find("WARN"), std::string::npos);
+        EXPECT_EQ(line.find("ERROR"), std::string::npos);
+    }
+}

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -443,13 +443,23 @@ TEST(MonitorEngine, StreamParamsReachBackends) {
     FakeRig rig;
     MonitorEngine eng(rig.factory());
     StreamParams cap; cap.bufferMs = 30;
-    StreamParams ren; ren.category = AudioCategory::Media; ren.ducking = DuckingMode::OptOut;
+    cap.clientProperties.enabled = true;
+    cap.clientProperties.category = AudioCategory::Speech;
+    cap.clientProperties.offload = true;
+    cap.clientProperties.option = StreamOption::Ambisonics;
+    StreamParams ren; ren.clientProperties.enabled = true;
+    ren.clientProperties.category = AudioCategory::Media;
+    ren.ducking = DuckingMode::OptOut;
     ASSERT_TRUE(eng.start(BackendKind::WasapiShared, L"", L"", 100, true, cap, ren));
     ASSERT_NE(rig.capPtr, nullptr);
     ASSERT_NE(rig.renderPtr, nullptr);
     EXPECT_EQ(rig.capPtr->lastOpenParams_.bufferMs, 30u);
-    EXPECT_EQ(rig.capPtr->lastOpenParams_.category, AudioCategory::Default);
-    EXPECT_EQ(rig.renderPtr->lastOpenParams_.category, AudioCategory::Media);
+    EXPECT_TRUE(rig.capPtr->lastOpenParams_.clientProperties.enabled);
+    EXPECT_EQ(rig.capPtr->lastOpenParams_.clientProperties.category, AudioCategory::Speech);
+    EXPECT_TRUE(rig.capPtr->lastOpenParams_.clientProperties.offload);
+    EXPECT_EQ(rig.capPtr->lastOpenParams_.clientProperties.option, StreamOption::Ambisonics);
+    EXPECT_TRUE(rig.renderPtr->lastOpenParams_.clientProperties.enabled);
+    EXPECT_EQ(rig.renderPtr->lastOpenParams_.clientProperties.category, AudioCategory::Media);
     EXPECT_EQ(rig.renderPtr->lastOpenParams_.ducking,  DuckingMode::OptOut);
     eng.stop();
 }
@@ -459,9 +469,10 @@ TEST(MonitorEngine, SetRenderParamsAppliesOnReengage) {
     MonitorEngine eng(rig.factory());
     ASSERT_TRUE(eng.start(BackendKind::WasapiShared, L"", L"", 100, true));   // params 全默认
     ASSERT_NE(rig.renderPtr, nullptr);
-    EXPECT_EQ(rig.renderPtr->lastOpenParams_.option, StreamOption::Default);
+    EXPECT_FALSE(rig.renderPtr->lastOpenParams_.clientProperties.enabled);
 
-    StreamParams np; np.option = StreamOption::Raw; np.bufferMs = 20;
+    StreamParams np; np.clientProperties.enabled = true;
+    np.clientProperties.option = StreamOption::Raw; np.bufferMs = 20;
     eng.setRenderParams(np);                    // 运行中改参数
     eng.setPlaybackEnabled(false);              // 关播放(disengage)
     // 等 pump 完成 disengage
@@ -473,7 +484,8 @@ TEST(MonitorEngine, SetRenderParamsAppliesOnReengage) {
     // in the factory — safer than the relaxed renderState_ store used by poll()).
     ASSERT_TRUE(waitFor([&]{ return rig.renderOpenDone.load(std::memory_order_acquire) >= 2; }))
         << "pump did not complete re-engage open within timeout";
-    EXPECT_EQ(rig.renderPtr->lastOpenParams_.option,   StreamOption::Raw);
+    EXPECT_TRUE(rig.renderPtr->lastOpenParams_.clientProperties.enabled);
+    EXPECT_EQ(rig.renderPtr->lastOpenParams_.clientProperties.option, StreamOption::Raw);
     EXPECT_EQ(rig.renderPtr->lastOpenParams_.bufferMs, 20u);
     eng.stop();
 }

--- a/src/tests/test_streamparams.cpp
+++ b/src/tests/test_streamparams.cpp
@@ -5,18 +5,25 @@ using namespace wa;
 
 TEST(StreamParams, DefaultIsAllDefault) {
     StreamParams p;
+    EXPECT_FALSE(p.clientProperties.enabled);
+    EXPECT_EQ(p.clientProperties.category, AudioCategory::Communications);
+    EXPECT_FALSE(p.clientProperties.offload);
+    EXPECT_EQ(p.clientProperties.option, StreamOption::None);
+    EXPECT_EQ(p.ducking, DuckingMode::Default);
     EXPECT_TRUE(p.isDefault());
     EXPECT_FALSE(p.anyClientProps());
     EXPECT_EQ(p.bufferMs, 0u);
 }
 
 TEST(StreamParams, Predicates) {
-    StreamParams a; a.category = AudioCategory::Communications;
+    StreamParams a; a.clientProperties.enabled = true;
     EXPECT_TRUE(a.anyClientProps()); EXPECT_FALSE(a.isDefault());
-    StreamParams b; b.option = StreamOption::Raw;
-    EXPECT_TRUE(b.anyClientProps()); EXPECT_FALSE(b.isDefault());
-    StreamParams c; c.offload = OffloadMode::Force;
-    EXPECT_TRUE(c.anyClientProps()); EXPECT_FALSE(c.isDefault());
+
+    StreamParams b; b.clientProperties.category = AudioCategory::Media;
+    b.clientProperties.option = StreamOption::Raw;
+    b.clientProperties.offload = true;
+    EXPECT_FALSE(b.anyClientProps()); EXPECT_TRUE(b.isDefault());
+
     StreamParams d; d.ducking = DuckingMode::OptOut;      // ducking 不属于 client-props
     EXPECT_FALSE(d.anyClientProps()); EXPECT_FALSE(d.isDefault());
     StreamParams e; e.bufferMs = 50;                       // bufferMs 也不属于
@@ -32,19 +39,22 @@ TEST(StreamParams, CategoryMapping) {
     EXPECT_EQ(mapCategory(AudioCategory::Speech),         AudioCategory_Speech);
     EXPECT_EQ(mapCategory(AudioCategory::SoundEffects),   AudioCategory_SoundEffects);
     EXPECT_EQ(mapCategory(AudioCategory::GameMedia),      AudioCategory_GameMedia);
-    EXPECT_EQ(mapCategory(AudioCategory::Default),        AudioCategory_Other); // placeholder when props set w/o category
 }
 
 TEST(StreamParams, OptionMapping) {
-    EXPECT_EQ(mapStreamOption(StreamOption::Default),     AUDCLNT_STREAMOPTIONS_NONE);
+    EXPECT_EQ(mapStreamOption(StreamOption::None),        AUDCLNT_STREAMOPTIONS_NONE);
     EXPECT_EQ(mapStreamOption(StreamOption::Raw),         AUDCLNT_STREAMOPTIONS_RAW);
     EXPECT_EQ(mapStreamOption(StreamOption::MatchFormat), AUDCLNT_STREAMOPTIONS_MATCH_FORMAT);
+    EXPECT_EQ(mapStreamOption(StreamOption::Ambisonics),  AUDCLNT_STREAMOPTIONS_AMBISONICS);
+    EXPECT_EQ(mapStreamOption(StreamOption::PostVolumeLoopback),
+              AUDCLNT_STREAMOPTIONS_POST_VOLUME_LOOPBACK);
 }
 
 TEST(StreamParams, ExclusiveRejectsAdvancedParams) {
     // open() validates synchronously (no hardware touched: activation is deferred to start()).
     WasapiCaptureStream s(WasapiMode::Exclusive, nullptr);
-    StreamParams raw; raw.option = StreamOption::Raw;
+    StreamParams raw; raw.clientProperties.enabled = true;
+    raw.clientProperties.option = StreamOption::Raw;
     EXPECT_FALSE(s.open(L"", AudioFormat{}, nullptr, raw));
     StreamParams duck; duck.ducking = DuckingMode::OptOut;
     EXPECT_FALSE(s.open(L"", AudioFormat{}, nullptr, duck));


### PR DESCRIPTION
## Summary
- Shorten log level markers to compact `[I]`/`[W]`/`[E]` style output.
- Gate WASAPI client property calls behind explicit capture/render switches and cover the full stream option set used by AudioClientProperties.
- Add repository guidance, PR template, README, and the application loopback implementation plan docs.

## Test Plan
- `cmake --build build --config Debug --target WinAudioTests WinAudioGui -j`
- `./build/bin/Debug/WinAudioTests.exe` (116/116 passed)
- `git diff --check origin/main..HEAD`