### PR TITLE
Allow manual release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ['v*']          # e.g. v0.1.0, v1.2.3
+  workflow_dispatch:
+    inputs:
+      package_suffix:
+        description: Zip filename suffix for manual packages
+        required: false
+        default: manual
 
 permissions:
   contents: write         # create the GitHub Release + upload assets
@@ -27,9 +33,26 @@ jobs:
         run: ctest --test-dir build -C Release --output-on-failure
 
       - name: Package
-        run: Compress-Archive -Path build/bin/Release/WinAudioGui.exe, build/bin/Release/WinAudioCli.exe -DestinationPath "WinAudio-${{ github.ref_name }}-win-x64.zip"
+        env:
+          PACKAGE_SUFFIX: ${{ github.event.inputs.package_suffix || github.ref_name }}
+        run: |
+          $suffix = $env:PACKAGE_SUFFIX
+          if ([string]::IsNullOrWhiteSpace($suffix)) {
+            $suffix = "${{ github.ref_name }}"
+          }
+          $safeSuffix = $suffix -replace '[^A-Za-z0-9._-]', '-'
+          Compress-Archive -Path build/bin/Release/WinAudioGui.exe, build/bin/Release/WinAudioCli.exe -DestinationPath "WinAudio-$safeSuffix-win-x64.zip"
+
+      - name: Upload manual package
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: WinAudio-manual-win-x64
+          path: WinAudio-*-win-x64.zip
+          if-no-files-found: error
 
       - name: Create GitHub Release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
           files: WinAudio-*-win-x64.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ capture source（endpoint | system loopback | application loopback(PID)）
 ## 测试与 CI
 
 - CI（`.github/workflows/ci.yml`）：push / PR 到 `main`，Debug + Release 双配置 build + ctest。**runner 必须 pin `windows-2022`**（`windows-latest` 已预装 VS 2026，`Visual Studio 17 2022` generator 找不到工具链）；checkout 必须 `submodules: recursive`。
-- 发布：推 `v*` tag → `release.yml` 构建、打包 zip、创建 GitHub Release。
+- 发布/打包：推 `v*` tag → `release.yml` 构建、打包 zip、创建 GitHub Release；也可在 GitHub Actions 页面手动触发 `Release` workflow，手动运行只上传 zip artifact，不创建正式 GitHub Release。
 - 涉及真实设备的行为（延迟、漂移、独占格式协商）单测覆盖不到，相关改动合并前需人工冒烟（CLI `monitor` 或 GUI）。
 
 ## Commit 与 PR 规范

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [-
 ## 开发
 
 - 开发者指南（构建细节、架构、编码约束）见 [CLAUDE.md](CLAUDE.md)；历次功能的设计文档在 `docs/superpowers/specs/`，实施计划在 `docs/superpowers/plans/`。
-- CI：push / PR 到 `main` 自动以 Debug + Release 双配置构建并跑测试；推送 `v*` tag 自动发布 Release。
+- CI：push / PR 到 `main` 自动以 Debug + Release 双配置构建并跑测试；推送 `v*` tag 自动发布 Release；`Release` workflow 也支持在 GitHub Actions 页面手动触发，手动运行会构建 Release、跑测试并上传 zip artifact，不创建正式 GitHub Release。


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the Release workflow so packages can be built manually from GitHub Actions.
- Upload manual packages as workflow artifacts while keeping GitHub Release publishing limited to `v*` tag pushes.
- Document the manual packaging path in README and CLAUDE.md.

## Test Plan
- `git diff --check origin/main..HEAD`
- Inspected `.github/workflows/release.yml` trigger/conditions locally