### PR TITLE
refactor(gui): Chart Data Pipeline for hop-aligned chart refresh

### DIFF
--- a/src/core/FakeScopeReader.h
+++ b/src/core/FakeScopeReader.h
@@ -1,0 +1,82 @@
+#pragma once
+#include "ScopeReader.h"
+#include <cstdint>
+#include <vector>
+
+namespace wa {
+
+// In-memory Scope Reader for Chart Data Pipeline / hop tests (no audio hardware).
+// Stores interleaved frames [ch0, ch1, ...] chronologically from index 0.
+class FakeScopeReader final : public ScopeReader {
+public:
+    explicit FakeScopeReader(uint16_t channels = 1)
+        : channels_(channels ? channels : static_cast<uint16_t>(1)) {}
+
+    // Append frames of interleaved samples (size must be frames * channels).
+    void pushInterleaved(const float* interleaved, size_t frames) {
+        if (!interleaved || frames == 0) return;
+        const size_t n = frames * static_cast<size_t>(channels_);
+        samples_.insert(samples_.end(), interleaved, interleaved + n);
+        written_ += frames;
+    }
+
+    // Append mono samples (broadcast to all channels if multi-ch).
+    void pushMono(const float* mono, size_t frames) {
+        if (!mono || frames == 0) return;
+        for (size_t i = 0; i < frames; ++i) {
+            for (uint16_t ch = 0; ch < channels_; ++ch)
+                samples_.push_back(mono[i]);
+        }
+        written_ += frames;
+    }
+
+    // Set absolute written count without growing samples (advanced tests).
+    void setWritten(uint64_t w) { written_ = w; }
+
+    uint64_t written() const override { return written_; }
+    uint16_t channels() const override { return channels_; }
+
+    bool snapshotLatest(size_t n, float* out, uint64_t& endIdxOut) const override {
+        if (!out || n == 0 || written_ < n) return false;
+        const uint64_t end = written_;
+        if (!snapshotEndingAt(end, n, out)) return false;
+        endIdxOut = end;
+        return true;
+    }
+
+    bool snapshotEndingAt(uint64_t endIdx, size_t n, float* out) const override {
+        if (!out || n == 0 || endIdx > written_ || endIdx < n) return false;
+        const uint64_t start = endIdx - n;
+        // Only frames we actually stored (from 0) are available.
+        if (endIdx > static_cast<uint64_t>(samples_.size() / channels_)) return false;
+        const float invCh = 1.0f / static_cast<float>(channels_);
+        for (size_t i = 0; i < n; ++i) {
+            const size_t frame = static_cast<size_t>(start + i);
+            float sum = 0.0f;
+            for (uint16_t ch = 0; ch < channels_; ++ch)
+                sum += samples_[frame * static_cast<size_t>(channels_) + ch];
+            out[i] = sum * invCh;
+        }
+        return true;
+    }
+
+    bool snapshotChannelEndingAt(uint16_t channel, uint64_t endIdx, size_t n,
+                                 float* out) const override {
+        if (!out || channel >= channels_ || n == 0 || endIdx > written_ || endIdx < n)
+            return false;
+        if (endIdx > static_cast<uint64_t>(samples_.size() / channels_)) return false;
+        const uint64_t start = endIdx - n;
+        for (size_t i = 0; i < n; ++i) {
+            const size_t frame = static_cast<size_t>(start + i);
+            out[i] = samples_[frame * static_cast<size_t>(channels_) + channel];
+        }
+        return true;
+    }
+
+private:
+    uint16_t           channels_ = 1;
+    uint64_t           written_  = 0;
+    std::vector<float> samples_;
+};
+
+} // namespace wa

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -529,6 +529,11 @@ bool MonitorEngine::snapshotCapture(size_t n, float* out, uint64_t& endIdxOut) {
     return s ? s->snapshotLatest(n, out, endIdxOut) : false;
 }
 
+bool MonitorEngine::snapshotCaptureAt(uint64_t endIdx, size_t n, float* out) {
+    ScopeBuffer* s = captureScope_.get();
+    return s ? s->snapshotEndingAt(endIdx, n, out) : false;
+}
+
 bool MonitorEngine::snapshotCaptureChannel(uint16_t channel, size_t n, float* out,
                                            uint64_t& endIdxOut) {
     ScopeBuffer* s = captureScope_.get();
@@ -546,6 +551,11 @@ bool MonitorEngine::snapshotRender(size_t n, float* out, uint64_t& endIdxOut) {
     return s ? s->snapshotLatest(n, out, endIdxOut) : false;
 }
 
+bool MonitorEngine::snapshotRenderAt(uint64_t endIdx, size_t n, float* out) {
+    ScopeBuffer* s = renderScope_.get();
+    return s ? s->snapshotEndingAt(endIdx, n, out) : false;
+}
+
 uint64_t MonitorEngine::capWritten() const {
     ScopeBuffer* s = captureScope_.get();
     return s ? s->totalWritten() : 0;
@@ -554,6 +564,11 @@ uint64_t MonitorEngine::capWritten() const {
 uint64_t MonitorEngine::renderWritten() const {
     ScopeBuffer* s = renderScope_.get();
     return s ? s->totalWritten() : 0;
+}
+
+uint16_t MonitorEngine::captureScopeChannels() const {
+    ScopeBuffer* s = captureScope_.get();
+    return s ? s->channels() : 0;
 }
 
 } // namespace wa

--- a/src/core/MonitorEngine.h
+++ b/src/core/MonitorEngine.h
@@ -98,12 +98,15 @@ public:
     void   setRenderParams(const StreamParams& p);                  // 运行中可调;下次 engage 取快照生效
 
     bool snapshotCapture(size_t n, float* out, uint64_t& endIdxOut);
+    bool snapshotCaptureAt(uint64_t endIdx, size_t n, float* out);
     bool snapshotCaptureChannel(uint16_t channel, size_t n, float* out, uint64_t& endIdxOut);
     bool snapshotCaptureChannelAt(uint16_t channel, uint64_t endIdx, size_t n, float* out);
     bool snapshotRender (size_t n, float* out, uint64_t& endIdxOut);
+    bool snapshotRenderAt(uint64_t endIdx, size_t n, float* out);
 
     uint64_t capWritten()    const;
     uint64_t renderWritten() const;
+    uint16_t captureScopeChannels() const;
 
 private:
     void   pumpLoop();

--- a/src/core/MonitorScopeReader.h
+++ b/src/core/MonitorScopeReader.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "MonitorEngine.h"
+#include "ScopeReader.h"
+
+namespace wa {
+
+// Production Scope Reader over MonitorEngine capture or render scope taps.
+class MonitorScopeReader final : public ScopeReader {
+public:
+    enum class Side { Capture, Render };
+
+    MonitorScopeReader(MonitorEngine& engine, Side side) : engine_(engine), side_(side) {}
+
+    uint64_t written() const override {
+        return side_ == Side::Capture ? engine_.capWritten() : engine_.renderWritten();
+    }
+
+    uint16_t channels() const override {
+        if (side_ == Side::Capture) return engine_.captureScopeChannels();
+        return 1; // render scope is mono
+    }
+
+    bool snapshotLatest(size_t n, float* out, uint64_t& endIdxOut) const override {
+        return side_ == Side::Capture ? engine_.snapshotCapture(n, out, endIdxOut)
+                                      : engine_.snapshotRender(n, out, endIdxOut);
+    }
+
+    bool snapshotEndingAt(uint64_t endIdx, size_t n, float* out) const override {
+        return side_ == Side::Capture ? engine_.snapshotCaptureAt(endIdx, n, out)
+                                      : engine_.snapshotRenderAt(endIdx, n, out);
+    }
+
+    bool snapshotChannelEndingAt(uint16_t channel, uint64_t endIdx, size_t n,
+                                 float* out) const override {
+        if (side_ == Side::Render) {
+            // Render tap is mono: channel 0 only.
+            if (channel != 0) return false;
+            return engine_.snapshotRenderAt(endIdx, n, out);
+        }
+        return engine_.snapshotCaptureChannelAt(channel, endIdx, n, out);
+    }
+
+private:
+    MonitorEngine& engine_;
+    Side           side_;
+};
+
+} // namespace wa

--- a/src/core/ScopeBuffer.h
+++ b/src/core/ScopeBuffer.h
@@ -106,6 +106,31 @@ public:
         return false;                                    // couldn't get a quiet window (caller skips a frame)
     }
 
+    // Consistent mono/downmix snapshot of n frames ending at endIdx (exclusive).
+    // Same availability contract as snapshotChannelEndingAt; n <= capacity/2.
+    bool snapshotEndingAt(uint64_t endIdx, size_t n, float* out) const {
+        const size_t cap = capacityFrames();
+        if (n == 0 || n > cap / 2) return false;
+        for (int attempt = 0; attempt < 16; ++attempt) {
+            const uint64_t s0 = seq_.load(std::memory_order_acquire);
+            if (s0 & 1u) continue;
+            const uint64_t w0 = written_.load(std::memory_order_acquire);
+            if (!windowAvailable(w0, endIdx, n, cap)) return false;
+            const uint64_t start = endIdx - n;
+            const float invCh = 1.0f / static_cast<float>(channels_);
+            for (size_t i = 0; i < n; ++i) {
+                const size_t frame = static_cast<size_t>((start + i) % cap);
+                const float* src = &buf_[frame * static_cast<size_t>(channels_)];
+                float sum = 0.0f;
+                for (uint16_t ch = 0; ch < channels_; ++ch) sum += src[ch];
+                out[i] = sum * invCh;
+            }
+            const uint64_t s1 = seq_.load(std::memory_order_acquire);
+            if (s0 == s1) return true;
+        }
+        return false;
+    }
+
 private:
     size_t capacityFrames() const { return buf_.size() / static_cast<size_t>(channels_); }
     static bool windowAvailable(uint64_t written, uint64_t endIdx, size_t n, size_t cap) {

--- a/src/core/ScopeReader.h
+++ b/src/core/ScopeReader.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace wa {
+
+// Narrow scope-tap read surface for Chart Data Pipeline (one stream side).
+// Production adapter: MonitorScopeReader. Tests: FakeScopeReader.
+class ScopeReader {
+public:
+    virtual ~ScopeReader() = default;
+
+    // Total frames written to the tap (exclusive end index of the full history).
+    virtual uint64_t written() const = 0;
+
+    // Channel count stored in the tap (1 for mono/render; capture may be multi-ch).
+    virtual uint16_t channels() const = 0;
+
+    // Mono/downmix of the most recent n frames; endIdxOut is exclusive end on success.
+    virtual bool snapshotLatest(size_t n, float* out, uint64_t& endIdxOut) const = 0;
+
+    // Mono/downmix of n frames ending at endIdx (exclusive).
+    virtual bool snapshotEndingAt(uint64_t endIdx, size_t n, float* out) const = 0;
+
+    // Single channel of n frames ending at endIdx (exclusive).
+    virtual bool snapshotChannelEndingAt(uint16_t channel, uint64_t endIdx, size_t n,
+                                         float* out) const = 0;
+};
+
+} // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -2,13 +2,13 @@
 #include "ApplicationLoopbackUiModel.h"
 #include "AppUiText.h"
 #include "CaptureChannelView.h"
+#include "ChartDataPipeline.h"
 #include "ChartsFreezePolicy.h"
 #include "ChartsTimeZoomPolicy.h"
 #include "ComUtil.h"
+#include "MonitorScopeReader.h"
 #include "imgui.h"
 #include "implot.h"
-#include "Fft.h"
-#include "Analysis.h"
 #include "FormatSpec.h"
 #include "Log.h"
 #include <algorithm>
@@ -1129,12 +1129,25 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     const uint32_t sr         = status.sampleRate;
     const bool overallRunning = (status.overall     == wa::StreamState::Running && sr > 0);
     const bool renderRunning  = (status.renderState == wa::StreamState::Running);
-    const bool refreshCharts  =
-        wa::charts_freeze::shouldRefreshCharts(overallRunning, viz.chartsFrozen);
     const auto capturePlan = wa::capture_channel_view::makePlan(status.captureChannels);
     // Split layout follows the capture plan whenever the page is running (including frozen),
     // so multi-channel panels stay mounted while chart data is held.
     const bool splitCapture = !renderSide && overallRunning && capturePlan.split;
+
+    // Chart Data Pipeline: hop-aligned spectrum + latest wave history; freeze gated inside.
+    wa::MonitorScopeReader reader(
+        engine, renderSide ? wa::MonitorScopeReader::Side::Render
+                           : wa::MonitorScopeReader::Side::Capture);
+    wa::ChartRefreshParams refreshParams;
+    refreshParams.reader = &reader;
+    refreshParams.frozen = viz.chartsFrozen;
+    // Live: require overall (+ render when render-side). Frozen: still "active" so haveWave
+    // can report retained buffers; pipeline skips writes when frozen.
+    refreshParams.streamActive =
+        overallRunning && (viz.chartsFrozen || !renderSide || renderRunning);
+    refreshParams.fftWin = kFftWin;
+    refreshParams.fftHop = kFftHop;
+    refreshParams.maxCatchup = kCatchup;
 
     if (splitCapture) {
         const uint32_t actualChannels = capturePlan.actualChannels;
@@ -1143,49 +1156,26 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
         if (actualChannels > shownChannels)
             ImGui::Text("Capture channels: %u / %u channels shown", shownChannels, actualChannels);
 
-        const uint64_t waveEnd = engine.capWritten();
-        const size_t nn = (size_t)std::min<uint64_t>(waveEnd, (uint64_t)viz.waveN);
+        wa::ChartBuffers buffers;
+        buffers.channelWaves = &viz.capChannelWaves;
+        buffers.channelCount = shownChannels;
+        buffers.waveN = viz.waveN;
+        buffers.waveSr = viz.waveSr;
+        buffers.channelSpecWindows = &viz.capSpecWindows;
+        buffers.channelSpecs = &viz.capChannelSpecs;
+        buffers.work = &viz.workCap;
+        buffers.mag = &viz.magCap;
+        buffers.nextEnd = &viz.nextCapEnd;
+        buffers.specSr = viz.specSr;
+        const wa::ChartRefreshResult refreshed = wa::refreshCharts(refreshParams, buffers);
+
         for (uint32_t ch = 0; ch < shownChannels; ++ch) {
             std::vector<float>& wave = viz.capChannelWaves[(size_t)ch];
-            bool ok = false;
-            if (refreshCharts && viz.waveSr > 0 && nn > 0) {
-                const int head = viz.waveN - (int)nn;
-                std::fill(wave.begin(), wave.begin() + head, 0.f);
-                ok = engine.snapshotCaptureChannelAt((uint16_t)ch, waveEnd, nn,
-                                                     wave.data() + head);
-            } else if (viz.chartsFrozen && viz.waveSr > 0 && viz.waveN > 0) {
-                ok = true; // redraw last frozen channel buffer
-            }
             const std::string title = "Capture Ch " + std::to_string(ch + 1u) + " waveform";
             ImGui::TextUnformatted(title.c_str());
             const std::string plotId = "##capWaveCh" + std::to_string(ch);
-            drawWaveformPanel(viz, plotId.c_str(), wave.data(), viz.waveN, viz.waveSr, ok,
-                              kMultiWaveH, kSlotCapWaveBase + (int)ch);
-        }
-
-        const uint32_t specChannels = std::min<uint32_t>(
-            shownChannels,
-            std::min<uint32_t>((uint32_t)viz.capChannelSpecs.size(),
-                               (uint32_t)viz.capSpecWindows.size()));
-        if (refreshCharts && viz.specSr > 0 && specChannels > 0) {
-            const uint64_t written = engine.capWritten();
-            wa::advanceAnalysis(written, viz.nextCapEnd, kFftWin, kFftHop, kCatchup, [&](uint64_t endIdx) {
-                bool allGot = true;
-                for (uint32_t ch = 0; ch < specChannels; ++ch) {
-                    if (!engine.snapshotCaptureChannelAt((uint16_t)ch, endIdx, kFftWin,
-                                                         viz.capSpecWindows[(size_t)ch].data())) {
-                        allGot = false;
-                        break;
-                    }
-                }
-                if (!allGot) return;
-                for (uint32_t ch = 0; ch < specChannels; ++ch) {
-                    wa::magnitudeSpectrumDb(viz.capSpecWindows[(size_t)ch].data(), kFftWin,
-                                            viz.workCap.data(), viz.magCap);
-                    if (viz.capChannelSpecs[(size_t)ch])
-                        viz.capChannelSpecs[(size_t)ch]->pushColumn(viz.magCap);
-                }
-            });
+            drawWaveformPanel(viz, plotId.c_str(), wave.data(), viz.waveN, viz.waveSr,
+                              refreshed.haveWave, kMultiWaveH, kSlotCapWaveBase + (int)ch);
         }
 
         const uint32_t hz = (sr > 0) ? sr : 48000u;
@@ -1203,24 +1193,22 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
         return;
     }
 
-    // Snapshot the newest samples into the tail of the history buffer (progressive fill).
-    // When charts are frozen, skip the snapshot and redraw the last buffers.
     std::vector<float>& wave = renderSide ? viz.renderWave : viz.capWave;
-    bool ok = false;
-    if (refreshCharts && viz.waveSr > 0 && (!renderSide || renderRunning)) {
-        const size_t avail = (size_t)(renderSide ? engine.renderWritten() : engine.capWritten());
-        const size_t nn = std::min(avail, (size_t)viz.waveN);
-        if (nn > 0) {
-            const int head = viz.waveN - (int)nn;
-            std::fill(wave.begin(), wave.begin() + head, 0.f);
-            uint64_t end = 0;
-            ok = renderSide ? engine.snapshotRender(nn, wave.data() + head, end)
-                            : engine.snapshotCapture(nn, wave.data() + head, end);
-        }
-    } else if (viz.chartsFrozen && viz.waveSr > 0 && viz.waveN > 0 &&
-               (!renderSide || !viz.renderWave.empty())) {
+    wa::ChartBuffers buffers;
+    buffers.wave = wave.empty() ? nullptr : wave.data();
+    buffers.waveN = viz.waveN;
+    buffers.waveSr = viz.waveSr;
+    buffers.specWin = &viz.specWin;
+    buffers.work = renderSide ? &viz.workRender : &viz.workCap;
+    buffers.mag = renderSide ? &viz.magRender : &viz.magCap;
+    buffers.spectrogram = renderSide ? viz.renderSpec.get() : viz.capSpec.get();
+    buffers.nextEnd = renderSide ? &viz.nextRenderEnd : &viz.nextCapEnd;
+    buffers.specSr = viz.specSr;
+    const wa::ChartRefreshResult refreshed = wa::refreshCharts(refreshParams, buffers);
+    bool ok = refreshed.haveWave;
+    if (!ok && viz.chartsFrozen && viz.waveSr > 0 && viz.waveN > 0 &&
+        (!renderSide || !viz.renderWave.empty()))
         ok = true;
-    }
 
     const float waveH = kComboH * viz.comboRatio;
     drawWaveformPanel(viz, renderSide ? "##renWave" : "##capWave", wave.data(), viz.waveN, viz.waveSr, ok,
@@ -1236,25 +1224,6 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     ImGui::GetWindowDrawList()->AddLine(ImVec2(smn.x, (smn.y + smx.y) * 0.5f),
                                         ImVec2(smx.x, (smn.y + smx.y) * 0.5f),
                                         ImGui::GetColorU32(ImGuiCol_Separator), 1.0f);
-
-    // Advance the FFT analysis feeding this stream's spectrogram (relocated here from the former
-    // spectrum panels): one column per hop, catching up a few frames per poll. workCap_/workRender_
-    // and magCap_/magRender_ are reused as scratch. Skipped while charts are frozen.
-    if (refreshCharts && viz.specSr > 0 && (!renderSide || renderRunning)) {
-        uint64_t se = 0;
-        const uint64_t written = renderSide ? engine.renderWritten() : engine.capWritten();
-        uint64_t& nextEnd      = renderSide ? viz.nextRenderEnd : viz.nextCapEnd;
-        wa::advanceAnalysis(written, nextEnd, kFftWin, kFftHop, kCatchup, [&](uint64_t) {
-            const bool got = renderSide ? engine.snapshotRender(kFftWin, viz.specWin.data(), se)
-                                        : engine.snapshotCapture(kFftWin, viz.specWin.data(), se);
-            if (!got) return;
-            std::vector<std::complex<float>>& work = renderSide ? viz.workRender : viz.workCap;
-            std::vector<float>&               mag  = renderSide ? viz.magRender  : viz.magCap;
-            wa::magnitudeSpectrumDb(viz.specWin.data(), kFftWin, work.data(), mag);
-            if (wa::Spectrogram* sp = renderSide ? viz.renderSpec.get() : viz.capSpec.get())
-                sp->pushColumn(mag);
-        });
-    }
 
     wa::Spectrogram* spec = nullptr;
     if (overallRunning) {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(WinAudioGui
     AppUi.cpp
+    ChartDataPipeline.cpp
     main.cpp
     Spectrogram.cpp
 )

--- a/src/gui/ChartDataPipeline.cpp
+++ b/src/gui/ChartDataPipeline.cpp
@@ -1,0 +1,124 @@
+#include "ChartDataPipeline.h"
+#include "Analysis.h"
+#include "Fft.h"
+#include <algorithm>
+
+namespace wa {
+namespace {
+
+bool fillLatestWaveMono(const ScopeReader& reader, float* wave, int waveN) {
+    if (!wave || waveN <= 0) return false;
+    const uint64_t written = reader.written();
+    const size_t nn = static_cast<size_t>(std::min<uint64_t>(written, static_cast<uint64_t>(waveN)));
+    if (nn == 0) return false;
+    const int head = waveN - static_cast<int>(nn);
+    std::fill(wave, wave + head, 0.f);
+    uint64_t end = 0;
+    return reader.snapshotLatest(nn, wave + head, end);
+}
+
+bool fillLatestWaveChannels(const ScopeReader& reader, std::vector<std::vector<float>>& channelWaves,
+                            uint32_t channelCount, int waveN) {
+    if (waveN <= 0 || channelCount == 0) return false;
+    const uint64_t written = reader.written();
+    const size_t nn = static_cast<size_t>(std::min<uint64_t>(written, static_cast<uint64_t>(waveN)));
+    if (nn == 0) return false;
+    const uint32_t shown =
+        std::min(channelCount, static_cast<uint32_t>(channelWaves.size()));
+    bool any = false;
+    for (uint32_t ch = 0; ch < shown; ++ch) {
+        std::vector<float>& wave = channelWaves[static_cast<size_t>(ch)];
+        if (static_cast<int>(wave.size()) < waveN) continue;
+        const int head = waveN - static_cast<int>(nn);
+        std::fill(wave.begin(), wave.begin() + head, 0.f);
+        if (reader.snapshotChannelEndingAt(static_cast<uint16_t>(ch), written, nn,
+                                           wave.data() + head))
+            any = true;
+    }
+    return any;
+}
+
+void advanceSpectraMono(const ChartRefreshParams& p, ChartBuffers& b) {
+    if (!p.reader || !b.nextEnd || !b.specWin || !b.work || !b.mag) return;
+    if (b.specWin->size() < p.fftWin || b.work->size() < p.fftWin) return;
+    const uint64_t written = p.reader->written();
+    advanceAnalysis(written, *b.nextEnd, p.fftWin, p.fftHop, p.maxCatchup, [&](uint64_t endIdx) {
+        if (!p.reader->snapshotEndingAt(endIdx, p.fftWin, b.specWin->data())) return;
+        magnitudeSpectrumDb(b.specWin->data(), p.fftWin, b.work->data(), *b.mag);
+        if (b.spectrogram) b.spectrogram->pushColumn(*b.mag);
+    });
+}
+
+void advanceSpectraMulti(const ChartRefreshParams& p, ChartBuffers& b) {
+    if (!p.reader || !b.nextEnd || !b.channelSpecWindows || !b.channelSpecs || !b.work || !b.mag)
+        return;
+    if (b.work->size() < p.fftWin) return;
+    const uint32_t nCh = std::min(
+        b.channelCount,
+        std::min(static_cast<uint32_t>(b.channelSpecWindows->size()),
+                 static_cast<uint32_t>(b.channelSpecs->size())));
+    if (nCh == 0) return;
+    for (uint32_t ch = 0; ch < nCh; ++ch) {
+        if ((*b.channelSpecWindows)[ch].size() < p.fftWin) return;
+    }
+    const uint64_t written = p.reader->written();
+    advanceAnalysis(written, *b.nextEnd, p.fftWin, p.fftHop, p.maxCatchup, [&](uint64_t endIdx) {
+        bool allGot = true;
+        for (uint32_t ch = 0; ch < nCh; ++ch) {
+            if (!p.reader->snapshotChannelEndingAt(
+                    static_cast<uint16_t>(ch), endIdx, p.fftWin,
+                    (*b.channelSpecWindows)[ch].data())) {
+                allGot = false;
+                break;
+            }
+        }
+        if (!allGot) return;
+        for (uint32_t ch = 0; ch < nCh; ++ch) {
+            magnitudeSpectrumDb((*b.channelSpecWindows)[ch].data(), p.fftWin, b.work->data(),
+                                *b.mag);
+            if ((*b.channelSpecs)[ch])
+                (*b.channelSpecs)[ch]->pushColumn(*b.mag);
+        }
+    });
+}
+
+bool buffersHaveWave(const ChartBuffers& b) {
+    if (b.waveN <= 0 || b.waveSr == 0) return false;
+    if (b.channelCount >= 2 && b.channelWaves)
+        return !b.channelWaves->empty() && !(*b.channelWaves)[0].empty();
+    return b.wave != nullptr;
+}
+
+} // namespace
+
+ChartRefreshResult refreshCharts(const ChartRefreshParams& params, ChartBuffers& buffers) {
+    ChartRefreshResult result;
+    if (!params.reader) return result;
+
+    if (params.frozen) {
+        result.haveWave = buffersHaveWave(buffers);
+        return result;
+    }
+    if (!params.streamActive) return result;
+
+    const bool multi = buffers.channelCount >= 2 && buffers.channelWaves != nullptr;
+
+    if (buffers.waveSr > 0 && buffers.waveN > 0) {
+        if (multi)
+            result.haveWave = fillLatestWaveChannels(*params.reader, *buffers.channelWaves,
+                                                     buffers.channelCount, buffers.waveN);
+        else if (buffers.wave)
+            result.haveWave = fillLatestWaveMono(*params.reader, buffers.wave, buffers.waveN);
+    }
+
+    if (buffers.specSr > 0 && buffers.nextEnd) {
+        if (multi)
+            advanceSpectraMulti(params, buffers);
+        else
+            advanceSpectraMono(params, buffers);
+    }
+
+    return result;
+}
+
+} // namespace wa

--- a/src/gui/ChartDataPipeline.h
+++ b/src/gui/ChartDataPipeline.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "ScopeReader.h"
+#include "Spectrogram.h"
+#include <complex>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace wa {
+
+// Parameters for one Chart Data Pipeline refresh (one stream side).
+struct ChartRefreshParams {
+    const ScopeReader* reader = nullptr;
+    bool               frozen = false;       // chart freeze: no writes
+    bool               streamActive = false; // e.g. capture overall running / render running
+    size_t             fftWin = 2048;
+    size_t             fftHop = 1024;
+    size_t             maxCatchup = 8;
+};
+
+// External buffers owned by VisualState (or tests). Mono vs multi-channel:
+// - Mono/downmix: set wave + spectrogram + specWin; channelCount = 0 or 1.
+// - Multi-channel capture: set channelWaves / channelSpecs / channelSpecWindows; channelCount >= 2.
+struct ChartBuffers {
+    // Wave history (latest rolling window, progressive fill into tail).
+    float*                         wave = nullptr;          // mono path, size waveN
+    std::vector<std::vector<float>>* channelWaves = nullptr;  // multi-ch
+    uint32_t                       channelCount = 0;        // 0/1 => mono; >=2 multi
+    int                            waveN = 0;
+    uint32_t                       waveSr = 0;              // >0 when wave/spec buffers ready
+
+    // Spectrogram hop windows + FFT scratch.
+    std::vector<float>*                       specWin = nullptr;           // mono, size fftWin
+    std::vector<std::vector<float>>*          channelSpecWindows = nullptr; // multi
+    std::vector<std::complex<float>>*         work = nullptr;
+    std::vector<float>*                       mag = nullptr;
+    Spectrogram*                              spectrogram = nullptr;       // mono
+    std::vector<std::unique_ptr<Spectrogram>>* channelSpecs = nullptr;     // multi
+    uint64_t*                                 nextEnd = nullptr;           // analysis cursor
+    uint32_t                                  specSr = 0;                  // >0 when analysis ready
+};
+
+struct ChartRefreshResult {
+    bool haveWave = false;
+};
+
+// Refresh chart data from a Scope Reader into external buffers. No ImGui.
+// Wave: latest history window. Spectrogram: hop-aligned ending-at for all paths.
+ChartRefreshResult refreshCharts(const ChartRefreshParams& params, ChartBuffers& buffers);
+
+} // namespace wa

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(WinAudioTests
     test_wavfile.cpp
     test_formatspec.cpp
     test_scopebuffer.cpp
+    test_scope_reader.cpp
     test_analysis.cpp
     test_monitorengine.cpp
     test_spectrogram.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,12 +16,14 @@ add_executable(WinAudioTests
     test_capture_channel_view.cpp
     test_charts_freeze.cpp
     test_charts_time_zoom.cpp
+    test_chart_data_pipeline.cpp
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp
     test_audio_session_enumerator.cpp
     test_cli_options.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
+    ${CMAKE_SOURCE_DIR}/src/gui/ChartDataPipeline.cpp
 )
 target_include_directories(WinAudioTests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/tests/test_chart_data_pipeline.cpp
+++ b/src/tests/test_chart_data_pipeline.cpp
@@ -1,0 +1,237 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <vector>
+#include "ChartDataPipeline.h"
+#include "FakeScopeReader.h"
+#include "Spectrogram.h"
+
+using namespace wa;
+
+namespace {
+
+constexpr size_t kWin = 64;
+constexpr size_t kHop = 32;
+constexpr size_t kCatch = 8;
+
+// Fill fake reader with a long mono ramp so hop windows are distinct.
+void fillRamp(FakeScopeReader& r, size_t frames) {
+    std::vector<float> s(frames);
+    for (size_t i = 0; i < frames; ++i) s[i] = static_cast<float>(i);
+    r.pushMono(s.data(), frames);
+}
+
+ChartBuffers makeMonoBuffers(std::vector<float>& wave, std::vector<float>& specWin,
+                             std::vector<std::complex<float>>& work, std::vector<float>& mag,
+                             Spectrogram& spec, uint64_t& nextEnd, int waveN) {
+    ChartBuffers b;
+    b.wave = wave.data();
+    b.waveN = waveN;
+    b.waveSr = 48000;
+    b.specWin = &specWin;
+    b.work = &work;
+    b.mag = &mag;
+    b.spectrogram = &spec;
+    b.nextEnd = &nextEnd;
+    b.specSr = 48000;
+    return b;
+}
+
+} // namespace
+
+TEST(ChartDataPipeline, FrozenDoesNotAdvanceCursorOrWave) {
+    FakeScopeReader r(1);
+    fillRamp(r, 512);
+
+    std::vector<float> wave(128, 0.f);
+    std::vector<float> specWin(kWin, 0.f);
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    Spectrogram spec(16, 32, 20.0, 24000.0, 48000);
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = true;
+    p.frozen = false;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+    p.maxCatchup = kCatch;
+
+    ChartBuffers b = makeMonoBuffers(wave, specWin, work, mag, spec, nextEnd, 128);
+    auto live = refreshCharts(p, b);
+    EXPECT_TRUE(live.haveWave);
+    const uint64_t endAfterLive = nextEnd;
+    EXPECT_GT(endAfterLive, 0u);
+    const float wave0 = wave[100];
+
+    p.frozen = true;
+    auto frozen = refreshCharts(p, b);
+    EXPECT_TRUE(frozen.haveWave);
+    EXPECT_EQ(nextEnd, endAfterLive);
+    EXPECT_FLOAT_EQ(wave[100], wave0);
+}
+
+TEST(ChartDataPipeline, InactiveStreamDoesNotWrite) {
+    FakeScopeReader r(1);
+    fillRamp(r, 256);
+    std::vector<float> wave(64, -1.f);
+    std::vector<float> specWin(kWin);
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    Spectrogram spec(8, 16, 20.0, 24000.0, 48000);
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = false;
+    p.frozen = false;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+
+    ChartBuffers b = makeMonoBuffers(wave, specWin, work, mag, spec, nextEnd, 64);
+    auto res = refreshCharts(p, b);
+    EXPECT_FALSE(res.haveWave);
+    EXPECT_EQ(nextEnd, 0u);
+    EXPECT_FLOAT_EQ(wave[0], -1.f);
+}
+
+TEST(ChartDataPipeline, MonoSpectrogramHopsUseDistinctEndingAtWindows) {
+    // With hop alignment, each catch-up hop pulls a different ending-at window.
+    // Inject enough samples so multiple hops fire in one refresh.
+    FakeScopeReader r(1);
+    fillRamp(r, kWin + 4 * kHop); // several hop boundaries
+
+    std::vector<float> wave(256, 0.f);
+    std::vector<float> specWin(kWin, 0.f);
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    Spectrogram spec(8, 16, 20.0, 24000.0, 48000);
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = true;
+    p.frozen = false;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+    p.maxCatchup = kCatch;
+
+    ChartBuffers b = makeMonoBuffers(wave, specWin, work, mag, spec, nextEnd, 256);
+    refreshCharts(p, b);
+
+    // First emission at window size, then +hop each time.
+    EXPECT_GE(nextEnd, static_cast<uint64_t>(kWin));
+    EXPECT_EQ((nextEnd - static_cast<uint64_t>(kWin)) % static_cast<uint64_t>(kHop), 0u);
+
+    // Last hop window content: samples [nextEnd-kWin, nextEnd)
+    float expectedLast[kWin];
+    ASSERT_TRUE(r.snapshotEndingAt(nextEnd, kWin, expectedLast));
+    // specWin holds the last successful hop's samples after refresh.
+    for (size_t i = 0; i < kWin; ++i)
+        EXPECT_FLOAT_EQ(specWin[i], expectedLast[i]) << "i=" << i;
+}
+
+TEST(ChartDataPipeline, CatchupCapsHopsPerRefresh) {
+    FakeScopeReader r(1);
+    // Far ahead of analysis: many pending hops.
+    fillRamp(r, kWin + 100 * kHop);
+
+    std::vector<float> wave(64, 0.f);
+    std::vector<float> specWin(kWin);
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    Spectrogram spec(8, 16, 20.0, 24000.0, 48000);
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = true;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+    p.maxCatchup = 3; // tight cap
+
+    ChartBuffers b = makeMonoBuffers(wave, specWin, work, mag, spec, nextEnd, 64);
+    refreshCharts(p, b);
+
+    // After fast-forward + at most maxCatchup emissions, cursor stays near the end.
+    // Max emissions in one call is maxCatchup; first seed then process.
+    // nextEnd should not equal written if backlog was huge... actually advanceAnalysis
+    // fast-forwards then processes up to remaining which is maxCatchup hops.
+    // So nextEnd = written - (written-next) % hop after processing maxCatchup from near end.
+    EXPECT_GT(nextEnd, 0u);
+    EXPECT_LE(nextEnd, r.written());
+    // Distance from written to nextEnd should be < hop (fully caught to last boundary).
+    EXPECT_LT(r.written() - nextEnd, static_cast<uint64_t>(kHop));
+}
+
+TEST(ChartDataPipeline, MultiChannelWavesShareWrittenEnd) {
+    FakeScopeReader r(2);
+    // 4 frames stereo
+    const float in[] = {
+        1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60, 7, 70, 8, 80,
+    };
+    r.pushInterleaved(in, 8);
+
+    std::vector<std::vector<float>> chWaves(2, std::vector<float>(4, 0.f));
+    std::vector<std::vector<float>> chSpecWin(2, std::vector<float>(kWin, 0.f));
+    std::vector<std::unique_ptr<Spectrogram>> chSpecs;
+    chSpecs.push_back(std::make_unique<Spectrogram>(8, 8, 20.0, 24000.0, 48000));
+    chSpecs.push_back(std::make_unique<Spectrogram>(8, 8, 20.0, 24000.0, 48000));
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = true;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+
+    ChartBuffers b;
+    b.channelWaves = &chWaves;
+    b.channelCount = 2;
+    b.waveN = 4;
+    b.waveSr = 48000;
+    b.channelSpecWindows = &chSpecWin;
+    b.channelSpecs = &chSpecs;
+    b.work = &work;
+    b.mag = &mag;
+    b.nextEnd = &nextEnd;
+    b.specSr = 48000;
+
+    auto res = refreshCharts(p, b);
+    EXPECT_TRUE(res.haveWave);
+    // Latest 4 frames: 5..8 on ch0, 50..80 on ch1
+    EXPECT_FLOAT_EQ(chWaves[0][0], 5.f);
+    EXPECT_FLOAT_EQ(chWaves[0][3], 8.f);
+    EXPECT_FLOAT_EQ(chWaves[1][0], 50.f);
+    EXPECT_FLOAT_EQ(chWaves[1][3], 80.f);
+}
+
+TEST(ChartDataPipeline, WaveProgressiveFillPutsNewestAtTail) {
+    FakeScopeReader r(1);
+    const float s[] = {10.f, 20.f, 30.f};
+    r.pushMono(s, 3);
+
+    std::vector<float> wave(8, -9.f);
+    std::vector<float> specWin(kWin);
+    std::vector<std::complex<float>> work(kWin);
+    std::vector<float> mag;
+    Spectrogram spec(4, 4, 20.0, 24000.0, 48000);
+    uint64_t nextEnd = 0;
+
+    ChartRefreshParams p;
+    p.reader = &r;
+    p.streamActive = true;
+    p.fftWin = kWin;
+    p.fftHop = kHop;
+
+    ChartBuffers b = makeMonoBuffers(wave, specWin, work, mag, spec, nextEnd, 8);
+    ASSERT_TRUE(refreshCharts(p, b).haveWave);
+    // head zeros, tail = samples
+    EXPECT_FLOAT_EQ(wave[0], 0.f);
+    EXPECT_FLOAT_EQ(wave[4], 0.f);
+    EXPECT_FLOAT_EQ(wave[5], 10.f);
+    EXPECT_FLOAT_EQ(wave[6], 20.f);
+    EXPECT_FLOAT_EQ(wave[7], 30.f);
+}

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -15,6 +15,7 @@
 #include <thread>
 #include <vector>
 #include "MonitorEngine.h"
+#include "MonitorScopeReader.h"
 #include "RingBuffer.h"
 
 using namespace wa;
@@ -345,6 +346,88 @@ TEST(MonitorEngine, CaptureChannelSnapshotAtUsesRequestedEndIndex) {
     }
 
     EXPECT_FALSE(eng.snapshotCaptureChannelAt(1, frames + 1, 8, out));
+
+    eng.stop();
+}
+
+TEST(MonitorEngine, CaptureSnapshotAtDownmixUsesRequestedEndIndex) {
+    FakeRig rig;
+    rig.capFmt = {48000, 2, 16, false};
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 20, false)));
+    ASSERT_NE(rig.capPtr, nullptr);
+
+    const uint32_t frames = 256;
+    std::vector<int16_t> left(frames);
+    std::vector<int16_t> right(frames);
+    for (uint32_t i = 0; i < frames; ++i) {
+        left[i] = static_cast<int16_t>(100 + i);
+        right[i] = static_cast<int16_t>(1000 + i);
+    }
+    auto pcm = makeStereoPcm(left, right);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+
+    ASSERT_TRUE(waitFor([&] { return eng.capWritten() >= frames; }))
+        << "capWritten never reached " << frames;
+
+    float out[8] = {};
+    ASSERT_TRUE(eng.snapshotCaptureAt(128, 8, out));
+    for (uint32_t k = 0; k < 8; ++k) {
+        const uint32_t idx = 120 + k;
+        const float expected =
+            (static_cast<float>(left[idx]) + static_cast<float>(right[idx])) * 0.5f / 32768.f;
+        EXPECT_NEAR(out[k], expected, 1e-4f) << "mono mismatch at k=" << k;
+    }
+    EXPECT_FALSE(eng.snapshotCaptureAt(frames + 1, 8, out));
+    EXPECT_EQ(eng.captureScopeChannels(), 2u);
+
+    eng.stop();
+}
+
+TEST(MonitorScopeReader, CaptureAdapterMatchesEngineSnapshotAt) {
+    FakeRig rig;
+    rig.capFmt = {48000, 2, 16, false};
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 20, false)));
+    ASSERT_NE(rig.capPtr, nullptr);
+
+    const uint32_t frames = 128;
+    std::vector<int16_t> left(frames);
+    std::vector<int16_t> right(frames);
+    for (uint32_t i = 0; i < frames; ++i) {
+        left[i] = static_cast<int16_t>(i);
+        right[i] = static_cast<int16_t>(1000 + i);
+    }
+    auto pcm = makeStereoPcm(left, right);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.capWritten() >= frames; }));
+
+    MonitorScopeReader cap(eng, MonitorScopeReader::Side::Capture);
+    EXPECT_EQ(cap.written(), eng.capWritten());
+    EXPECT_EQ(cap.channels(), eng.captureScopeChannels());
+
+    float viaEngine[8] = {};
+    float viaReader[8] = {};
+    ASSERT_TRUE(eng.snapshotCaptureAt(64, 8, viaEngine));
+    ASSERT_TRUE(cap.snapshotEndingAt(64, 8, viaReader));
+    for (int i = 0; i < 8; ++i) EXPECT_FLOAT_EQ(viaEngine[i], viaReader[i]);
+
+    float ch[4] = {};
+    ASSERT_TRUE(cap.snapshotChannelEndingAt(0, 64, 4, ch));
+
+    eng.stop();
+}
+
+TEST(MonitorScopeReader, RenderSideIsMonoOnly) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    // playback on so render scope exists and can receive delayed samples
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 20, true)));
+
+    MonitorScopeReader ren(eng, MonitorScopeReader::Side::Render);
+    EXPECT_EQ(ren.channels(), 1u);
+    float out[4] = {};
+    EXPECT_FALSE(ren.snapshotChannelEndingAt(1, 4, 4, out));
 
     eng.stop();
 }

--- a/src/tests/test_scope_reader.cpp
+++ b/src/tests/test_scope_reader.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "FakeScopeReader.h"
+
+using namespace wa;
+
+TEST(FakeScopeReader, WrittenAndLatestMono) {
+    FakeScopeReader r(1);
+    const float s[] = {1.f, 2.f, 3.f, 4.f, 5.f};
+    r.pushMono(s, 5);
+    EXPECT_EQ(r.written(), 5u);
+    EXPECT_EQ(r.channels(), 1u);
+
+    float out[3] = {};
+    uint64_t end = 0;
+    ASSERT_TRUE(r.snapshotLatest(3, out, end));
+    EXPECT_EQ(end, 5u);
+    EXPECT_FLOAT_EQ(out[0], 3.f);
+    EXPECT_FLOAT_EQ(out[1], 4.f);
+    EXPECT_FLOAT_EQ(out[2], 5.f);
+}
+
+TEST(FakeScopeReader, EndingAtMonoAndChannel) {
+    FakeScopeReader r(2);
+    // frames: (0,10), (1,11), (2,12), (3,13)
+    const float in[] = {0, 10, 1, 11, 2, 12, 3, 13};
+    r.pushInterleaved(in, 4);
+
+    float mono[2] = {};
+    ASSERT_TRUE(r.snapshotEndingAt(3, 2, mono)); // frames 1,2 -> avg (1+11)/2, (2+12)/2
+    EXPECT_FLOAT_EQ(mono[0], 6.f);
+    EXPECT_FLOAT_EQ(mono[1], 7.f);
+
+    float ch1[2] = {};
+    ASSERT_TRUE(r.snapshotChannelEndingAt(1, 3, 2, ch1));
+    EXPECT_FLOAT_EQ(ch1[0], 11.f);
+    EXPECT_FLOAT_EQ(ch1[1], 12.f);
+
+    EXPECT_FALSE(r.snapshotEndingAt(5, 2, mono));           // end beyond written
+    EXPECT_FALSE(r.snapshotChannelEndingAt(2, 3, 1, ch1));  // bad channel
+}
+
+TEST(FakeScopeReader, LatestEndIdxMatchesEndingAt) {
+    FakeScopeReader r(1);
+    std::vector<float> s(16);
+    for (size_t i = 0; i < s.size(); ++i) s[i] = (float)i;
+    r.pushMono(s.data(), s.size());
+
+    float a[4] = {}, b[4] = {};
+    uint64_t end = 0;
+    ASSERT_TRUE(r.snapshotLatest(4, a, end));
+    ASSERT_TRUE(r.snapshotEndingAt(end, 4, b));
+    for (int i = 0; i < 4; ++i) EXPECT_FLOAT_EQ(a[i], b[i]);
+}
+
+TEST(FakeScopeReader, EmptyReaderFailsSnapshots) {
+    FakeScopeReader r(1);
+    float out[4] = {};
+    uint64_t end = 0;
+    EXPECT_EQ(r.written(), 0u);
+    EXPECT_FALSE(r.snapshotLatest(4, out, end));
+    EXPECT_FALSE(r.snapshotEndingAt(4, 4, out));
+    EXPECT_FALSE(r.snapshotChannelEndingAt(0, 4, 4, out));
+}

--- a/src/tests/test_scopebuffer.cpp
+++ b/src/tests/test_scopebuffer.cpp
@@ -79,6 +79,47 @@ TEST(ScopeBuffer, SnapshotChannelEndingAtUsesRequestedWindow) {
     sb.pushInterleaved(more.data(), 16);
     EXPECT_FALSE(sb.snapshotChannelEndingAt(1, 6, 3, out));
 }
+TEST(ScopeBuffer, SnapshotEndingAtDownmixUsesRequestedWindow) {
+    ScopeBuffer sb(16, 2);
+    std::vector<float> in;
+    for (int i = 0; i < 10; ++i) {
+        in.push_back((float)i);           // ch0
+        in.push_back((float)(100 + i));   // ch1
+    }
+    sb.pushInterleaved(in.data(), 10);
+
+    // Frames ending at 6: indices 3,4,5 -> avg (3+103)/2, (4+104)/2, (5+105)/2
+    float out[3] = {};
+    ASSERT_TRUE(sb.snapshotEndingAt(6, 3, out));
+    EXPECT_FLOAT_EQ(out[0], 53.0f);
+    EXPECT_FLOAT_EQ(out[1], 54.0f);
+    EXPECT_FLOAT_EQ(out[2], 55.0f);
+
+    EXPECT_FALSE(sb.snapshotEndingAt(11, 3, out)); // beyond written
+
+    // Same roll-off contract as channel EndingAt: old window becomes unavailable.
+    std::vector<float> more;
+    for (int i = 10; i < 26; ++i) {
+        more.push_back((float)i);
+        more.push_back((float)(100 + i));
+    }
+    sb.pushInterleaved(more.data(), 16);
+    EXPECT_FALSE(sb.snapshotEndingAt(6, 3, out));
+}
+TEST(ScopeBuffer, SnapshotEndingAtMonoMatchesLatestWindow) {
+    ScopeBuffer sb(64);
+    std::vector<float> in(32);
+    for (size_t i = 0; i < 32; ++i) in[i] = (float)i;
+    sb.push(in.data(), 32);
+
+    float latest[8] = {};
+    float at[8] = {};
+    uint64_t end = 0;
+    ASSERT_TRUE(sb.snapshotLatest(8, latest, end));
+    EXPECT_EQ(end, 32u);
+    ASSERT_TRUE(sb.snapshotEndingAt(end, 8, at));
+    for (int i = 0; i < 8; ++i) EXPECT_FLOAT_EQ(at[i], latest[i]);
+}
 TEST(ScopeBuffer, ConcurrentSpscConsistency) {
     ScopeBuffer sb(8192);
     std::atomic<bool> stop{false};


### PR DESCRIPTION
## What / Why

Chart data refresh (wave history, spectrogram hops, freeze gating, multi-channel vs mono) lived inside `drawComboPanel`, was untestable as a unit, and mono/render spectrograms ignored hop end indices (repeated latest windows under catch-up). This PR deepens a **Chart Data Pipeline** behind a **Scope Reader** seam and fixes hop alignment.

Parent: #33  
Closes #34  
Closes #35  
Closes #33

## How

1. **Scope taps**: mono/downmix `snapshotEndingAt`; MonitorEngine `snapshotCaptureAt` / `snapshotRenderAt`; narrow **ScopeReader** + **FakeScopeReader** + **MonitorScopeReader**.
2. **Chart Data Pipeline** `refreshCharts`: latest wave progressive fill; hop ending-at spectra for mono/multi/render; freeze skips writes; external buffers stay in VisualState.
3. **AppUi**: combo panel calls pipeline then draws only (no embedded snapshot/FFT policy).

## Testing

- Debug ctest: **159/159** passed
- Release ctest: run locally with PR (see CI)
- New coverage: ScopeBuffer EndingAt, Fake/Monitor ScopeReader, ChartDataPipeline (freeze, hop, catchup, multi-ch, progressive fill)
- Manual smoke: requester confirmed charts OK before PR

## Checklist

- [x] Commits follow Conventional Commits and are atomic
- [x] Debug ctest 159/159; Release + CI on PR
- [x] Pipeline/reader tests without real audio devices
- [ ] Screenshots (N/A — no intentional UI chrome change)
- [x] Manual smoke by requester before PR