### PR TITLE
refactor(gui): unify Chart Host for three pages

### DIFF
--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -475,7 +475,8 @@ void AppUi::drawMonitorPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("charts", ImVec2(0, 0), true);
-    drawChartsColumn(monitor_, ms_, monitorViz_);
+    drawChartHost(&monitor_, ms_, monitorViz_, wa::chart_host::Mode::DualReorderable,
+                  nullptr, &chartOrder_);
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -498,11 +499,8 @@ void AppUi::drawLoopbackPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
-    ensureRunningVisuals(loopbackMs_, loopbackViz_, false);
-    drawChartsFreezeToolbar(loopbackViz_, loopbackMs_);
-    ImGui::TextUnformatted("System audio waveform + spectrogram");
-    drawChartPanel(0, loopback_, loopbackMs_, loopbackViz_);
-    loopbackViz_.resetYAxes = false;
+    drawChartHost(&loopback_, loopbackMs_, loopbackViz_, wa::chart_host::Mode::CaptureOnly,
+                  "System audio waveform + spectrogram", nullptr);
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -525,12 +523,9 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("appLoopbackCharts", ImVec2(0, 0), true);
-    ensureRunningVisuals(appLoopbackMs_, appLoopbackViz_, false);
-    drawChartsFreezeToolbar(appLoopbackViz_, appLoopbackMs_);
-    ImGui::TextUnformatted("Application audio waveform + spectrogram");
-    if (appLoopback_)
-        drawChartPanel(0, *appLoopback_, appLoopbackMs_, appLoopbackViz_);
-    appLoopbackViz_.resetYAxes = false;
+    drawChartHost(appLoopback_.get(), appLoopbackMs_, appLoopbackViz_,
+                  wa::chart_host::Mode::CaptureOnly,
+                  "Application audio waveform + spectrogram", nullptr);
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -941,42 +936,66 @@ void AppUi::drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& s
     }
 }
 
-void AppUi::drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
-                             VisualState& viz) {
-    ensureRunningVisuals(status, viz, true);
+void AppUi::drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& status,
+                          VisualState& viz, wa::chart_host::Mode mode, const char* caption,
+                          std::vector<int>* order) {
+    // Chart Host: ensure → freeze/zoom toolbar → panels → clear one-shot Y reset.
+    const bool includeRender = (mode == wa::chart_host::Mode::DualReorderable);
+    ensureRunningVisuals(status, viz, includeRender);
     drawChartsFreezeToolbar(viz, status);
 
-    for (int pos = 0; pos < (int)chartOrder_.size(); ++pos) {
-        int id = chartOrder_[pos];
-        ImGui::PushID(pos);
-        const float bh = ImGui::GetFrameHeight();
-        ImGui::Button("##drag", ImVec2(bh, bh));             // drag handle (move icon drawn on top)
-        if (ImGui::IsItemHovered()) ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
-        const ImVec2 hmn = ImGui::GetItemRectMin(), hmx = ImGui::GetItemRectMax();
-        drawMoveIcon(ImGui::GetWindowDrawList(),
-                     ImVec2((hmn.x + hmx.x) * 0.5f, (hmn.y + hmx.y) * 0.5f),
-                     ImGui::GetFontSize(), ImGui::GetColorU32(ImGuiCol_Text));
-        if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None)) {
-            ImGui::SetDragDropPayload("CHART_POS", &pos, sizeof(int));
-            ImGui::TextUnformatted(chartTitle(id));
-            ImGui::EndDragDropSource();
-        }
-        ImGui::SameLine(); ImGui::TextUnformatted(chartTitle(id));
-        drawChartPanel(id, engine, status, viz);
-        if (ImGui::BeginDragDropTarget()) {
-            if (const ImGuiPayload* pl = ImGui::AcceptDragDropPayload("CHART_POS")) {
-                int from = *(const int*)pl->Data;
-                if (from != pos) {
-                    int moved = chartOrder_[from];
-                    chartOrder_.erase(chartOrder_.begin() + from);
-                    chartOrder_.insert(chartOrder_.begin() + pos, moved);
-                }
+    if (caption && caption[0] != '\0')
+        ImGui::TextUnformatted(caption);
+
+    if (mode == wa::chart_host::Mode::DualReorderable) {
+        // Sanitize / complete order each frame; reorder UI mutates and writes back if order != null.
+        std::vector<int> panelOrder =
+            wa::chart_host::resolvePanelIds(mode, order ? *order : std::vector<int>{});
+        if (order) *order = panelOrder;
+
+        for (int pos = 0; pos < (int)panelOrder.size(); ++pos) {
+            const int id = panelOrder[(size_t)pos];
+            if (!engine) continue;
+            ImGui::PushID(pos);
+            const float bh = ImGui::GetFrameHeight();
+            ImGui::Button("##drag", ImVec2(bh, bh));
+            if (ImGui::IsItemHovered()) ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeAll);
+            const ImVec2 hmn = ImGui::GetItemRectMin(), hmx = ImGui::GetItemRectMax();
+            drawMoveIcon(ImGui::GetWindowDrawList(),
+                         ImVec2((hmn.x + hmx.x) * 0.5f, (hmn.y + hmx.y) * 0.5f),
+                         ImGui::GetFontSize(), ImGui::GetColorU32(ImGuiCol_Text));
+            if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_None)) {
+                ImGui::SetDragDropPayload("CHART_POS", &pos, sizeof(int));
+                ImGui::TextUnformatted(chartTitle(id));
+                ImGui::EndDragDropSource();
             }
-            ImGui::EndDragDropTarget();
+            ImGui::SameLine();
+            ImGui::TextUnformatted(chartTitle(id));
+            drawChartPanel(id, *engine, status, viz);
+            if (ImGui::BeginDragDropTarget()) {
+                if (const ImGuiPayload* pl = ImGui::AcceptDragDropPayload("CHART_POS")) {
+                    const int from = *(const int*)pl->Data;
+                    if (from != pos && from >= 0 && from < (int)panelOrder.size()) {
+                        const int moved = panelOrder[(size_t)from];
+                        panelOrder.erase(panelOrder.begin() + from);
+                        panelOrder.insert(panelOrder.begin() + pos, moved);
+                        if (order) *order = panelOrder;
+                    }
+                }
+                ImGui::EndDragDropTarget();
+            }
+            ImGui::PopID();
         }
-        ImGui::PopID();
+    } else {
+        // Capture-only: single capture combo; skip draw when engine is null.
+        if (engine) {
+            const auto ids = wa::chart_host::resolvePanelIds(mode, {});
+            for (int id : ids)
+                drawChartPanel(id, *engine, status, viz);
+        }
     }
-    viz.resetYAxes = false; // one-shot Y restore consumed by all plots this frame
+
+    viz.resetYAxes = false;
 }
 
 // Plasma-like colormap whose low end fades to fully transparent: silence shows the normal plot

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -6,6 +6,7 @@
 #include <thread>
 #include <vector>
 #include "AudioSessionEnumerator.h"
+#include "ChartHost.h"
 #include "DeviceEnumerator.h"
 #include "MonitorEngine.h"
 #include "Spectrogram.h"
@@ -65,7 +66,11 @@ private:
     void recomputeDefaultFormat();
     void ensureRunningVisuals(const wa::MonitorStatus& status, VisualState& viz,
                               bool includeRender);
-    void drawChartsColumn(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
+    // Chart Host: right-hand charts column (ensure + toolbar + panels + clear resetYAxes).
+    // engine may be null (capture-only toolbar only). order non-null only for DualReorderable.
+    void drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& status, VisualState& viz,
+                       wa::chart_host::Mode mode, const char* caption = nullptr,
+                       std::vector<int>* order = nullptr);
     void drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& status);
     void drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
     void drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz, bool renderSide);

--- a/src/gui/ChartHost.h
+++ b/src/gui/ChartHost.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <vector>
+
+// Pure Chart Host panel-id resolution (no ImGui). AppUi::drawChartHost consumes this.
+namespace wa::chart_host {
+
+enum class Mode {
+    DualReorderable, // Monitor: capture + render combos, reorderable
+    CaptureOnly,     // Loopback pages: single capture combo
+};
+
+inline constexpr int kPanelCapture = 0;
+inline constexpr int kPanelRender  = 1;
+
+// Returns panel ids to draw.
+// CaptureOnly: always {kPanelCapture}.
+// DualReorderable: first occurrence of each valid id (0 or 1) in order, then any missing
+// of {0,1} appended in ascending id order. Unknown ids ignored. Empty order -> {0,1}.
+inline std::vector<int> resolvePanelIds(Mode mode, const std::vector<int>& order) {
+    if (mode == Mode::CaptureOnly)
+        return {kPanelCapture};
+
+    std::vector<int> out;
+    bool seen0 = false;
+    bool seen1 = false;
+    for (int id : order) {
+        if (id == kPanelCapture && !seen0) {
+            out.push_back(kPanelCapture);
+            seen0 = true;
+        } else if (id == kPanelRender && !seen1) {
+            out.push_back(kPanelRender);
+            seen1 = true;
+        }
+    }
+    if (!seen0) out.push_back(kPanelCapture);
+    if (!seen1) out.push_back(kPanelRender);
+    return out;
+}
+
+} // namespace wa::chart_host

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(WinAudioTests
     test_charts_freeze.cpp
     test_charts_time_zoom.cpp
     test_chart_data_pipeline.cpp
+    test_chart_host.cpp
     test_capabilities.cpp
     test_log.cpp
     test_loopback.cpp

--- a/src/tests/test_chart_host.cpp
+++ b/src/tests/test_chart_host.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include "ChartHost.h"
+
+using namespace wa::chart_host;
+
+TEST(ChartHostResolvePanelIds, CaptureOnlyAlwaysCapture) {
+    const auto ids = resolvePanelIds(Mode::CaptureOnly, {1, 0, 2});
+    ASSERT_EQ(ids.size(), 1u);
+    EXPECT_EQ(ids[0], kPanelCapture);
+}
+
+TEST(ChartHostResolvePanelIds, CaptureOnlyIgnoresEmptyOrder) {
+    const auto ids = resolvePanelIds(Mode::CaptureOnly, {});
+    ASSERT_EQ(ids.size(), 1u);
+    EXPECT_EQ(ids[0], kPanelCapture);
+}
+
+TEST(ChartHostResolvePanelIds, DualDefaultWhenEmpty) {
+    const auto ids = resolvePanelIds(Mode::DualReorderable, {});
+    ASSERT_EQ(ids.size(), 2u);
+    EXPECT_EQ(ids[0], kPanelCapture);
+    EXPECT_EQ(ids[1], kPanelRender);
+}
+
+TEST(ChartHostResolvePanelIds, DualPreservesSwappedOrder) {
+    const auto ids = resolvePanelIds(Mode::DualReorderable, {1, 0});
+    ASSERT_EQ(ids.size(), 2u);
+    EXPECT_EQ(ids[0], kPanelRender);
+    EXPECT_EQ(ids[1], kPanelCapture);
+}
+
+TEST(ChartHostResolvePanelIds, DualDropsDuplicatesKeepsFirst) {
+    const auto ids = resolvePanelIds(Mode::DualReorderable, {0, 0, 1, 1});
+    ASSERT_EQ(ids.size(), 2u);
+    EXPECT_EQ(ids[0], kPanelCapture);
+    EXPECT_EQ(ids[1], kPanelRender);
+}
+
+TEST(ChartHostResolvePanelIds, DualIgnoresUnknownAndFillsMissing) {
+    const auto ids = resolvePanelIds(Mode::DualReorderable, {2, 1, 99});
+    ASSERT_EQ(ids.size(), 2u);
+    EXPECT_EQ(ids[0], kPanelRender);
+    EXPECT_EQ(ids[1], kPanelCapture); // missing capture appended after known
+}
+
+TEST(ChartHostResolvePanelIds, DualOnlyCaptureGetsRenderAppended) {
+    const auto ids = resolvePanelIds(Mode::DualReorderable, {0});
+    ASSERT_EQ(ids.size(), 2u);
+    EXPECT_EQ(ids[0], kPanelCapture);
+    EXPECT_EQ(ids[1], kPanelRender);
+}


### PR DESCRIPTION
## What / Why

Monitor, System Loopback, and Application Loopback each hand-rolled the right-hand charts column (ensure visuals, freeze/zoom toolbar, panels, Y-reset clear). That triplication made lifecycle fixes easy to miss. This PR unifies them behind one **Chart Host**.

Parent: #37  
Closes #38  
Closes #37

## How

- Pure `resolvePanelIds` (Dual reorderable vs Capture-only) with gtest.
- `drawChartHost`: ensure → toolbar → panels → clear `resetYAxes`; dual mode uses app `chartOrder_` with drag-reorder; capture-only optional caption and nullable engine.
- Three pages call the same host; left panels and logs unchanged. Chart Data Pipeline untouched.

## Testing

- Debug ctest: **166/166** passed
- Release ctest: local run with PR; CI Debug + Release on this PR
- New: `ChartHostResolvePanelIds.*`
- Manual smoke: requester confirmed before PR

## Checklist

- [x] Conventional Commits, atomic
- [x] Debug 166/166; Release + CI
- [x] resolvePanelIds covered without devices
- [ ] Screenshots N/A (no intentional chrome change)
- [x] Manual smoke by requester