### PR TITLE
fix(gui): remove nested main window title

### DIFF
--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -354,8 +354,17 @@ void AppUi::draw() {
     }
     prevRenderState_ = curRenderState;
 
-    ImGui::SetNextWindowSizeConstraints(ImVec2(800, 400), ImVec2(FLT_MAX, FLT_MAX));
-    ImGui::Begin("WinAudio");
+    const ImGuiIO& io = ImGui::GetIO();
+    ImGui::SetNextWindowPos(ImVec2(0.0f, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(io.DisplaySize, ImGuiCond_Always);
+
+    constexpr ImGuiWindowFlags kWindowFlags =
+        ImGuiWindowFlags_NoTitleBar |
+        ImGuiWindowFlags_NoCollapse |
+        ImGuiWindowFlags_NoResize |
+        ImGuiWindowFlags_NoMove |
+        ImGuiWindowFlags_NoSavedSettings;
+    ImGui::Begin("WinAudio", nullptr, kWindowFlags);
 
     if (ImGui::BeginTabBar("##pages")) {
         if (ImGui::BeginTabItem("Monitor")) {


### PR DESCRIPTION
## What / Why

Removes the extra nested ImGui `WinAudio` title/collapse bar from the GUI.
The OS window already provides the application frame, so the in-app title bar
was redundant and made the main tabs feel like they were inside a collapsible
group.

## How

The main ImGui window is now pinned to the host client area every frame and
uses no-title/no-collapse/no-resize/no-move/no-saved-settings flags. The
existing Monitor, Loopback, and Application Loopback tabs remain unchanged, and
vertical scrolling behavior is preserved.

## Testing

- `git diff --check` passed.
- `cmake --build build --config Debug --target WinAudioGui WinAudioTests -j` passed.
- `ctest --test-dir build -C Debug --output-on-failure` passed: 116/116 tests.
- Manual GUI smoke: launched `build\\bin\\Debug\\WinAudioGui.exe`, captured a local screenshot at `C:\\Users\\admin\\AppData\\Local\\Temp\\winaudio-pr-gui-container-check.png`, and confirmed the internal `WinAudio` collapse/title bar is gone while the page tabs remain at the top.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [ ] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices (not applicable; GUI container-only change)
- [x] GUI changes: screenshot captured locally and smoke result stated above
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above (not applicable; no audio behavior changed)
