### PR TITLE
feat(loopback): Application Loopback include/exclude process tree modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ cmake --build build-x86 --config Release -j
 数据流主线（多数改动落在这条链上）：
 
 ```
-capture source（endpoint | system loopback | application loopback(PID)）
+capture source（endpoint | system loopback | application loopback(PID + ProcessLoopbackMode)）
   ├─ Engine：单流。采集→WAV / WAV→render 播放 / probeFormat 格式探测
   └─ MonitorEngine：双流直通。capture → DelayFifo（固定延迟+漂移补偿）→ render
                     ├─ ScopeBuffer tap ×2（cap 保留实际 channel 快照，ren 为 mono tap）
@@ -43,7 +43,7 @@ capture source（endpoint | system loopback | application loopback(PID)）
 ```
 
 - **分层**：前端把 `BackendKind`（`WasapiShared` / `WasapiExclusive`）传给 Engine/MonitorEngine，同一上层流程可切后端做对比测试；流生命周期统一为 open → start → poll → stop → close（`IAudioBackend.h`）。
-- **`src/core/WasapiStream.{h,cpp}` 是 WASAPI 心脏**：基类做模式感知格式协商（Shared = `GetMixFormat` + `AUTOCONVERTPCM`；Exclusive = `IsFormatSupported` + `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` 对齐重试）、事件驱动线程模型、同步启动握手；派生出 capture / render / system-loopback / silent-render 各流。按 PID 的 process loopback 在 `ApplicationLoopbackCapture.*`（Shared-only）。
+- **`src/core/WasapiStream.{h,cpp}` 是 WASAPI 心脏**：基类做模式感知格式协商（Shared = `GetMixFormat` + `AUTOCONVERTPCM`；Exclusive = `IsFormatSupported` + `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` 对齐重试）、事件驱动线程模型、同步启动握手；派生出 capture / render / system-loopback / silent-render 各流。按 PID 的 process loopback 在 `ApplicationLoopbackCapture.*`（Shared-only）：`CaptureSource::processLoopbackMode` 为 `IncludeTree`（默认）或 `ExcludeTree`，激活时映射 Win32 `PROCESS_LOOPBACK_MODE_*_TARGET_PROCESS_TREE`；GUI Application Loopback tab 用 Exclude checkbox 选择（运行中不可改）。
 - **跨线程原语**（音频线程 ↔ GUI/控制线程的唯一通道）：`RingBuffer`（SPSC + xrun 计数）、`ScopeBuffer`（seqlock 快照，读不阻塞写；capture 可按 channel snapshot，legacy snapshot 仍返回 mono/downmix）、`DelayFifo`（单帧丢/插 + crossfade）、`Analysis`（采样计数节拍触发 FFT）。
 - **GUI**：逻辑集中在 `src/gui/AppUi.*`；用户可见文案集中在 `AppUiText.h`（有对应文案测试）；`Spectrogram.*` 纯 STL、可脱离 GUI 单测。ImGui / ImPlot / googletest 是 `third_party/` 内的 vendored 副本；spdlog 是唯一 git submodule。
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **WASAPI 双后端**：Shared（共享模式）与 Exclusive（独占模式、低延迟），同一流程可切换后端做对比测试。
 - **采集 / 播放**：采集落盘 WAV，播放标准 RIFF WAV；可用 `--format` 指定目标格式（Shared 经 WASAPI 引擎 `AUTOCONVERTPCM` 转换；Exclusive 要求硬件原生支持）。
 - **系统 loopback**：以 render endpoint 为采集源回采系统输出，可选静音 render keepalive 保持时钟推进。
-- **Application Loopback**：按 PID 回采指定进程及其子进程树的音频（Shared-only；需要 Windows 10 build 20348 及以上）。
+- **Application Loopback**：按 PID 做 WASAPI process loopback（Shared-only；Windows 10 build 20348+）。默认 **IncludeTree**（只采目标进程及其子进程树）；可选 **ExcludeTree**（采 process-loopback 混音中除该进程树以外的部分）。
 - **双流延迟监听**：capture → 固定延迟 FIFO（漂移补偿）→ render 实时直通，显示 fifo 水位 / drift / xrun。
 - **设备能力查询**：Mix / Device / OEM 三来源格式 + 候选格式在 Shared/Exclusive 下的支持矩阵。
 - **格式探测**：检测设备是否支持指定格式（shared 反映 WASAPI 混音器转换能力，exclusive 反映硬件独占可用性）。
@@ -65,7 +65,18 @@ cd winaudio
 
 ### Application Loopback（按进程回采）
 
-打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举；点击列表行会把 PID 填入下方输入框，也可手动输入任意非零 PID（不要求出现在列表中）。Start 后以 WASAPI process loopback（Shared）采集该进程及其子进程的音频；实际 2ch+ 时按 `Ch N` 分开显示采集到的前 8 个 channel。
+打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举；点击列表行会把 PID 填入下方输入框，也可手动输入任意非零 PID（不要求出现在列表中）。
+
+Control 区同一行：**PID** 输入 + **Exclude** checkbox（默认未勾选）。
+
+| 模式 | UI | Status / 日志 | 语义（Windows process tree） |
+|------|----|---------------|------------------------------|
+| **IncludeTree**（默认） | Exclude 未勾 | `mode=IncludeTree` | 只采集目标 PID 及其**子进程树**的音频 |
+| **ExcludeTree** | 勾选 Exclude | `mode=ExcludeTree` | 采集 process-loopback 混音中**除**该进程树以外的部分 |
+
+Start 后以 WASAPI process loopback（Shared）按上表模式开流；Starting / Running 时 PID 与 Exclude 一并禁用，改 mode 需先 Stop 再 Start。实际 2ch+ 时按 `Ch N` 分开显示采集到的前 8 个 channel。
+
+不支持：多 PID 列表、运行中热切换 mode、CLI 入口（仅 GUI）。
 
 ## CLI 使用
 
@@ -144,6 +155,7 @@ WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [-
 - **漂移补偿为单帧丢/插 + crossfade**：跨时钟域设备组合（如 USB 麦克风 + HDMI 输出）漂移率高；同接口 loopback 漂移很小。
 - GUI 采集侧 waveform / spectrogram 对实际 2ch+ 格式按 `Ch N` 分开显示，最多显示前 8 个 channel；播放端可视化与电平指示仍为单声道降混。
 - 系统 loopback 与 Application Loopback 仅支持 Shared 后端。
+- Application Loopback 的 Exclude 作用于**整个目标进程树**（含子进程），不是任意多 PID 过滤；与 System Loopback tab 路径不同，对比时请按实际听感理解。
 - waveIn / waveOut（MME 后端）未实现。
 
 ## 开发

--- a/docs/gui-screenshots.md
+++ b/docs/gui-screenshots.md
@@ -16,6 +16,6 @@
 
 ## Application Loopback
 
-Application Loopback 模式按 PID 捕获指定进程及其子进程树的音频。
+Application Loopback 按 PID 做 process loopback：默认 IncludeTree（目标进程树），可选 Exclude（ExcludeTree，混音去掉该进程树）。详见 README Application Loopback 小节。
 
 ![Application Loopback running](images/winaudio-application-loopback-running.png)

--- a/src/core/ApplicationLoopbackCapture.cpp
+++ b/src/core/ApplicationLoopbackCapture.cpp
@@ -59,7 +59,8 @@ private:
     Microsoft::WRL::ComPtr<IUnknown> activated_;
 };
 
-Result activateProcessLoopbackClient(uint32_t processId, ComPtr<IAudioClient>& client) {
+Result activateProcessLoopbackClient(uint32_t processId, ProcessLoopbackMode processLoopbackMode,
+                                     ComPtr<IAudioClient>& client) {
 #if WA_HAS_AUDIOCLIENT_ACTIVATION_PARAMS && defined(VIRTUAL_AUDIO_DEVICE_PROCESS_LOOPBACK)
     auto done = std::make_shared<ActivationEvent>();
     if (!done->handle) {
@@ -71,7 +72,14 @@ Result activateProcessLoopbackClient(uint32_t processId, ComPtr<IAudioClient>& c
     activationParams.ActivationType = AUDIOCLIENT_ACTIVATION_TYPE_PROCESS_LOOPBACK;
     activationParams.ProcessLoopbackParams.TargetProcessId = processId;
     activationParams.ProcessLoopbackParams.ProcessLoopbackMode =
-        PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE;
+        (processLoopbackMode == ProcessLoopbackMode::ExcludeTree)
+            ? PROCESS_LOOPBACK_MODE_EXCLUDE_TARGET_PROCESS_TREE
+            : PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE;
+
+    WA_LOG(wa::log::Level::Debug, "ApplicationLoopbackCaptureStream", "activate",
+           "pid=" + std::to_string(processId) +
+               " mode=" + processLoopbackModeName(processLoopbackMode),
+           "");
 
     PROPVARIANT prop{};
     prop.vt = VT_BLOB;
@@ -106,6 +114,7 @@ Result activateProcessLoopbackClient(uint32_t processId, ComPtr<IAudioClient>& c
     return Result::Ok();
 #else
     (void)processId;
+    (void)processLoopbackMode;
     (void)client;
     return Result::Fail(-1,
         "ApplicationLoopbackCaptureStream: Application Loopback requires Windows SDK 10.0.20348+");
@@ -115,8 +124,10 @@ Result activateProcessLoopbackClient(uint32_t processId, ComPtr<IAudioClient>& c
 } // namespace
 
 ApplicationLoopbackCaptureStream::ApplicationLoopbackCaptureStream(
-    WasapiMode mode, uint32_t processId, const AudioFormat* requested)
-    : mode_(mode), processId_(processId), hasRequested_(requested != nullptr) {
+    WasapiMode mode, uint32_t processId, const AudioFormat* requested,
+    ProcessLoopbackMode processLoopbackMode)
+    : mode_(mode), processId_(processId), processLoopbackMode_(processLoopbackMode),
+      hasRequested_(requested != nullptr) {
     if (requested) requestedFormat_ = *requested;
 }
 
@@ -220,7 +231,7 @@ void ApplicationLoopbackCaptureStream::signalReady(Result res) {
 }
 
 Result ApplicationLoopbackCaptureStream::activateClient() {
-    return activateProcessLoopbackClient(processId_, client_);
+    return activateProcessLoopbackClient(processId_, processLoopbackMode_, client_);
 }
 
 Result ApplicationLoopbackCaptureStream::initializeClient() {
@@ -291,7 +302,9 @@ void ApplicationLoopbackCaptureStream::threadMain() {
     }
 
     WA_LOG(wa::log::Level::Info, "ApplicationLoopbackCaptureStream", "Start",
-           "pid=" + std::to_string(processId_) + " fmt=" + wa::formatAudio(actualFormat_),
+           "pid=" + std::to_string(processId_) +
+               " mode=" + processLoopbackModeName(processLoopbackMode_) +
+               " fmt=" + wa::formatAudio(actualFormat_),
            "ok");
     signalReady(Result::Ok());
     runLoop();

--- a/src/core/ApplicationLoopbackCapture.h
+++ b/src/core/ApplicationLoopbackCapture.h
@@ -24,7 +24,9 @@ AudioFormat defaultApplicationLoopbackFormat();
 class ApplicationLoopbackCaptureStream : public IAudioBackend {
 public:
     ApplicationLoopbackCaptureStream(WasapiMode mode, uint32_t processId,
-                                     const AudioFormat* requested);
+                                     const AudioFormat* requested,
+                                     ProcessLoopbackMode processLoopbackMode =
+                                         ProcessLoopbackMode::IncludeTree);
     ~ApplicationLoopbackCaptureStream() override;
 
     Result open(const DeviceId& id, const AudioFormat& fmt, RingBuffer* ring,
@@ -45,6 +47,7 @@ private:
 
     WasapiMode mode_;
     uint32_t processId_ = 0;
+    ProcessLoopbackMode processLoopbackMode_ = ProcessLoopbackMode::IncludeTree;
     bool hasRequested_ = false;
     AudioFormat requestedFormat_{};
     StreamParams params_{};

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -18,10 +18,21 @@ enum class CaptureSourceKind {
     ApplicationLoopback,
 };
 
+// ApplicationLoopback only; Endpoint / SystemLoopback ignore this field.
+enum class ProcessLoopbackMode {
+    IncludeTree,
+    ExcludeTree,
+};
+
+inline const char* processLoopbackModeName(ProcessLoopbackMode mode) {
+    return mode == ProcessLoopbackMode::ExcludeTree ? "ExcludeTree" : "IncludeTree";
+}
+
 struct CaptureSource {
     CaptureSourceKind kind = CaptureSourceKind::Endpoint;
     DeviceId deviceId; // Endpoint: capture endpoint; SystemLoopback: render endpoint
     uint32_t processId = 0; // ApplicationLoopback target PID
+    ProcessLoopbackMode processLoopbackMode = ProcessLoopbackMode::IncludeTree;
 };
 
 struct LoopbackOptions {

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -78,8 +78,8 @@ std::unique_ptr<IAudioBackend> MonitorEngine::makeBackend(DataFlow flow, Backend
         if (source && source->kind == CaptureSourceKind::SystemLoopback)
             return std::make_unique<WasapiSystemLoopbackCaptureStream>(mode, requested);
         if (source && source->kind == CaptureSourceKind::ApplicationLoopback)
-            return std::make_unique<ApplicationLoopbackCaptureStream>(mode, source->processId,
-                                                                      requested);
+            return std::make_unique<ApplicationLoopbackCaptureStream>(
+                mode, source->processId, requested, source->processLoopbackMode);
         return std::make_unique<WasapiCaptureStream>(mode, requested);
     }
     return std::make_unique<WasapiRenderStream>(mode, requested);

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -127,17 +127,18 @@ void AppUi::refreshApplicationLoopbackSessions() {
                                             std::move(rows));
 }
 
-void AppUi::beginApplicationLoopbackStart(uint32_t pid) {
+void AppUi::beginApplicationLoopbackStart(uint32_t pid, wa::ProcessLoopbackMode mode) {
     if (appLoopbackStartThread_.joinable())
         appLoopbackStartThread_.join();
 
     auto job = std::make_shared<AppLoopbackStartJob>();
     appLoopbackStartJob_ = job;
     appLoopbackStartPending_ = true;
+    appLoopbackMode_ = mode;
 
-    appLoopbackStartThread_ = std::thread([job, pid] {
+    appLoopbackStartThread_ = std::thread([job, pid, mode] {
         auto engine = std::make_unique<wa::MonitorEngine>();
-        wa::CaptureSource source{wa::CaptureSourceKind::ApplicationLoopback, L"", pid};
+        wa::CaptureSource source{wa::CaptureSourceKind::ApplicationLoopback, L"", pid, mode};
         wa::Result r = engine->start(wa::BackendKind::WasapiShared, source, L"", 0,
                                      false, {}, {}, nullptr, {});
         std::lock_guard<std::mutex> lk(job->mtx);
@@ -620,9 +621,13 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     ImGui::EndChild();
 
     ImGui::SeparatorText("Control");
+    const bool freezeParams = appLoopbackStartPending_ || appLoopbackStarted_;
+    if (freezeParams) ImGui::BeginDisabled();
     ImGui::SetNextItemWidth(-1);
     ImGui::InputText(wa::ui_text::kApplicationLoopbackPidLabel,
                      appLoopbackPid_, sizeof(appLoopbackPid_));
+    ImGui::Checkbox(wa::ui_text::kApplicationLoopbackExclude, &appLoopbackExclude_);
+    if (freezeParams) ImGui::EndDisabled();
 
     const ImVec2 ctrlBtn(120.0f, ImGui::GetFrameHeight() * 1.3f);
     bool startPending = appLoopbackStartPending_;
@@ -636,8 +641,12 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
             if (!wa::parseApplicationLoopbackPid(appLoopbackPid_, pid)) {
                 logLines_.push_back("application loopback error: invalid PID");
             } else {
-                logLines_.push_back("application loopback starting");
-                beginApplicationLoopbackStart(pid);
+                const wa::ProcessLoopbackMode mode = appLoopbackExclude_
+                    ? wa::ProcessLoopbackMode::ExcludeTree
+                    : wa::ProcessLoopbackMode::IncludeTree;
+                logLines_.push_back(std::string("application loopback starting mode=") +
+                                    wa::processLoopbackModeName(mode));
+                beginApplicationLoopbackStart(pid, mode);
             }
         }
     } else {
@@ -654,6 +663,13 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     ImGui::Text("overall=%s  cap=%s  sr=%u",
         ss[(int)appLoopbackMs_.overall], ss[(int)appLoopbackMs_.capState],
         appLoopbackMs_.sampleRate);
+    // Running/pending: mode latched at Start; idle: preview from checkbox.
+    const wa::ProcessLoopbackMode statusMode =
+        freezeParams
+            ? appLoopbackMode_
+            : (appLoopbackExclude_ ? wa::ProcessLoopbackMode::ExcludeTree
+                                   : wa::ProcessLoopbackMode::IncludeTree);
+    ImGui::Text("mode=%s", wa::processLoopbackModeName(statusMode));
     ImGui::Text("xrun=%llu", (unsigned long long)appLoopbackMs_.capXruns);
     ImGui::Text("frames=%llu", (unsigned long long)appLoopbackMs_.capWrittenFrames);
     ImGui::Text("silent-packet=%llu  idle-fill=%llu",

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -623,9 +623,12 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     ImGui::SeparatorText("Control");
     const bool freezeParams = appLoopbackStartPending_ || appLoopbackStarted_;
     if (freezeParams) ImGui::BeginDisabled();
-    ImGui::SetNextItemWidth(-1);
-    ImGui::InputText(wa::ui_text::kApplicationLoopbackPidLabel,
-                     appLoopbackPid_, sizeof(appLoopbackPid_));
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(wa::ui_text::kApplicationLoopbackPidLabel);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(120.0f);
+    ImGui::InputText("##appLoopbackPid", appLoopbackPid_, sizeof(appLoopbackPid_));
+    ImGui::SameLine();
     ImGui::Checkbox(wa::ui_text::kApplicationLoopbackExclude, &appLoopbackExclude_);
     if (freezeParams) ImGui::EndDisabled();
 

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -49,7 +49,7 @@ private:
 
     void refreshMonitorDevices();
     void refreshApplicationLoopbackSessions();
-    void beginApplicationLoopbackStart(uint32_t pid);
+    void beginApplicationLoopbackStart(uint32_t pid, wa::ProcessLoopbackMode mode);
     void drainApplicationLoopbackStart();
     void drawMonitorPage();
     void drawLoopbackPage();
@@ -104,10 +104,12 @@ private:
     bool                        loopbackSilentRender_ = true;
     bool                        appLoopbackStarted_ = false;
     bool                        appLoopbackStartPending_ = false;
+    bool                        appLoopbackExclude_ = false; // checkbox; false = IncludeTree
     bool                        appLoopbackSessionsLoaded_ = false;
     std::vector<wa::AudioSessionProcess> appLoopbackSessions_;
     int                         appLoopbackSessionIdx_ = -1;
     char                        appLoopbackPid_[32] = "";
+    wa::ProcessLoopbackMode     appLoopbackMode_ = wa::ProcessLoopbackMode::IncludeTree;
     std::thread                 appLoopbackStartThread_;
     std::shared_ptr<AppLoopbackStartJob> appLoopbackStartJob_;
 

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -5,6 +5,7 @@ namespace wa::ui_text {
 inline constexpr const char* kApplicationLoopbackTab = "Application Loopback";
 inline constexpr const char* kApplicationLoopbackRefresh = "Refresh";
 inline constexpr const char* kApplicationLoopbackPidLabel = "PID";
+inline constexpr const char* kApplicationLoopbackExclude = "Exclude";
 inline constexpr const char* kApplicationLoopbackSessions = "Sessions";
 
 inline constexpr const char* kAdvancedOptionsHelp =

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -67,6 +67,7 @@ TEST(AppLoopbackUiText, ExposesRequiredControls) {
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackTab, "Application Loopback");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackRefresh, "Refresh");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackPidLabel, "PID");
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackExclude, "Exclude");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackSessions, "Sessions");
 }
 

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -25,6 +25,20 @@ TEST(CaptureSource, CanRepresentApplicationLoopbackProcess) {
     EXPECT_EQ(source.kind, CaptureSourceKind::ApplicationLoopback);
     EXPECT_TRUE(source.deviceId.empty());
     EXPECT_EQ(source.processId, 4242u);
+    EXPECT_EQ(source.processLoopbackMode, ProcessLoopbackMode::IncludeTree);
+}
+
+TEST(CaptureSource, DefaultsProcessLoopbackModeToIncludeTree) {
+    CaptureSource source;
+    EXPECT_EQ(source.processLoopbackMode, ProcessLoopbackMode::IncludeTree);
+}
+
+TEST(CaptureSource, CanRepresentApplicationLoopbackExcludeTree) {
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 4242u,
+                         ProcessLoopbackMode::ExcludeTree};
+    EXPECT_EQ(source.kind, CaptureSourceKind::ApplicationLoopback);
+    EXPECT_EQ(source.processId, 4242u);
+    EXPECT_EQ(source.processLoopbackMode, ProcessLoopbackMode::ExcludeTree);
 }
 
 TEST(WasapiSystemLoopbackCaptureStream, RejectsExclusiveInOpen) {

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -641,7 +641,23 @@ TEST(MonitorEngine, ApplicationLoopbackCaptureSourceReachesFactory) {
     EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::ApplicationLoopback);
     EXPECT_TRUE(rig.lastCaptureSource.deviceId.empty());
     EXPECT_EQ(rig.lastCaptureSource.processId, 4242u);
+    EXPECT_EQ(rig.lastCaptureSource.processLoopbackMode, ProcessLoopbackMode::IncludeTree);
     EXPECT_EQ(rig.renderOpenCount.load(), 0);
+    eng.stop();
+}
+
+TEST(MonitorEngine, ApplicationLoopbackExcludeTreeModeReachesFactory) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory(), rig.silentFactory());
+    CaptureSource source{CaptureSourceKind::ApplicationLoopback, L"", 4242u,
+                         ProcessLoopbackMode::ExcludeTree};
+
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, source, L"", 50, false));
+
+    EXPECT_TRUE(rig.sawCaptureSource);
+    EXPECT_EQ(rig.lastCaptureSource.kind, CaptureSourceKind::ApplicationLoopback);
+    EXPECT_EQ(rig.lastCaptureSource.processId, 4242u);
+    EXPECT_EQ(rig.lastCaptureSource.processLoopbackMode, ProcessLoopbackMode::ExcludeTree);
     eng.stop();
 }
 


### PR DESCRIPTION
## What / Why

Application Loopback was hard-coded to include the target process tree. Testers need **exclude** as well (process-loopback mix minus that tree).

Closes #18  
Closes #19  
Closes #20  
Closes #21  

## How

- Core: `ProcessLoopbackMode` (`IncludeTree` / `ExcludeTree`, default include) on `CaptureSource`; MonitorEngine wires it into `ApplicationLoopbackCaptureStream`; activation maps to Win32 `PROCESS_LOOPBACK_MODE_*_TARGET_PROCESS_TREE`; start/activate logs include pid + mode.
- GUI: Application Loopback Control row has PID + **Exclude** checkbox (default off); mode frozen while Starting/Running; Status shows `mode=IncludeTree|ExcludeTree`.
- Docs: README, CLAUDE, screenshot notes describe both modes and out-of-scope limits (no multi-PID list, no CLI, no hot switch).

## Testing

- `ctest --test-dir build -C Debug`: **126/126 passed** (after core + GUI work).
- Focused: CaptureSource mode defaults / ExcludeTree representation; MonitorEngine factory observes ExcludeTree; AppUiText Exclude constant; existing ApplicationLoopback open guards still green.
- Manual GUI smoke (include then exclude same PID): **passed** (reporter).
- Release config not re-run in this session (Debug full suite green; CI will cover Debug+Release).

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug tests pass locally (full ctest)
- [ ] `test.bat Release` not re-run in this session (CI)
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached (layout tweak only; existing app-loopback screenshot still valid)
- [x] Real-device smoke done on Application Loopback include/exclude