### PR TITLE
feat(gui): zoom and reset charts time axis from toolbar

### DIFF
--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -3,6 +3,7 @@
 #include "AppUiText.h"
 #include "CaptureChannelView.h"
 #include "ChartsFreezePolicy.h"
+#include "ChartsTimeZoomPolicy.h"
 #include "ComUtil.h"
 #include "imgui.h"
 #include "implot.h"
@@ -336,6 +337,7 @@ void AppUi::resetVisuals(VisualState& viz) {
     viz.renderSpec.reset();
     viz.capChannelSpecs.clear();
     viz.chartsFrozen = false;
+    viz.resetYAxes = false;
     std::fill(std::begin(viz.plotHovPrev), std::end(viz.plotHovPrev), false);
 }
 
@@ -496,6 +498,7 @@ void AppUi::drawLoopbackPage() {
     drawChartsFreezeToolbar(loopbackViz_, loopbackMs_);
     ImGui::TextUnformatted("System audio waveform + spectrogram");
     drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
+    loopbackViz_.resetYAxes = false;
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -523,6 +526,7 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::TextUnformatted("Application audio waveform + spectrogram");
     if (appLoopback_)
         drawChartPanel(0, *appLoopback_, appLoopbackMs_, appLoopbackViz_);
+    appLoopbackViz_.resetYAxes = false;
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -882,7 +886,7 @@ void AppUi::drawAdvancedModal() {
 }
 
 void AppUi::drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& status) {
-    // Shared by Monitor / Loopback / Application Loopback: freeze chart data only.
+    // Shared by Monitor / Loopback / Application Loopback: freeze + time zoom / reset.
     const bool overallRunning =
         (status.overall == wa::StreamState::Running && status.sampleRate > 0);
     viz.chartsFrozen = wa::charts_freeze::applyLifecycle(overallRunning, viz.chartsFrozen);
@@ -894,6 +898,42 @@ void AppUi::drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& s
     if (viz.chartsFrozen) {
         ImGui::SameLine();
         ImGui::TextUnformatted(wa::ui_text::kChartsPaused);
+    }
+
+    // History length for the shared time axis (same window as wave/spec buffers).
+    const uint32_t sr = (status.sampleRate > 0) ? status.sampleRate
+                       : (viz.waveSr > 0)       ? viz.waveSr
+                                                : 48000u;
+    const double historyH = (viz.waveN > 0 && viz.waveSr > 0)
+                                ? (double)viz.waveN / (double)viz.waveSr
+                                : (double)(kSpecCols * kFftHop) / (double)sr;
+    const double hopSec = (double)kFftHop / (double)sr;
+    if (viz.xLink1 <= viz.xLink0)
+        viz.xLink1 = historyH > 0.0 ? historyH : viz.xLink0;
+
+    ImGui::SameLine();
+    ImGui::BeginDisabled(!wa::charts_time_zoom::canZoomOut(viz.xLink0, viz.xLink1, historyH));
+    if (ImGui::Button(wa::ui_text::kChartsZoomOut)) {
+        const auto z = wa::charts_time_zoom::zoomCentered(viz.xLink0, viz.xLink1, historyH, hopSec, 2.0);
+        viz.xLink0 = z.x0;
+        viz.xLink1 = z.x1;
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    ImGui::BeginDisabled(
+        !wa::charts_time_zoom::canZoomIn(viz.xLink0, viz.xLink1, historyH, hopSec));
+    if (ImGui::Button(wa::ui_text::kChartsZoomIn)) {
+        const auto z = wa::charts_time_zoom::zoomCentered(viz.xLink0, viz.xLink1, historyH, hopSec, 0.5);
+        viz.xLink0 = z.x0;
+        viz.xLink1 = z.x1;
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    if (ImGui::Button(wa::ui_text::kChartsResetView)) {
+        const auto full = wa::charts_time_zoom::fullHistory(historyH);
+        viz.xLink0 = full.x0;
+        viz.xLink1 = full.x1;
+        viz.resetYAxes = true; // applied once by each plot this frame; cleared after charts draw
     }
 }
 
@@ -932,6 +972,7 @@ void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus&
         }
         ImGui::PopID();
     }
+    viz.resetYAxes = false; // one-shot Y restore consumed by all plots this frame
 }
 
 // Plasma-like colormap whose low end fades to fully transparent: silence shows the normal plot
@@ -994,7 +1035,8 @@ void AppUi::drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spect
         // Clamp panning/zooming to the buffered history / frequency range — no empty space.
         ImPlot::SetupAxisLimitsConstraints(ImAxis_X1, 0.0, histSec);
         ImPlot::SetupAxisLimitsConstraints(ImAxis_Y1, loL, hiL);
-        ImPlot::SetupAxisLimits(ImAxis_Y1, lo0, hiL, ImGuiCond_Once);
+        ImPlot::SetupAxisLimits(ImAxis_Y1, lo0, hiL,
+                                viz.resetYAxes ? ImGuiCond_Always : ImGuiCond_Once);
         if (nTick > 0) ImPlot::SetupAxisTicks(ImAxis_Y1, tickV, nTick, tickL);
         if (spec)
             ImPlot::PlotHeatmap("##hm", spec->data(), spec->rows(), spec->cols(), -96.0, 0.0, nullptr,
@@ -1025,7 +1067,8 @@ void AppUi::drawWaveformPanel(VisualState& viz, const char* plotId, const float*
                                           : (double)(kSpecCols * kFftHop) / 48000.0;
     ImPlot::SetupAxisLimitsConstraints(ImAxis_X1, 0.0, hist);
     ImPlot::SetupAxisLimitsConstraints(ImAxis_Y1, -1.0, 1.0);
-    ImPlot::SetupAxisLimits(ImAxis_Y1, -1.0, 1.0, ImGuiCond_Once);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, -1.0, 1.0,
+                            viz.resetYAxes ? ImGuiCond_Always : ImGuiCond_Once);
     // dB ruler for the warped scale (positions = dbWarp of the label, with kWaveDbFloor = -60).
     static const double kAmpV[] = {-1.0, -0.9, -0.8, -0.6, -0.2, 0.0, 0.2, 0.6, 0.8, 0.9, 1.0};
     static const char*  kAmpL[] = {"0", "-6", "-12", "-24", "-48", "-inf", "-48", "-24", "-12", "-6", "0"};

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -33,6 +33,7 @@ private:
         std::vector<float> envX, envMin, envMax;
         float comboRatio = 0.5f;
         bool  chartsFrozen = false; // pause chart data refresh only; audio continues
+        bool  resetYAxes = false;   // one-shot: next draw restores default Y on all plots
         bool  plotHovPrev[18] = {}; // capture wave/spec slots for up to 8 channels + render slots
 
         std::vector<std::complex<float>> workCap, workRender;

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -32,5 +32,8 @@ inline constexpr const char* kAdvancedDuckingOptOut = "Ducking opt-out";
 inline constexpr const char* kChartsPause = "Pause charts";
 inline constexpr const char* kChartsResume = "Resume charts";
 inline constexpr const char* kChartsPaused = "PAUSED";
+inline constexpr const char* kChartsZoomOut = "Zoom out";
+inline constexpr const char* kChartsZoomIn = "Zoom in";
+inline constexpr const char* kChartsResetView = "Reset view";
 
 } // namespace wa::ui_text

--- a/src/gui/ChartsTimeZoomPolicy.h
+++ b/src/gui/ChartsTimeZoomPolicy.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Pure shared-time-axis zoom policy for GUI charts (no ImGui / no engine).
+// Zoom mutates only the linked X window; Y defaults are restored by the draw path.
+namespace wa::charts_time_zoom {
+
+struct Interval {
+    double x0 = 0.0;
+    double x1 = 0.0;
+};
+
+// Absolute floor for the visible time window (~10 ms).
+inline constexpr double kMinWidthSecondsFloor = 0.010;
+
+// Epsilon for enable/disable comparisons against full history / min width.
+inline constexpr double kWidthEps = 1e-9;
+
+// Minimum window width: max(10 ms, hopSeconds), capped by history H.
+inline double minWidthSeconds(double hopSeconds, double historyH) noexcept {
+    if (!(historyH > 0.0)) return 0.0;
+    double w = hopSeconds;
+    if (w < kMinWidthSecondsFloor) w = kMinWidthSecondsFloor;
+    if (w > historyH) w = historyH;
+    if (w < 0.0) w = 0.0;
+    return w;
+}
+
+// Full buffered history on the shared time axis.
+inline Interval fullHistory(double historyH) noexcept {
+    if (!(historyH > 0.0)) return Interval{0.0, 0.0};
+    return Interval{0.0, historyH};
+}
+
+// Clamp [x0, x1] into [0, H], preserving width when possible.
+inline Interval clampToHistory(double x0, double x1, double historyH) noexcept {
+    if (!(historyH > 0.0)) return Interval{0.0, 0.0};
+    if (x1 < x0) std::swap(x0, x1);
+    double w = x1 - x0;
+    if (w > historyH) w = historyH;
+    if (w < 0.0) w = 0.0;
+    if (x0 < 0.0) {
+        x1 -= x0;
+        x0 = 0.0;
+    }
+    if (x1 > historyH) {
+        x0 -= (x1 - historyH);
+        x1 = historyH;
+    }
+    if (x0 < 0.0) x0 = 0.0;
+    // Re-assert width after edge clamp (numerical safety).
+    if (x1 - x0 > historyH) x1 = x0 + historyH;
+    if (x1 > historyH) {
+        x1 = historyH;
+        x0 = historyH - w;
+        if (x0 < 0.0) x0 = 0.0;
+    }
+    return Interval{x0, x1};
+}
+
+// True when the window can still shrink (zoom in).
+inline bool canZoomIn(double x0, double x1, double historyH, double hopSeconds) noexcept {
+    if (!(historyH > 0.0)) return false;
+    const double w = x1 - x0;
+    const double minW = minWidthSeconds(hopSeconds, historyH);
+    return w > minW + kWidthEps;
+}
+
+// True when the window is not yet the full history (zoom out).
+inline bool canZoomOut(double x0, double x1, double historyH) noexcept {
+    if (!(historyH > 0.0)) return false;
+    const double w = x1 - x0;
+    return w + kWidthEps < historyH;
+}
+
+// Centered zoom: new width = current width * widthFactor (0.5 = in, 2.0 = out),
+// then clamp into [0, H] and enforce min width.
+inline Interval zoomCentered(double x0, double x1, double historyH, double hopSeconds,
+                             double widthFactor) noexcept {
+    if (!(historyH > 0.0) || !(widthFactor > 0.0)) return fullHistory(historyH);
+    if (x1 < x0) std::swap(x0, x1);
+    double w = x1 - x0;
+    if (!(w > 0.0)) w = historyH;
+    const double minW = minWidthSeconds(hopSeconds, historyH);
+    double newW = w * widthFactor;
+    if (newW < minW) newW = minW;
+    if (newW > historyH) newW = historyH;
+    const double center = 0.5 * (x0 + x1);
+    return clampToHistory(center - 0.5 * newW, center + 0.5 * newW, historyH);
+}
+
+} // namespace wa::charts_time_zoom

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(WinAudioTests
     test_spectrogram.cpp
     test_capture_channel_view.cpp
     test_charts_freeze.cpp
+    test_charts_time_zoom.cpp
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -90,6 +90,12 @@ TEST(ChartsFreezeUiText, ExposesPauseResumeAndPausedLabels) {
     EXPECT_STREQ(wa::ui_text::kChartsPaused, "PAUSED");
 }
 
+TEST(ChartsTimeZoomUiText, ExposesZoomAndResetLabels) {
+    EXPECT_STREQ(wa::ui_text::kChartsZoomOut, "Zoom out");
+    EXPECT_STREQ(wa::ui_text::kChartsZoomIn, "Zoom in");
+    EXPECT_STREQ(wa::ui_text::kChartsResetView, "Reset view");
+}
+
 TEST(AppLoopbackUiModel, SelectingRowCopiesPidIntoEditableBuffer) {
     std::vector<AudioSessionProcess> rows = {
         {111u, L"one.exe"},

--- a/src/tests/test_charts_time_zoom.cpp
+++ b/src/tests/test_charts_time_zoom.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+#include "ChartsTimeZoomPolicy.h"
+
+using namespace wa::charts_time_zoom;
+
+TEST(ChartsTimeZoomPolicy, MinWidthIsMaxOfTenMsAndHopCappedByHistory) {
+    EXPECT_DOUBLE_EQ(minWidthSeconds(/*hop=*/0.005, /*H=*/10.0), 0.010);
+    EXPECT_DOUBLE_EQ(minWidthSeconds(/*hop=*/0.021333, /*H=*/10.0), 0.021333);
+    EXPECT_DOUBLE_EQ(minWidthSeconds(/*hop=*/0.5, /*H=*/0.1), 0.1);
+    EXPECT_DOUBLE_EQ(minWidthSeconds(/*hop=*/0.01, /*H=*/0.0), 0.0);
+}
+
+TEST(ChartsTimeZoomPolicy, FullHistoryIsZeroToH) {
+    const Interval full = fullHistory(10.24);
+    EXPECT_DOUBLE_EQ(full.x0, 0.0);
+    EXPECT_DOUBLE_EQ(full.x1, 10.24);
+    EXPECT_DOUBLE_EQ(fullHistory(0.0).x1, 0.0);
+}
+
+TEST(ChartsTimeZoomPolicy, ZoomInHalvesWidthAboutCenter) {
+    // [2, 6] width 4, center 4 -> half width 2 -> [3, 5]
+    const Interval z = zoomCentered(2.0, 6.0, /*H=*/10.0, /*hop=*/0.01, /*factor=*/0.5);
+    EXPECT_NEAR(z.x0, 3.0, 1e-12);
+    EXPECT_NEAR(z.x1, 5.0, 1e-12);
+    EXPECT_NEAR(z.x1 - z.x0, 2.0, 1e-12);
+}
+
+TEST(ChartsTimeZoomPolicy, ZoomOutDoublesWidthAboutCenter) {
+    // [3, 5] width 2, center 4 -> width 4 -> [2, 6]
+    const Interval z = zoomCentered(3.0, 5.0, /*H=*/10.0, /*hop=*/0.01, /*factor=*/2.0);
+    EXPECT_NEAR(z.x0, 2.0, 1e-12);
+    EXPECT_NEAR(z.x1, 6.0, 1e-12);
+}
+
+TEST(ChartsTimeZoomPolicy, ZoomOutClampsToFullHistory) {
+    const Interval z = zoomCentered(1.0, 9.0, /*H=*/10.0, /*hop=*/0.01, /*factor=*/2.0);
+    EXPECT_NEAR(z.x0, 0.0, 1e-12);
+    EXPECT_NEAR(z.x1, 10.0, 1e-12);
+}
+
+TEST(ChartsTimeZoomPolicy, ZoomInStopsAtMinWidth) {
+    const double hop = 0.02;
+    const double H = 10.0;
+    const double minW = minWidthSeconds(hop, H);
+    // Already at min width around center.
+    const double c = 5.0;
+    const Interval z = zoomCentered(c - 0.5 * minW, c + 0.5 * minW, H, hop, 0.5);
+    EXPECT_NEAR(z.x1 - z.x0, minW, 1e-12);
+    EXPECT_FALSE(canZoomIn(z.x0, z.x1, H, hop));
+}
+
+TEST(ChartsTimeZoomPolicy, CanZoomOutFalseAtFullHistory) {
+    EXPECT_FALSE(canZoomOut(0.0, 10.0, 10.0));
+    EXPECT_TRUE(canZoomOut(1.0, 9.0, 10.0));
+}
+
+TEST(ChartsTimeZoomPolicy, CanZoomInFalseAtMinWidth) {
+    const double hop = 0.01;
+    const double H = 5.0;
+    const double minW = minWidthSeconds(hop, H);
+    EXPECT_FALSE(canZoomIn(0.0, minW, H, hop));
+    EXPECT_TRUE(canZoomIn(0.0, minW * 4.0, H, hop));
+}
+
+TEST(ChartsTimeZoomPolicy, EdgeClampDoesNotInvertInterval) {
+    // Near left edge: zoom out should stay ordered and inside [0, H].
+    const Interval z = zoomCentered(0.0, 0.5, /*H=*/10.0, /*hop=*/0.01, /*factor=*/2.0);
+    EXPECT_LE(z.x0, z.x1);
+    EXPECT_GE(z.x0, 0.0);
+    EXPECT_LE(z.x1, 10.0);
+    EXPECT_NEAR(z.x1 - z.x0, 1.0, 1e-12);
+}
+
+TEST(ChartsTimeZoomPolicy, ClampToHistoryKeepsValidRange) {
+    const Interval c = clampToHistory(-1.0, 3.0, 10.0);
+    EXPECT_GE(c.x0, 0.0);
+    EXPECT_LE(c.x1, 10.0);
+    EXPECT_LE(c.x0, c.x1);
+}


### PR DESCRIPTION
## What / Why

After zooming the linked waveform/spectrogram time axis (or accidentally zooming Y), restoring a useful full view is awkward with mouse gestures alone. This PR adds fixed-step **Zoom out / Zoom in** and one-click **Reset view** on the charts toolbar.

Parent: #27  
Closes #28

## How

- Pure **time-zoom policy** (center ×2/÷2, clamp to history `[0, H]`, min width ≈ max(10 ms, 1 hop), enable/disable at ends) with unit tests.
- Shared charts toolbar on Monitor / System Loopback / Application Loopback: Pause… → Zoom out → Zoom in → Reset view.
- Zoom mutates only the shared time axis (`xLink`); Reset restores full history X and one-shot default Y limits (waveform full scale; spectrogram default frequency span). Does not clear Pause charts.
- Zoom/reset available while frozen or idle; mouse pan/zoom unchanged. GUI-only.

## Testing

- Debug ctest: **144/144** passed
- Release ctest: **144/144** passed
- New coverage: `ChartsTimeZoomPolicy.*`, `ChartsTimeZoomUiText.*`
- Manual smoke (user acceptance): deep zoom → Reset; step Zoom ±; freeze + zoom; idle zoom; multi-page

## Checklist

- [x] Commits follow Conventional Commits and are atomic
- [x] Debug and Release ctest pass locally (144/144 each)
- [x] New time-zoom policy has gtest coverage without real audio devices
- [ ] GUI changes: screenshots attached (optional)
- [x] Real-device GUI smoke done by requester; result: acceptance passed