### PR TITLE
feat(gui): pause charts while audio continues

### DIFF
--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -2,6 +2,7 @@
 #include "ApplicationLoopbackUiModel.h"
 #include "AppUiText.h"
 #include "CaptureChannelView.h"
+#include "ChartsFreezePolicy.h"
 #include "ComUtil.h"
 #include "imgui.h"
 #include "implot.h"
@@ -334,6 +335,7 @@ void AppUi::resetVisuals(VisualState& viz) {
     viz.capSpec.reset();
     viz.renderSpec.reset();
     viz.capChannelSpecs.clear();
+    viz.chartsFrozen = false;
     std::fill(std::begin(viz.plotHovPrev), std::end(viz.plotHovPrev), false);
 }
 
@@ -417,7 +419,9 @@ void AppUi::draw() {
     const int curRenderState = (int)ms_.renderState;
     if (prevRenderState_ == (int)wa::StreamState::Running &&
         curRenderState  != (int)wa::StreamState::Running) {
-        resetRenderVisuals(monitorViz_);
+        // Keep frozen render charts for inspection; wipe only when charts are live.
+        if (wa::charts_freeze::shouldResetRenderVisuals(monitorViz_.chartsFrozen))
+            resetRenderVisuals(monitorViz_);
     }
     prevRenderState_ = curRenderState;
 
@@ -879,6 +883,20 @@ void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus&
                              VisualState& viz) {
     ensureRunningVisuals(status, viz, true);
 
+    const bool overallRunning =
+        (status.overall == wa::StreamState::Running && status.sampleRate > 0);
+    viz.chartsFrozen = wa::charts_freeze::applyLifecycle(overallRunning, viz.chartsFrozen);
+
+    // Charts toolbar: freeze visualization only (audio continues).
+    ImGui::BeginDisabled(!wa::charts_freeze::isControlEnabled(overallRunning));
+    if (ImGui::Button(viz.chartsFrozen ? wa::ui_text::kChartsResume : wa::ui_text::kChartsPause))
+        viz.chartsFrozen = !viz.chartsFrozen;
+    ImGui::EndDisabled();
+    if (viz.chartsFrozen) {
+        ImGui::SameLine();
+        ImGui::TextUnformatted(wa::ui_text::kChartsPaused);
+    }
+
     for (int pos = 0; pos < (int)chartOrder_.size(); ++pos) {
         int id = chartOrder_[pos];
         ImGui::PushID(pos);
@@ -1054,7 +1072,11 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     const uint32_t sr         = status.sampleRate;
     const bool overallRunning = (status.overall     == wa::StreamState::Running && sr > 0);
     const bool renderRunning  = (status.renderState == wa::StreamState::Running);
+    const bool refreshCharts  =
+        wa::charts_freeze::shouldRefreshCharts(overallRunning, viz.chartsFrozen);
     const auto capturePlan = wa::capture_channel_view::makePlan(status.captureChannels);
+    // Split layout follows the capture plan whenever the page is running (including frozen),
+    // so multi-channel panels stay mounted while chart data is held.
     const bool splitCapture = !renderSide && overallRunning && capturePlan.split;
 
     if (splitCapture) {
@@ -1069,11 +1091,13 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
         for (uint32_t ch = 0; ch < shownChannels; ++ch) {
             std::vector<float>& wave = viz.capChannelWaves[(size_t)ch];
             bool ok = false;
-            if (viz.waveSr > 0 && nn > 0) {
+            if (refreshCharts && viz.waveSr > 0 && nn > 0) {
                 const int head = viz.waveN - (int)nn;
                 std::fill(wave.begin(), wave.begin() + head, 0.f);
                 ok = engine.snapshotCaptureChannelAt((uint16_t)ch, waveEnd, nn,
                                                      wave.data() + head);
+            } else if (viz.chartsFrozen && viz.waveSr > 0 && viz.waveN > 0) {
+                ok = true; // redraw last frozen channel buffer
             }
             const std::string title = "Capture Ch " + std::to_string(ch + 1u) + " waveform";
             ImGui::TextUnformatted(title.c_str());
@@ -1086,7 +1110,7 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
             shownChannels,
             std::min<uint32_t>((uint32_t)viz.capChannelSpecs.size(),
                                (uint32_t)viz.capSpecWindows.size()));
-        if (viz.specSr > 0 && specChannels > 0) {
+        if (refreshCharts && viz.specSr > 0 && specChannels > 0) {
             const uint64_t written = engine.capWritten();
             wa::advanceAnalysis(written, viz.nextCapEnd, kFftWin, kFftHop, kCatchup, [&](uint64_t endIdx) {
                 bool allGot = true;
@@ -1123,9 +1147,10 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     }
 
     // Snapshot the newest samples into the tail of the history buffer (progressive fill).
+    // When charts are frozen, skip the snapshot and redraw the last buffers.
     std::vector<float>& wave = renderSide ? viz.renderWave : viz.capWave;
     bool ok = false;
-    if (overallRunning && viz.waveSr > 0 && (!renderSide || renderRunning)) {
+    if (refreshCharts && viz.waveSr > 0 && (!renderSide || renderRunning)) {
         const size_t avail = (size_t)(renderSide ? engine.renderWritten() : engine.capWritten());
         const size_t nn = std::min(avail, (size_t)viz.waveN);
         if (nn > 0) {
@@ -1135,6 +1160,9 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
             ok = renderSide ? engine.snapshotRender(nn, wave.data() + head, end)
                             : engine.snapshotCapture(nn, wave.data() + head, end);
         }
+    } else if (viz.chartsFrozen && viz.waveSr > 0 && viz.waveN > 0 &&
+               (!renderSide || !viz.renderWave.empty())) {
+        ok = true;
     }
 
     const float waveH = kComboH * viz.comboRatio;
@@ -1154,8 +1182,8 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
 
     // Advance the FFT analysis feeding this stream's spectrogram (relocated here from the former
     // spectrum panels): one column per hop, catching up a few frames per poll. workCap_/workRender_
-    // and magCap_/magRender_ are reused as scratch.
-    if (overallRunning && viz.specSr > 0 && (!renderSide || renderRunning)) {
+    // and magCap_/magRender_ are reused as scratch. Skipped while charts are frozen.
+    if (refreshCharts && viz.specSr > 0 && (!renderSide || renderRunning)) {
         uint64_t se = 0;
         const uint64_t written = renderSide ? engine.renderWritten() : engine.capWritten();
         uint64_t& nextEnd      = renderSide ? viz.nextRenderEnd : viz.nextCapEnd;
@@ -1172,7 +1200,14 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     }
 
     wa::Spectrogram* spec = nullptr;
-    if (overallRunning) spec = renderSide ? (renderRunning ? viz.renderSpec.get() : nullptr) : viz.capSpec.get();
+    if (overallRunning) {
+        // Live: render spectrogram only while playback runs. Frozen: keep last renderSpec even
+        // if playback was turned off mid-freeze (resetRenderVisuals is suppressed).
+        if (renderSide)
+            spec = (renderRunning || viz.chartsFrozen) ? viz.renderSpec.get() : nullptr;
+        else
+            spec = viz.capSpec.get();
+    }
     const uint32_t hz = (sr > 0) ? sr : 48000u;   // idle: assume 48 kHz for the axis ranges
     drawSpectrogramPanel(viz, renderSide ? "##renSpec" : "##capSpec", spec,
                          (double)(kSpecCols * kFftHop) / (double)hz, kComboH - waveH,

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -493,6 +493,7 @@ void AppUi::drawLoopbackPage() {
 
     ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
     ensureRunningVisuals(loopbackMs_, loopbackViz_, false);
+    drawChartsFreezeToolbar(loopbackViz_, loopbackMs_);
     ImGui::TextUnformatted("System audio waveform + spectrogram");
     drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
     ImGui::EndChild();
@@ -518,6 +519,7 @@ void AppUi::drawApplicationLoopbackPage() {
 
     ImGui::BeginChild("appLoopbackCharts", ImVec2(0, 0), true);
     ensureRunningVisuals(appLoopbackMs_, appLoopbackViz_, false);
+    drawChartsFreezeToolbar(appLoopbackViz_, appLoopbackMs_);
     ImGui::TextUnformatted("Application audio waveform + spectrogram");
     if (appLoopback_)
         drawChartPanel(0, *appLoopback_, appLoopbackMs_, appLoopbackViz_);
@@ -879,15 +881,12 @@ void AppUi::drawAdvancedModal() {
     ImGui::EndPopup();
 }
 
-void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
-                             VisualState& viz) {
-    ensureRunningVisuals(status, viz, true);
-
+void AppUi::drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& status) {
+    // Shared by Monitor / Loopback / Application Loopback: freeze chart data only.
     const bool overallRunning =
         (status.overall == wa::StreamState::Running && status.sampleRate > 0);
     viz.chartsFrozen = wa::charts_freeze::applyLifecycle(overallRunning, viz.chartsFrozen);
 
-    // Charts toolbar: freeze visualization only (audio continues).
     ImGui::BeginDisabled(!wa::charts_freeze::isControlEnabled(overallRunning));
     if (ImGui::Button(viz.chartsFrozen ? wa::ui_text::kChartsResume : wa::ui_text::kChartsPause))
         viz.chartsFrozen = !viz.chartsFrozen;
@@ -896,6 +895,12 @@ void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus&
         ImGui::SameLine();
         ImGui::TextUnformatted(wa::ui_text::kChartsPaused);
     }
+}
+
+void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
+                             VisualState& viz) {
+    ensureRunningVisuals(status, viz, true);
+    drawChartsFreezeToolbar(viz, status);
 
     for (int pos = 0; pos < (int)chartOrder_.size(); ++pos) {
         int id = chartOrder_[pos];

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -32,6 +32,7 @@ private:
         double   xLink0 = 0.0, xLink1 = 0.0;
         std::vector<float> envX, envMin, envMax;
         float comboRatio = 0.5f;
+        bool  chartsFrozen = false; // pause chart data refresh only; audio continues
         bool  plotHovPrev[18] = {}; // capture wave/spec slots for up to 8 channels + render slots
 
         std::vector<std::complex<float>> workCap, workRender;

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -65,6 +65,7 @@ private:
     void ensureRunningVisuals(const wa::MonitorStatus& status, VisualState& viz,
                               bool includeRender);
     void drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
+    void drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& status);
     void drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
     void drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz, bool renderSide);
     void drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot);

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -29,4 +29,8 @@ inline constexpr int kAdvancedStreamOptionCount =
     static_cast<int>(sizeof(kAdvancedStreamOptions) / sizeof(kAdvancedStreamOptions[0]));
 inline constexpr const char* kAdvancedDuckingOptOut = "Ducking opt-out";
 
+inline constexpr const char* kChartsPause = "Pause charts";
+inline constexpr const char* kChartsResume = "Resume charts";
+inline constexpr const char* kChartsPaused = "PAUSED";
+
 } // namespace wa::ui_text

--- a/src/gui/ChartsFreezePolicy.h
+++ b/src/gui/ChartsFreezePolicy.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Pure charts-freeze policy for GUI visualization (no ImGui / no engine).
+// Freeze stops chart data refresh only; audio capture/render continue elsewhere.
+namespace wa::charts_freeze {
+
+// Scope snapshots + spectrogram analysis advance only when the session is running
+// and the page charts are not frozen.
+inline bool shouldRefreshCharts(bool overallRunning, bool frozen) noexcept {
+    return overallRunning && !frozen;
+}
+
+// Pause/Resume control is interactive only while overall is Running.
+inline bool isControlEnabled(bool overallRunning) noexcept {
+    return overallRunning;
+}
+
+// Freeze must be cleared when the session is not running (Stop, error, idle).
+inline bool shouldClearFreeze(bool overallRunning) noexcept {
+    return !overallRunning;
+}
+
+// Returns the freeze flag after applying lifecycle rules for this frame/state.
+inline bool applyLifecycle(bool overallRunning, bool frozen) noexcept {
+    if (shouldClearFreeze(overallRunning)) return false;
+    return frozen;
+}
+
+// When render leaves Running, wipe render-side chart buffers only if not frozen
+// (frozen pages keep the last render snapshot for inspection).
+inline bool shouldResetRenderVisuals(bool frozen) noexcept {
+    return !frozen;
+}
+
+} // namespace wa::charts_freeze

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(WinAudioTests
     test_monitorengine.cpp
     test_spectrogram.cpp
     test_capture_channel_view.cpp
+    test_charts_freeze.cpp
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -84,6 +84,12 @@ TEST(AdvancedOptionsUiText, ExposesExplicitClientPropertiesControls) {
               std::string::npos);
 }
 
+TEST(ChartsFreezeUiText, ExposesPauseResumeAndPausedLabels) {
+    EXPECT_STREQ(wa::ui_text::kChartsPause, "Pause charts");
+    EXPECT_STREQ(wa::ui_text::kChartsResume, "Resume charts");
+    EXPECT_STREQ(wa::ui_text::kChartsPaused, "PAUSED");
+}
+
 TEST(AppLoopbackUiModel, SelectingRowCopiesPidIntoEditableBuffer) {
     std::vector<AudioSessionProcess> rows = {
         {111u, L"one.exe"},

--- a/src/tests/test_charts_freeze.cpp
+++ b/src/tests/test_charts_freeze.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+#include "ChartsFreezePolicy.h"
+
+using namespace wa::charts_freeze;
+
+TEST(ChartsFreezePolicy, RefreshOnlyWhenRunningAndNotFrozen) {
+    EXPECT_TRUE(shouldRefreshCharts(/*overallRunning=*/true, /*frozen=*/false));
+    EXPECT_FALSE(shouldRefreshCharts(/*overallRunning=*/true, /*frozen=*/true));
+    EXPECT_FALSE(shouldRefreshCharts(/*overallRunning=*/false, /*frozen=*/false));
+    EXPECT_FALSE(shouldRefreshCharts(/*overallRunning=*/false, /*frozen=*/true));
+}
+
+TEST(ChartsFreezePolicy, ControlEnabledOnlyWhenRunning) {
+    EXPECT_TRUE(isControlEnabled(/*overallRunning=*/true));
+    EXPECT_FALSE(isControlEnabled(/*overallRunning=*/false));
+}
+
+TEST(ChartsFreezePolicy, ClearsFreezeWhenNotRunning) {
+    EXPECT_TRUE(shouldClearFreeze(/*overallRunning=*/false));
+    EXPECT_FALSE(shouldClearFreeze(/*overallRunning=*/true));
+}
+
+TEST(ChartsFreezePolicy, ApplyLifecycleClearsFreezeWhenNotRunning) {
+    EXPECT_FALSE(applyLifecycle(/*overallRunning=*/false, /*frozen=*/true));
+    EXPECT_FALSE(applyLifecycle(/*overallRunning=*/false, /*frozen=*/false));
+    EXPECT_TRUE(applyLifecycle(/*overallRunning=*/true, /*frozen=*/true));
+    EXPECT_FALSE(applyLifecycle(/*overallRunning=*/true, /*frozen=*/false));
+}
+
+TEST(ChartsFreezePolicy, ResetRenderVisualsSuppressedWhileFrozen) {
+    EXPECT_FALSE(shouldResetRenderVisuals(/*frozen=*/true));
+    EXPECT_TRUE(shouldResetRenderVisuals(/*frozen=*/false));
+}
+
+TEST(ChartsFreezePolicy, ClearedSessionStartsUnfrozen) {
+    // New / reset session: frozen flag is false; lifecycle while idle keeps it false.
+    constexpr bool kNewSessionFrozen = false;
+    EXPECT_FALSE(kNewSessionFrozen);
+    EXPECT_FALSE(applyLifecycle(/*overallRunning=*/false, kNewSessionFrozen));
+}


### PR DESCRIPTION
## What / Why

Zooming the live waveform/spectrogram time axis makes detail hard to inspect because the display scrolls too fast. This PR adds **Pause charts / Resume charts** so visualization freezes while capture, playback, and loopback audio keep running.

Parent: #23  
Closes #24  
Closes #25

## How

- Pure **charts freeze policy** (no ImGui/engine) gates snapshot + spectrogram analysis advancement; unit-tested lifecycle rules (refresh only when running and not frozen; auto-clear freeze when not running; suppress render-visual wipe while frozen).
- Per-page `chartsFrozen` on each page’s visual state (Monitor / System Loopback / Application Loopback are independent).
- Shared charts-column toolbar: Pause/Resume + `PAUSED`; disabled when not Running; cleared on Stop/`resetVisuals`.
- While frozen: still zoom/pan; Resume jumps to live and keeps the current time-axis view.
- GUI-only: core audio paths unchanged.

## Testing

- Debug ctest: **133/133** passed
- Release ctest: **133/133** passed
- New coverage: `ChartsFreezePolicy.*`, `ChartsFreezeUiText.*`
- Manual smoke (user acceptance): Monitor + Loopback + Application Loopback pause/resume while audio continues; page independence; stop clears freeze

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug and Release ctest pass locally (133/133 each)
- [x] New freeze policy has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached (optional; behavior verified by user smoke)
- [x] Real-device GUI smoke done by requester; result: acceptance passed