### PR TITLE
feat: multi-track loopback capture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,8 +7,8 @@ Windows audio test tool: capture, loopback, delayed monitor pass-through, and ch
 ### Capture and monitor
 
 **Monitor**:
-A dual-stream session that captures audio and optionally plays it back after a fixed delay, with scope taps for charts.
-_Avoid_: Engine session (when meaning the product feature), pass-through alone
+A dual-stream session that pairs exactly one Capture Track with at most one Render Track after a fixed delay, with scope taps for charts.
+_Avoid_: Engine session (when meaning the product feature), pass-through alone, Track (when meaning the whole pair)
 
 **System Loopback**:
 Capture of mixed system (render-device) audio rather than a microphone endpoint.
@@ -37,15 +37,15 @@ Fixed sample-count step between successive analysis windows that feed one spectr
 _Avoid_: Frame (GUI frame), buffer period alone
 
 **Chart freeze**:
-User-visible pause of chart data refresh only; capture and playback continue.
+User-visible pause of chart data refresh only; capture and playback continue. On a loopback page it applies to one Track’s Chart Host, not the whole page.
 _Avoid_: Pause (when meaning stop the session), Stop
 
 **Linked time axis**:
-Shared horizontal time window across waveforms and spectrograms on one page.
-_Avoid_: x-zoom alone, history length (buffer capacity)
+Shared horizontal time window across waveforms and spectrograms of one Track (including that Track’s channels). Loopback pages do not share one axis across Tracks. The Monitor page still links the pair.
+_Avoid_: x-zoom alone, history length (buffer capacity), page-wide axis (when several Tracks are shown)
 
 **Chart Host**:
-The right-hand charts column on a page: ensure visual buffers, freeze/zoom toolbar, draw the active chart panels, and clear one-shot view resets. Does not own the left control panel or the log region.
+Chart chrome for one visualization unit: freeze/zoom toolbar and the active panels. A loopback page stacks one Capture-only host per Capture Track. Does not own the left control panel or the log region.
 _Avoid_: whole page layout, Chart Data Pipeline, drawComboPanel alone
 
 **Dual reorderable host**:
@@ -58,10 +58,26 @@ _Avoid_: mono monitor (when meaning audio channels)
 
 ### Streams
 
+**Track**:
+A unidirectional stream the user can create and destroy on its own: either a capture of one source or a playback to one render endpoint. Create starts it immediately; there is no idle Track. It owns that source or endpoint, its own scope tap, and its own lifetime and status.
+_Avoid_: session (when meaning one direction), channel, mix, page, Monitor (when meaning one direction)
+
+**Capture source**:
+The kind and identity of what a Capture Track captures: a capture endpoint, a System Loopback render endpoint, or an Application Loopback process tree. It is the recipe, not the running instance.
+_Avoid_: Track, device (when meaning the whole instance)
+
+**Capture Track**:
+A Track that binds one Capture source and may own a WAV sink (optional on the GUI; required per Track on CLI capture).
+_Avoid_: record track, input track, Capture side (when meaning the Track itself)
+
+**Render Track**:
+A Track that plays to one render endpoint.
+_Avoid_: playback track, output track, silent render (helper keepalive is not a Track)
+
 **Capture side**:
-The input leg of a monitor or loopback session (endpoint, system loopback, or application loopback).
+The input leg of a Monitor — exactly one Capture Track — or a Capture Track on a loopback page.
 _Avoid_: Record side, mic only
 
 **Render side**:
-The delayed playback leg of a monitor session when sync playback is engaged.
+The delayed playback leg of a Monitor when sync playback is engaged — at most one Render Track.
 _Avoid_: Output only, speaker path alone

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 - **WASAPI 双后端**：Shared（共享模式）与 Exclusive（独占模式、低延迟），同一流程可切换后端做对比测试。
 - **采集 / 播放**：采集落盘 WAV，播放标准 RIFF WAV；可用 `--format` 指定目标格式（Shared 经 WASAPI 引擎 `AUTOCONVERTPCM` 转换；Exclusive 要求硬件原生支持）。
-- **系统 loopback**：以 render endpoint 为采集源回采系统输出，可选静音 render keepalive 保持时钟推进。
-- **Application Loopback**：按 PID 做 WASAPI process loopback（Shared-only；Windows 10 build 20348+）。默认 **IncludeTree**（只采目标进程及其子进程树）；可选 **ExcludeTree**（采 process-loopback 混音中除该进程树以外的部分）。
-- **双流延迟监听**：capture → 固定延迟 FIFO（漂移补偿）→ render 实时直通，显示 fifo 水位 / drift / xrun。
+- **系统 loopback**：以 render endpoint 为 **Capture source** 回采系统输出，可选静音 render keepalive 保持时钟推进。GUI Loopback 页可同时跑多路 **Capture Track**。
+- **Application Loopback**：按 PID 做 WASAPI process loopback（Shared-only；Windows 10 build 20348+）。默认 **IncludeTree**（只采目标进程及其子进程树）；可选 **ExcludeTree**（采 process-loopback 混音中除该进程树以外的部分）。GUI Application Loopback 页同样是多路 Capture Track。
+- **双流延迟监听**：**Monitor** 仍是一对：正好一路 Capture Track，加上至多一路 Render Track（capture → 固定延迟 FIFO（漂移补偿）→ render），显示 fifo 水位 / drift / xrun。GUI 与 CLI `monitor` 都不做多路列表。
 - **设备能力查询**：Mix / Device / OEM 三来源格式 + 候选格式在 Shared/Exclusive 下的支持矩阵。
 - **格式探测**：检测设备是否支持指定格式（shared 反映 WASAPI 混音器转换能力，exclusive 反映硬件独占可用性）。
 - **实时分析**：dB 时域波形 + 滚动 log 频率声谱图（自带 radix-2 FFT，Hann 窗，dBFS 标定）；GUI 采集侧 2ch+ 按实际 channel 分开显示。
@@ -50,6 +50,8 @@ cd winaudio
 
 运行 `WinAudioGui.exe`，包含 **Monitor** / **Loopback** / **Application Loopback** 三个 tab。日志默认写运行目录下的 `winaudio.log`（双击启动即 exe 目录），左栏日志面板可运行时切换级别、清空、自动滚动。
 
+领域用语：**Track** 是一路可单独创建/销毁的单向流（采集或播放），Create 立即开流，没有 idle Track；**Capture source** 是配方（设备 / PID+mode），不是正在跑的那一路；**Capture Track** 绑定一个 Capture source，GUI 上 WAV 可选；**Monitor** 是唯一的双流会话名；**Chart Host** 是一路图的工具栏 + 面板。两个 loopback 页各自一份列表，每次启动为空；切走 tab 不会停采集。
+
 ### Monitor（双流延迟监听）
 
 两列布局：左列为设备 / 控制 / 状态 / 日志，右列为采集、播放两路「波形 + 声谱图」单元。采集端实际格式为 1ch 时保持单张视图；2ch+ 时按 `Ch N` 垂直堆叠显示各 channel 的 waveform，再显示各 channel 的 spectrogram（最多前 8 个 channel，超出时标出 `8 / N channels`），并按同一 capture end index 同步推进。播放端仍为单张延迟播放视图。所有图共享时间轴，单声道/播放单元中间分割线可上下调节，单元可拖拽重排。
@@ -58,25 +60,29 @@ cd winaudio
 - **Format**：显示当前将用格式（如 `48000 Hz, 16-bit, 2-ch`）；候选下拉第一项为 System default，随后是当前后端支持的候选格式，末项 Custom 可手动输入；切换设备或后端时自动重算默认值。
 - **Control**：「Options」弹窗配置高级流参数——capture/render 各自的 `SetClientProperties` 总开关、category、offload、stream option（None / Raw / MatchFormat / Ambisonics / Post-volume loopback）、ducking（仅 render）、buffer ms；弹窗仅 Start 前可改。「同步播放」checkbox 实时启停 render 直通流（Exclusive 模式要求渲染设备支持采集格式）。
 - **Status**：实时显示 fifo ms / drift，方便观察跨设备时钟漂移。
+- Monitor 保持单一会话：Start / Stop 控制这一对，没有「Destroy all」跨页清列表。DelayFifo 属于 Monitor，不是 Track。
 
 ### Loopback（系统回采）
 
-选择一个 render device 作为回采源，Start 后实时显示系统输出的波形 + 声谱图；实际 2ch+ 时同样按 `Ch N` 分开显示采集到的前 8 个 channel。「Silent render keepalive」默认开启（用静音 render 保持 loopback 时钟推进），运行中不可改。
+本页是一份 System Loopback **Capture Track** 列表（Shared-only），不是单路 Start/Stop。
+
+- **Create Track**：选一个 render device 作为 Capture source，可选填 WAV 与 format，「Silent render keepalive」默认开启（该路 live 期间不可改）。Create 立即开流，没有第二步 Start。同一 render device 允许同时开多路。
+- **Destroy** / **Destroy all**：Destroy 只拆这一路（采集、silent render helper、该路 WAV、该路图）。Destroy all 只清本页，不动 Application Loopback 或 Monitor。
+- 右侧为每路独立的 Capture-only **Chart Host**（波形 + 声谱图；2ch+ 时 `Ch N` 拆分仍在该 Track 内，最多前 8 个 channel）。Chart freeze 与 linked time axis 按 Track，路与路不共享时间轴或格式。
+- WAV 可选：不填只看图；填了则该路单独写文件。多路不会混成一个流或一个文件。
 
 ### Application Loopback（按进程回采）
 
-打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举；点击列表行会把 PID 填入下方输入框，也可手动输入任意非零 PID（不要求出现在列表中）。
+本页是一份 Application Loopback Capture Track 列表（Create / Destroy / Destroy all、堆叠 Chart Host、可选 WAV / format）。Capture source 是 **PID + IncludeTree / ExcludeTree**。Destroy 只拆这一路；Destroy all 只清本页的 Application Loopback Capture Track，不动 Loopback 页或 Monitor。
 
-Control 区同一行：**PID** 输入 + **Exclude** checkbox（默认未勾选）。
+打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举。Session 列表只做发现：点击一行把 PID 填入输入框，也可手输任意非零 PID（不必出现在列表中）。点列表不会开流。
 
-| 模式 | UI | Status / 日志 | 语义（Windows process tree） |
-|------|----|---------------|------------------------------|
-| **IncludeTree**（默认） | Exclude 未勾 | `mode=IncludeTree` | 只采集目标 PID 及其**子进程树**的音频 |
-| **ExcludeTree** | 勾选 Exclude | `mode=ExcludeTree` | 采集 process-loopback 混音中**除**该进程树以外的部分 |
+**PID** 输入 + **Exclude** checkbox（默认未勾选）属于下一次 Create 的配方，写入该 Track 的 Capture source。已在跑的那一路 mode 不再改；要换 mode 或再采同一 PID，再 Create 一路即可。同 PID 不同 mode 不是相等 Capture source；同 PID+mode 也允许同时开两路。
 
-Start 后以 WASAPI process loopback（Shared）按上表模式开流；Starting / Running 时 PID 与 Exclude 一并禁用，改 mode 需先 Stop 再 Start。实际 2ch+ 时按 `Ch N` 分开显示采集到的前 8 个 channel。
-
-不支持：多 PID 列表、运行中热切换 mode、CLI 入口（仅 GUI）。
+| 模式 | UI | 该路状态 | 语义（Windows process tree） |
+|------|----|----------|------------------------------|
+| **IncludeTree**（默认） | Exclude 未勾 | `IncludeTree` | 只采集目标 PID 及其**子进程树**的音频 |
+| **ExcludeTree** | 勾选 Exclude | `ExcludeTree` | 采集 process-loopback 混音中**除**该进程树以外的部分 |
 
 ## CLI 使用
 
@@ -108,14 +114,25 @@ WinAudioCli probe --format 48000/16/2 [--device <id>] [--render|--capture] [--ba
 
 ### capture — 采集
 
+一次 `capture` 是一组 **Capture Track**，共享进程寿命（`--seconds` / Ctrl+C 一起停）。组本身不是 Track。
+
 ```powershell
-WinAudioCli capture --out <file.wav> [--seconds N] [--device <id>] [--loopback] [--no-silent-render]
+# 一路（无 --track，兼容旧脚本）
+WinAudioCli capture --out <file.wav> [--seconds N] [--device <id>] [--loopback]
+                    [--pid N] [--exclude-tree] [--no-silent-render]
                     [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2]
+
+# 一组：每个 --track 一段，每段必须有自己的 --out
+WinAudioCli capture --track --out a.wav --loopback --track --out b.wav --pid 4242 [--seconds N]
 ```
 
-- 默认采集 5 秒，实时打印 L/R 电平与 overrun/underrun 计数。
-- `--format` 两个后端均可用：Shared 经 WASAPI 引擎转换（无本工具重采样）；Exclusive 要求硬件原生支持。
-- `--loopback` 回采系统输出：此时 `--device` 填 render 设备 id；仅支持 Shared；默认启动静音 render keepalive，`--no-silent-render` 关闭。
+- 不加 `--track`、只写一个 `--out`：仍是一路 Capture Track。
+- 重复 `--track`：每段一路。段内 `--pid`（可选 `--exclude-tree`）= Application Loopback；否则 `--loopback` = System Loopback；否则 Endpoint。`--device` 省略则用该种类的默认设备。`--pid` 与 `--loopback` 同段是 usage error。
+- `--format` 与 `--no-silent-render` 按段；`--backend` 与 `--seconds` 整组一次。
+- 一组可混 Endpoint / System Loopback / Application Loopback。相等 Capture source 允许同时开。某一路 Error 不中止其余路；任一路失败则退出码非 0。
+- 每路一个 WAV，没有把多路混成一个文件。默认采集 5 秒，状态行打印 `tracks=` 与电平 / overrun。
+- `--loopback` 时 `--device` 填 render 设备 id；loopback 仅支持 Shared；默认启动静音 render keepalive，`--no-silent-render` 关闭（只作用于 System Loopback 段）。
+- `--format` 两个后端均可用：Shared 经 WASAPI 引擎转换（无本工具重采样）；Exclusive 要求硬件原生支持（loopback 段仍会因 Shared-only 被拒绝）。
 
 ### play — 播放
 
@@ -136,6 +153,7 @@ WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [-
 - `--format` 仅作用于采集端。
 - Shared：WASAPI 引擎在渲染侧桥接采样率，采集/渲染可用不同采样率的设备；Exclusive：渲染设备必须支持采集格式，否则 render 启动失败。
 - `--loopback` 以 render endpoint 为采集源（`--cap` 填 render 设备 id），仅支持 Shared；注意不要把同一个 render 设备既作 loopback 输入又作监听输出。
+- `monitor` 仍是单一 Monitor 对，不接受 `--track` 列表。`list` / `caps` 也不做 Track 列表。
 
 ### 通用参数
 
@@ -156,9 +174,10 @@ WinAudioCli monitor [--cap <id>] [--render <id>] [--delay-ms N] [--seconds N] [-
 - GUI 采集侧 waveform / spectrogram 对实际 2ch+ 格式按 `Ch N` 分开显示，最多显示前 8 个 channel；播放端可视化与电平指示仍为单声道降混。
 - 系统 loopback 与 Application Loopback 仅支持 Shared 后端。
 - Application Loopback 的 Exclude 作用于**整个目标进程树**（含子进程），不是任意多 PID 过滤；与 System Loopback tab 路径不同，对比时请按实际听感理解。
+- 多路 Capture Track 各自独立：不混成一路音频，也不合成一个 WAV。没有产品侧的并发路数上限，也不把某个数字写成 Windows / WASAPI 限制。
 - waveIn / waveOut（MME 后端）未实现。
 
 ## 开发
 
-- 开发者指南（构建细节、架构、编码约束）见 [CLAUDE.md](CLAUDE.md)；历次功能的设计文档在 `docs/superpowers/specs/`，实施计划在 `docs/superpowers/plans/`。
+- 开发者指南（构建细节、架构、编码约束）见 [CLAUDE.md](CLAUDE.md)；领域用语见 [CONTEXT.md](CONTEXT.md)；历次功能的设计文档在 `docs/superpowers/specs/`，实施计划在 `docs/superpowers/plans/`。
 - CI：push / PR 到 `main` 自动以 Debug + Release 双配置构建并跑测试；推送 `v*` tag 自动发布 Release；`Release` workflow 也支持在 GitHub Actions 页面手动触发，手动运行会构建 Release、跑测试并上传 zip artifact，不创建正式 GitHub Release。

--- a/docs/gui-screenshots.md
+++ b/docs/gui-screenshots.md
@@ -10,12 +10,12 @@
 
 ## Loopback
 
-系统 loopback 模式回采当前 render endpoint 的系统输出。
+Loopback 页是一组 System Loopback Capture Track：每路一个 Capture-only Chart Host，回采所选 render endpoint。详见 README Loopback 小节。
 
 ![Loopback running](images/winaudio-loopback-running.png)
 
 ## Application Loopback
 
-Application Loopback 按 PID 做 process loopback：默认 IncludeTree（目标进程树），可选 Exclude（ExcludeTree，混音去掉该进程树）。详见 README Application Loopback 小节。
+Application Loopback 页同样是 Capture Track 列表。Capture source 为 PID + IncludeTree / ExcludeTree。详见 README Application Loopback 小节。
 
 ![Application Loopback running](images/winaudio-application-loopback-running.png)

--- a/docs/superpowers/plans/2026-07-13-winaudio-application-loopback.md
+++ b/docs/superpowers/plans/2026-07-13-winaudio-application-loopback.md
@@ -1,5 +1,7 @@
 # WinAudio Application Loopback Implementation Plan
 
+> **Historical executed plan.** Do not treat this file as a living spec. Product behavior for Application Loopback as Capture Tracks (multi-path GUI/CLI, lifetime, isolation) is specified in [../specs/2026-08-14-winaudio-multi-track-loopback-design.md](../specs/2026-08-14-winaudio-multi-track-loopback-design.md). Process-loopback activation and session enumeration described here remain useful implementation history.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a fully working GUI Application Loopback tab that discovers active WASAPI audio-session processes, allows choosing or manually entering any PID, and captures that process tree through Windows process-loopback audio.

--- a/docs/superpowers/specs/2026-07-09-winaudio-system-loopback-design.md
+++ b/docs/superpowers/specs/2026-07-09-winaudio-system-loopback-design.md
@@ -1,5 +1,7 @@
 # WinAudio System Loopback Design
 
+> **Historical.** Product behavior for how many captures a page may run, Track lifetime, per-Track silent render, and CLI multi-path is specified in [2026-08-14-winaudio-multi-track-loopback-design.md](2026-08-14-winaudio-multi-track-loopback-design.md). Keep the WASAPI narrative below (Shared-only, loopback flag, silent-render *mechanism*) as background only. One-session-per-page and a single page-level silent-render checkbox are obsolete.
+
 ## Scope
 
 This phase adds system loopback capture only. Application/process loopback stays

--- a/docs/superpowers/specs/2026-08-14-winaudio-multi-track-loopback-design.md
+++ b/docs/superpowers/specs/2026-08-14-winaudio-multi-track-loopback-design.md
@@ -1,0 +1,145 @@
+# WinAudio Multi-track Loopback Design
+
+**Status:** canonical for product behavior (Track and multi-path capture).  
+**Tracker copy:** `.scratch/loopback-tracks/spec.md` (`ready-for-agent`).  
+**Glossary:** `CONTEXT.md`.  
+**Map:** `.scratch/loopback-tracks/map.md`.
+
+This document supersedes product behavior in `2026-07-09-winaudio-system-loopback-design.md` (one session per Loopback page, page-level silent-render checkbox) and treats `docs/superpowers/plans/2026-07-13-winaudio-application-loopback.md` as a historical executed plan. WASAPI mechanisms in those files (Shared-only, `AUDCLNT_STREAMFLAGS_LOOPBACK`, process-loopback activation, silent-render helper) remain useful background; they are not the source of truth for how many captures a page may run or how the user starts and stops them.
+
+## Problem Statement
+
+I use WinAudio to compare system output and individual process trees. Today the Loopback page and the Application Loopback page each run only one capture at a time. To watch a second render device or a second PID I have to stop the capture I am already looking at. I need several independent captures alive together, each with its own picture and, when I choose, its own WAV. I do not want them mixed into one stream or one file.
+
+Monitor delayed listen should stay the single pair I already understand. CLI should start several captures in one command so I can script the same comparison.
+
+## Solution
+
+WinAudio gains a global **Track**: a unidirectional live stream the user creates and destroys on its own. A Track is either a **Capture Track** (one **Capture source**) or a **Render Track** (one render endpoint). Create starts immediately; there is no idle Track. Capture source is the recipe; Track is the instance.
+
+- The System Loopback page is a list of System Loopback Capture Tracks. The Application Loopback page is a list of Application Loopback Capture Tracks. Each page: create one, destroy one, destroy all **on this page only**.
+- Each live Capture Track has its own scope tap and, on a loopback page, its own stacked Capture-only **Chart Host** (full wave + spectrogram, multi-channel split inside that Track). The page scrolls. Freeze and the linked time axis are per Track. Tracks do not share an axis or a format.
+- GUI WAV path is optional per Track (omit = charts only). CLI `capture` requires a WAV path per Track. One file per Track; no mixdown.
+- **Monitor** remains one session: exactly one Capture Track plus at most one Render Track. DelayFifo belongs to the Monitor. GUI Monitor and CLI `monitor` do not grow a multi-Track list.
+- CLI `capture` is one process-lifetime **group** of Capture Tracks. Repeat `--track` for each member. No `--track` plus one `--out` remains one Capture Track. A group may mix Endpoint, System Loopback, and Application Loopback. `list` / `caps` do not change model.
+- No product-side numeric cap. Live Tracks may bind equal recipes. Failures stay on the Track that hit them; siblings and the other Monitor side are not auto-stopped. GUI lists are empty every launch.
+
+## User Stories
+
+1. As a test engineer, I want the Loopback page to keep a list of Capture Tracks instead of a single Start/Stop session, so that I can watch more than one render device at once.
+2. As a test engineer, I want the Application Loopback page to keep a list of Capture Tracks, so that I can watch more than one process tree at once.
+3. As a test engineer, I want each GUI loopback page to accept only its own Capture source kind, so that I do not mix device pickers and PID pickers on one page.
+4. As a test engineer, I want to create a Capture Track by choosing a Capture source (and optional WAV and format / silent render) and confirming, so that capture starts immediately without a second Start step.
+5. As a test engineer, I want creating a Track that fails open or start not to leave an idle row, so that the list only contains live instances or clearly failed ones.
+6. As a test engineer, I want to optionally attach a WAV path when I create a GUI Capture Track, so that I can record that path without forcing a file on every visual session.
+7. As a test engineer, I want a GUI Capture Track with no WAV path to still run and show charts, so that I can inspect loopback without choosing a file first.
+8. As a test engineer, I want each Capture Track that has a WAV path to write only its own file, so that two live Tracks never share or mix a recording.
+9. As a test engineer, I want a WAV write failure to mark only that Track, so that siblings on the same page keep running.
+10. As a test engineer, I want to destroy one Capture Track on a page, so that I can drop a path I no longer care about without stopping the others.
+11. As a test engineer, I want destroy to stop that Track’s capture, stop its silent render helper if it has one, close its WAV, drop its scope tap, and remove it from the page list, so that nothing of that instance keeps running or occupying UI.
+12. As a test engineer, I want a destroy-all control on the Loopback page that destroys only System Loopback Capture Tracks on that page, so that I can clear the page without touching Application Loopback or Monitor.
+13. As a test engineer, I want a destroy-all control on the Application Loopback page that destroys only Application Loopback Capture Tracks on that page, so that the other page and Monitor keep running.
+14. As a test engineer using Monitor, I want the page to remain a single Monitor pair (one Capture Track and at most one Render Track), so that delayed listen does not become a multi-output mixer.
+15. As a test engineer using Monitor, I want to stop Monitor with the existing session stop, so that I do not have a second “destroy all” that reaches across pages.
+16. As a test engineer, I want DelayFifo to stay part of Monitor delay, not a Track, so that loopback pages never grow a playback path by accident.
+17. As a test engineer, I want silent render to remain a System Loopback keepalive helper, not a Render Track, so that destroy-all does not look like I had extra playback Tracks.
+18. As a test engineer, I want each live Capture Track to have its own scope tap, so that I can see that path’s waveform and spectrogram without mixing samples from another Track.
+19. As a test engineer, I want multi-channel Capture Tracks to keep the existing per-channel chart split (up to the current channel cap) **inside that Track**, so that channel views are not confused with extra Tracks.
+20. As a test engineer, I want every live Capture Track on a loopback page to show a full stacked Chart Host, so that I can compare paths without selecting one at a time.
+21. As a test engineer, I want freeze on one Track’s host to leave other Tracks’ charts updating, so that I can pause one picture while watching another.
+22. As a test engineer, I want each Track’s wave and spectrogram (and its channels) to share one time axis that is not shared with other Tracks, so that 48 kHz and 44.1 kHz histories do not pretend to align.
+23. As a test engineer, I want to request a format per Track at create, so that I can compare negotiated formats without a page-wide format box.
+24. As a test engineer, I want actual format to appear as that Track’s status, so that sr/ch on its Chart Host match the stream.
+25. As a test engineer, I want silent render chosen per System Loopback Track at create (default on, immutable while live), so that I can run one path with keepalive and one without.
+26. As a test engineer, I want to create another Capture Track for a Capture source I just destroyed, so that teardown of an instance does not retire the device or PID.
+27. As a test engineer, I want to create a Capture Track for a source while another Track bound to the same source is still destroying, so that the UI does not lock the recipe during teardown.
+28. As a test engineer, I want two live Tracks to be allowed to bind equal recipes, so that I can compare silent render or format on the same endpoint or PID.
+29. As a test engineer, I want occupancy or platform errors from a second equal source to show up as that Track’s error, so that the product does not invent a “source busy” lock.
+30. As a test engineer switching tabs, I want Tracks on a hidden loopback page to keep running, so that leaving the page is not destroy.
+31. As a test engineer, I want Monitor’s pair and both loopback page lists to be able to run in the same process, so that I can listen on Monitor while recording loopback Tracks (without mixing them).
+32. As a test engineer, I want a capture open/start failure or a vanished source to Error only that Capture Track, so that siblings keep recording and drawing.
+33. As a test engineer, I want a silent render helper failure to mark only that helper, so that capture on that Track continues.
+34. As a test engineer on Monitor, I want a failed Capture Track or Render Track to report Error without auto-stopping the other side, so that I can observe a half-dead pair as a test phenomenon.
+35. As a test engineer, I want Monitor’s DelayFifo not to be torn down automatically on one-side Error, so that I stop the session myself when I am done looking.
+36. As a CLI user, I want one `capture` invocation to start a group of Capture Tracks, so that I can script a multi-path recording without a GUI.
+37. As a CLI user, I want every Capture Track in that group to require its own `--out`, so that the command cannot imply a shared or mixed WAV.
+38. As a CLI user, I want to write `capture --track --out a.wav --loopback --track --out b.wav --pid 4242`, so that one process records mixed kinds.
+39. As a CLI user, I want a command with no `--track` and one `--out` to remain one Capture Track, so that existing scripts keep working.
+40. As a CLI user, I want `--pid` (optional `--exclude-tree`), else `--loopback`, else Endpoint, mutually exclusive in a segment, so that I do not need `loopback:` prefixes.
+41. As a CLI user, I want `--format` and `--no-silent-render` inside the `--track` segment, so that those choices stay per Track.
+42. As a CLI user, I want `--backend` and `--seconds` once per group, so that process lifetime and backend kind stay shared.
+43. As a CLI user, I want `--pid` plus `--loopback` in the same segment to be a usage error, so that a bad recipe fails before open.
+44. As a CLI user, I want Ctrl+C or `--seconds` to stop the whole group together, so that a script has one lifetime.
+45. As a CLI user, I want some Tracks in the group to be allowed to Error while others keep writing, so that one bad path does not abort the recording set.
+46. As a CLI user, I want a non-zero exit code when any Track failed, so that automation can detect partial failure.
+47. As a CLI user, I want `list` and `caps` to keep their current model, so that discovery commands do not grow Track lists.
+48. As a CLI user, I want `monitor` to stay a single Monitor pair, so that delayed listen on the command line matches the GUI Monitor limit.
+49. As a CLI user, I want the capture group itself not to be a Track, so that logs and status talk about member Tracks, not a fictional mixed stream.
+50. As a test engineer, I want Application Loopback create to still accept a PID that is not in the session list, so that I can target a process that has not shown a session yet.
+51. As a test engineer, I want IncludeTree vs ExcludeTree to remain a property of the Application Loopback Capture source bound to that Track, so that two Tracks can express different modes on the same PID.
+52. As a test engineer, I want System Loopback Capture sources to remain render endpoints, not fake capture devices, so that existing device language stays intact.
+53. As a test engineer, I want Exclusive mode to remain rejected for loopback Tracks, so that Shared-only loopback is unchanged.
+54. As a test engineer, I want no resampler and no mixdown when two Tracks have different formats or rates, so that the tool does not pretend they are one stream.
+55. As a test engineer, I want “independent view” to mean samples from one Track’s scope tap only, so that overlaying or summing Tracks is not offered.
+56. As a test engineer, I want destroy of a Track not to close the render device or kill the target process, so that the Capture source recipe remains usable.
+57. As a test engineer, I want a new Track after recreate to have a new lifetime, new scope tap, and its own optional WAV, so that I do not inherit the destroyed instance’s buffers or file handle.
+58. As a test engineer, I want the empty loopback page (no Tracks) to be a valid state, so that I am not forced to keep a placeholder Track.
+59. As a test engineer, I want every GUI launch to start with empty Track lists, so that restart does not auto-grab devices or processes.
+60. As a test engineer, I want no product-side maximum number of live Tracks, so that I can open as many paths as the machine will take.
+61. As a documentation reader, I want Track, Capture Track, Render Track, Capture source, and Monitor to match `CONTEXT.md`, so that GUI copy, CLI help, and this spec do not invent synonyms.
+62. As an implementer writing tests, I want a Capture Track list I can create/destroy/destroy-all/poll without WASAPI, so that CI can lock lifetime rules.
+63. As an implementer, I want each live Track’s audio path to stay injectable via the existing backend factory style, so that I do not need real devices to prove a Track pumps.
+64. As an implementer, I want each Track’s scope tap to be readable through the existing Scope Reader / Chart Data Pipeline ideas, so that chart tests do not take a dependency on ImGui.
+65. As an implementer, I want GUI drawing and real WASAPI to stay outside the lifetime contract tests, so that create/destroy rules do not rot behind click tests.
+66. As an implementer, I want this spec not to name `MonitorEngine` vs a new type as the required shape, so that the implementation plan can choose composition behind the Capture Track list.
+67. As a test engineer on Monitor, I want creating extra Capture Tracks on that page to be impossible, so that the single-pair limit is a product rule, not a missing button.
+68. As a test engineer, I want CLI `play` / `probe` to stay outside this spec’s Track group, so that playback-from-file is not silently redefined as multi Render Tracks.
+
+## Implementation Decisions
+
+- Domain language is the `CONTEXT.md` glossary. Track is the live instance; Capture source is the recipe; Monitor is the only named session; silent render is not a Track; a CLI capture group is not a Track.
+- One new testable seam: a **Capture Track list**. Operations: create (bind Capture source + optional WAV + per-Track format / silent render, start immediately), destroy one, destroy all, poll per-Track status. GUI loopback pages each own one list. CLI `capture` uses the same list idea as one group with a single process lifetime.
+- Reuse the existing backend-factory injection for each live Track’s pump (fake backends in tests). Reuse Scope Reader / Chart Data Pipeline for per-Track taps. Reuse CLI option-parser tests for `--track` segmentation. Do not use ImGui or real WASAPI as the lifetime contract.
+- The spec does **not** mandate one existing engine object per Track or a new multi-Track engine type. The implementation plan chooses composition behind the list.
+- No second Start/Stop vocabulary on loopback pages. Create starts; destroy stops and removes.
+- Destroy all is scoped to that list / page, never to the whole application and never to Monitor.
+- WAV is per Capture Track. GUI path optional; CLI path required. One file per Track; no shared file; no mixdown into one file.
+- Failures stay on the Track that hit them: WAV write, capture open/start, runtime source loss, silent render helper. Siblings on the page or in the CLI group keep running. CLI `--seconds` / Ctrl+C still stop the whole group; exit code may be non-zero if any Track failed.
+- Monitor: a failed Capture Track or Render Track is Error (overall too). The other side is not auto-stopped; DelayFifo is not auto-torn down. The user stops the session.
+- No product-side maximum number of live Tracks (page, process, or kind). No soft warning threshold. Do not document a number as a Windows / WASAPI limit. Primary sources do not state a concurrent-loopback cap.
+- GUI Track lists do not persist across process restart. Every launch is an empty list. Window-layout persistence may remain chrome-only.
+- Same Capture source may be used to create a new Track while another instance is destroying, and two **live** Tracks may bind equal recipes (same kind + device, or same PID + mode). Same process name with a different PID is not equal. IncludeTree vs ExcludeTree on the same PID is not equal. No product-level “source in use” lock.
+- Loopback pages stack one Capture-only Chart Host per live Capture Track (prototype variant B). Chart freeze, linked time axis, requested/actual format, and (for System Loopback) the silent render toggle are per Track. Silent render is chosen at create, default on, immutable while live.
+- Monitor remains one Capture Track + at most one Render Track. DelayFifo belongs to Monitor.
+- Loopback stays Shared-only. No application resampler. No mixdown of Tracks.
+- CLI `capture` spelling: repeatable `--track` segments; per-segment `--out`, `--format`, `--no-silent-render`, `--pid` / `--exclude-tree` / `--loopback` / `--device`. No `--track` + one `--out` = one Capture Track. `--pid` and `--loopback` in the same segment is a usage error. `--backend` once per group. No manifest file.
+- Do not change `list` / `caps` models.
+
+## Testing Decisions
+
+- Good tests assert external lifetime and isolation behavior, not which concrete engine class sits under a Track, and not ImGui widget IDs.
+- Primary tests target the Capture Track list: create starts a live member; destroy removes it and releases its tap/WAV/helper; destroy all clears only that list; a second list (other page or Monitor) is unaffected; optional vs required WAV; WAV write failure does not destroy siblings; create during destroy of an equal source is allowed at the list API; two live equal recipes are allowed; a failed create does not stop siblings.
+- Those tests must run without audio hardware, using the existing fake-backend factory pattern already used for Monitor session tests.
+- Scope tap independence: reading one Track’s tap must not require another Track’s samples. Prefer the existing Scope Reader / Chart Data Pipeline test style.
+- Loopback source representation and Shared-only rejection stay covered by the existing loopback / monitor session tests; extend them only where a Track list must plumb a Capture source through.
+- CLI parser tests belong next to the current CLI options tests: `--track` segmentation, one-`--out` compat, `--pid` vs `--loopback` vs endpoint, `--pid`+`--loopback` rejected, each segment has `--out`, per-segment `--format` / `--no-silent-render`. No WASAPI.
+- Do not use GUI click-through or `PrintWindow` as the contract for create/destroy.
+- Real-device overlap (two loopbacks on one endpoint, two process loopbacks on one PID) is manual smoke, not CI.
+
+## Out of Scope
+
+- Mixing multiple Tracks into one audio stream or one WAV.
+- Multi-Track GUI Monitor or multi-Track CLI `monitor`.
+- Mixing Capture source kinds on one GUI page.
+- waveIn / waveOut, an in-app resampler, Exclusive-mode loopback.
+- Redefining CLI `play` / `probe` as multi Render Tracks.
+- Inventing a documented Windows concurrent-loopback guarantee.
+- Persisting GUI Track lists or adding a preset / start-all model.
+- Mandating a specific engine class layout in this spec.
+
+## Further Notes
+
+- Wayfinder map (all tickets resolved): `.scratch/loopback-tracks/map.md`.
+- Chart layout prototype (variant B won): `.scratch/loopback-tracks/prototype/multi-track-chart-presentation.html`.
+- WASAPI research: `.scratch/loopback-tracks/research/wasapi-concurrent-loopback-limits.md`.
+- Next flow: `/to-tickets` then `/implement` per ticket in a fresh session. Do not implement from this spec in the same wayfinder thread.

--- a/src/cli/CliOptions.h
+++ b/src/cli/CliOptions.h
@@ -1,5 +1,10 @@
 #pragma once
+#include <cstdlib>
 #include <cwchar>
+#include <string>
+#include <vector>
+#include "CaptureTrackList.h"
+#include "FormatSpec.h"
 #include "IAudioBackend.h"
 
 namespace wa::cli {
@@ -17,4 +22,152 @@ inline LoopbackOptions parseLoopbackOptions(int argc, wchar_t** argv) {
     return opts;
 }
 
+struct CaptureSegment {
+    std::wstring out;
+    std::wstring device;
+    bool         loopback = false;
+    bool         hasPid = false;
+    uint32_t     pid = 0;
+    bool         excludeTree = false;
+    bool         hasFormat = false;
+    AudioFormat  format{};
+    bool         noSilentRender = false;
+};
+
+struct CaptureGroupParse {
+    bool ok = true;
+    std::string message;
+    BackendKind backend = BackendKind::WasapiShared;
+    int seconds = 5;
+    std::vector<CaptureSegment> tracks;
+};
+
+inline int indexOf(int begin, int end, wchar_t** argv, const wchar_t* key) {
+    for (int i = begin; i < end; ++i) {
+        if (std::wcscmp(argv[i], key) == 0) return i;
+    }
+    return -1;
+}
+
+inline bool hasIn(int begin, int end, wchar_t** argv, const wchar_t* key) {
+    return indexOf(begin, end, argv, key) >= 0;
+}
+
+inline std::wstring argIn(int begin, int end, wchar_t** argv, const wchar_t* key) {
+    const int i = indexOf(begin, end, argv, key);
+    if (i < 0 || i + 1 >= end) return L"";
+    return argv[i + 1];
+}
+
+inline std::string narrowAscii(const std::wstring& w) {
+    std::string s;
+    s.reserve(w.size());
+    for (wchar_t c : w) s += static_cast<char>(c);
+    return s;
+}
+
+inline bool parseSegment(int begin, int end, wchar_t** argv, CaptureSegment& seg,
+                         std::string& err) {
+    seg.out = argIn(begin, end, argv, L"--out");
+    if (seg.out.empty()) {
+        err = "capture: each track requires --out";
+        return false;
+    }
+    seg.device = argIn(begin, end, argv, L"--device");
+    seg.loopback = hasIn(begin, end, argv, L"--loopback");
+    seg.excludeTree = hasIn(begin, end, argv, L"--exclude-tree");
+    seg.noSilentRender = hasIn(begin, end, argv, L"--no-silent-render");
+
+    const int pidAt = indexOf(begin, end, argv, L"--pid");
+    if (pidAt >= 0) {
+        if (pidAt + 1 >= end) {
+            err = "capture: --pid requires a process id";
+            return false;
+        }
+        wchar_t* endp = nullptr;
+        const unsigned long v = std::wcstoul(argv[pidAt + 1], &endp, 10);
+        if (!endp || *endp != L'\0' || v == 0) {
+            err = "capture: --pid must be a positive integer";
+            return false;
+        }
+        seg.hasPid = true;
+        seg.pid = static_cast<uint32_t>(v);
+    }
+    if (seg.hasPid && seg.loopback) {
+        err = "capture: --pid and --loopback cannot be combined in one track";
+        return false;
+    }
+
+    const std::wstring fmt = argIn(begin, end, argv, L"--format");
+    if (!fmt.empty()) {
+        if (!parseFormatSpec(narrowAscii(fmt), seg.format)) {
+            err = "invalid --format (want R/B/C[f], e.g. 48000/16/2)";
+            return false;
+        }
+        seg.hasFormat = true;
+    }
+    return true;
+}
+
+inline CaptureGroupParse parseCaptureGroup(int argc, wchar_t** argv) {
+    CaptureGroupParse out;
+    const int start = (argc >= 2) ? 2 : 1;
+
+    const std::wstring backend = argIn(start, argc, argv, L"--backend");
+    if (backend == L"wasapi-exclusive") out.backend = BackendKind::WasapiExclusive;
+
+    const std::wstring sec = argIn(start, argc, argv, L"--seconds");
+    if (!sec.empty()) out.seconds = static_cast<int>(std::wcstol(sec.c_str(), nullptr, 10));
+    if (out.seconds < 0) out.seconds = 0;
+
+    std::vector<int> marks;
+    for (int i = start; i < argc; ++i) {
+        if (std::wcscmp(argv[i], L"--track") == 0) marks.push_back(i);
+    }
+
+    if (marks.empty()) {
+        CaptureSegment seg;
+        if (!parseSegment(start, argc, argv, seg, out.message)) {
+            out.ok = false;
+            return out;
+        }
+        out.tracks.push_back(std::move(seg));
+        return out;
+    }
+
+    for (size_t i = 0; i < marks.size(); ++i) {
+        const int begin = marks[i] + 1;
+        const int end = (i + 1 < marks.size()) ? marks[i + 1] : argc;
+        CaptureSegment seg;
+        if (!parseSegment(begin, end, argv, seg, out.message)) {
+            out.ok = false;
+            return out;
+        }
+        out.tracks.push_back(std::move(seg));
+    }
+    return out;
+}
+
+inline CaptureTrackCreate captureCreateFromSegment(const CaptureSegment& seg, BackendKind kind) {
+    CaptureTrackCreate spec{};
+    spec.kind = kind;
+    spec.wavPath = seg.out;
+    spec.loopbackOptions.silentRender = !seg.noSilentRender;
+    spec.requested = seg.hasFormat ? &seg.format : nullptr;
+    if (seg.hasPid) {
+        spec.source.kind = CaptureSourceKind::ApplicationLoopback;
+        spec.source.processId = seg.pid;
+        spec.source.processLoopbackMode = seg.excludeTree ? ProcessLoopbackMode::ExcludeTree
+                                                          : ProcessLoopbackMode::IncludeTree;
+    } else if (seg.loopback) {
+        spec.source.kind = CaptureSourceKind::SystemLoopback;
+        spec.source.deviceId = seg.device;
+    } else {
+        spec.source.kind = CaptureSourceKind::Endpoint;
+        spec.source.deviceId = seg.device;
+    }
+    return spec;
+}
+
 } // namespace wa::cli
+

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include "CaptureTrackList.h"
 #include "Engine.h"
 #include "DeviceEnumerator.h"
 #include "ComUtil.h"
@@ -132,17 +133,36 @@ int wmain(int argc, wchar_t** argv) {
         }
         LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
         CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint, id};
-        Result r = eng.startCapture(kind, source, out, haveFmt ? &fmt : nullptr,
-                                    loopbackOptions);
+        CaptureTrackList list;
+        CaptureTrackCreate spec{};
+        spec.kind = kind;
+        spec.source = source;
+        spec.wavPath = out;
+        spec.requested = haveFmt ? &fmt : nullptr;
+        spec.loopbackOptions = loopbackOptions;
+        TrackId idTrack = 0;
+        Result r = list.create(spec, &idTrack);
         if (!r) { std::printf("capture start failed: %s\n", r.message.c_str()); return 2; }
+        StreamState last = StreamState::Running;
+        std::string err;
         for (int i = 0; i < seconds * 10; ++i) {
             Sleep(100);
-            EngineStatus s = eng.poll();
-            std::printf("\rL=%.2f R=%.2f over=%llu under=%llu  ",
-                s.levelL, s.levelR,
-                (unsigned long long)s.overruns, (unsigned long long)s.underruns);
+            auto st = list.poll();
+            const float l = st.empty() ? 0.f : st[0].levelL;
+            const float rlev = st.empty() ? 0.f : st[0].levelR;
+            const uint64_t ov = st.empty() ? 0 : st[0].overruns;
+            if (!st.empty()) {
+                last = st[0].state;
+                err = st[0].message;
+            }
+            std::printf("\rL=%.2f R=%.2f over=%llu  ",
+                l, rlev, (unsigned long long)ov);
         }
-        eng.stop();
+        list.destroyAll();
+        if (last == StreamState::Error) {
+            std::printf("\ncapture error: %s\n", err.c_str());
+            return 2;
+        }
         std::printf("\nwrote %ls\n", out.c_str());
         return 0;
     }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -18,8 +18,10 @@ static void usage() {
     std::printf(
         "WinAudioCli list  [--render|--capture]\n"
         "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N] [--loopback]\n"
-        "                    [--no-silent-render] [--backend wasapi-shared|wasapi-exclusive]\n"
-        "                    [--format 48000/16/2] (both backends)\n"
+        "                    [--pid N] [--exclude-tree] [--no-silent-render]\n"
+        "                    [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2]\n"
+        "                    [--track --out <file.wav> [--device <id>] [--loopback|--pid N]\n"
+        "                              [--exclude-tree] [--format ...] [--no-silent-render]]...\n"
         "WinAudioCli play    --in  <file.wav> [--device <id>]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
         "WinAudioCli probe   --format 48000/16/2 [--device <id>] [--render|--capture]\n"
@@ -30,6 +32,7 @@ static void usage() {
         "  (shared: WASAPI engine bridges sample rate on render side;\n"
         "   exclusive: render device must support capture format)\n"
         "  --loopback uses render endpoint ids for capture --device / monitor --cap.\n"
+        "  capture --track starts one Capture Track per segment; omit --track for one --out.\n"
         "WinAudioCli caps  [--device <id>] [--render|--capture]\n");
 }
 
@@ -118,52 +121,59 @@ int wmain(int argc, wchar_t** argv) {
 
     Engine eng;
     if (cmd == L"capture") {
-        std::wstring out = arg(argc, argv, L"--out");
-        if (out.empty()) { usage(); return 1; }
-        std::wstring id = arg(argc, argv, L"--device");
-        std::wstring secStr = arg(argc, argv, L"--seconds");
-        int seconds = secStr.empty() ? 5 : _wtoi(secStr.c_str());
-        AudioFormat fmt{};
-        bool haveFmt = formatArg(argc, argv, fmt);
-        const bool loopback = has(argc, argv, L"--loopback");
-        BackendKind kind = backendArg(argc, argv);
-        if (loopback && kind == BackendKind::WasapiExclusive) {
-            std::printf("capture: --loopback requires --backend wasapi-shared\n");
+        auto group = wa::cli::parseCaptureGroup(argc, argv);
+        if (!group.ok) {
+            std::printf("%s\n", group.message.c_str());
             return 2;
         }
-        LoopbackOptions loopbackOptions = wa::cli::parseLoopbackOptions(argc, argv);
-        CaptureSource source{loopback ? CaptureSourceKind::SystemLoopback : CaptureSourceKind::Endpoint, id};
         CaptureTrackList list;
-        CaptureTrackCreate spec{};
-        spec.kind = kind;
-        spec.source = source;
-        spec.wavPath = out;
-        spec.requested = haveFmt ? &fmt : nullptr;
-        spec.loopbackOptions = loopbackOptions;
-        TrackId idTrack = 0;
-        Result r = list.create(spec, &idTrack);
-        if (!r) { std::printf("capture start failed: %s\n", r.message.c_str()); return 2; }
-        StreamState last = StreamState::Running;
+        static CaptureTrackList* gCaptureList = nullptr;
+        gCaptureList = &list;
+        SetConsoleCtrlHandler([](DWORD) -> BOOL {
+            if (gCaptureList) gCaptureList->destroyAll();
+            return FALSE;
+        }, TRUE);
+        bool anyCreateFail = false;
+        std::vector<std::wstring> outs;
+        outs.reserve(group.tracks.size());
+        for (const auto& seg : group.tracks) {
+            auto spec = wa::cli::captureCreateFromSegment(seg, group.backend);
+            TrackId id = 0;
+            Result r = list.create(spec, &id);
+            if (!r) {
+                std::printf("capture start failed: %s\n", r.message.c_str());
+                anyCreateFail = true;
+                continue;
+            }
+            outs.push_back(seg.out);
+        }
+        if (list.poll().empty()) return 2;
+        bool anyError = anyCreateFail;
         std::string err;
-        for (int i = 0; i < seconds * 10; ++i) {
+        for (int i = 0; i < group.seconds * 10; ++i) {
             Sleep(100);
             auto st = list.poll();
-            const float l = st.empty() ? 0.f : st[0].levelL;
-            const float rlev = st.empty() ? 0.f : st[0].levelR;
-            const uint64_t ov = st.empty() ? 0 : st[0].overruns;
-            if (!st.empty()) {
-                last = st[0].state;
-                err = st[0].message;
+            float l = 0.f, rlev = 0.f;
+            uint64_t ov = 0;
+            for (const auto& s : st) {
+                l = s.levelL;
+                rlev = s.levelR;
+                ov += s.overruns;
+                if (s.state == StreamState::Error) {
+                    anyError = true;
+                    if (!s.message.empty()) err = s.message;
+                }
             }
-            std::printf("\rL=%.2f R=%.2f over=%llu  ",
-                l, rlev, (unsigned long long)ov);
+            std::printf("\rtracks=%zu L=%.2f R=%.2f over=%llu  ",
+                st.size(), l, rlev, (unsigned long long)ov);
         }
         list.destroyAll();
-        if (last == StreamState::Error) {
+        if (anyError) {
             std::printf("\ncapture error: %s\n", err.c_str());
             return 2;
         }
-        std::printf("\nwrote %ls\n", out.c_str());
+        for (const auto& p : outs) std::printf("\nwrote %ls", p.c_str());
+        std::printf("\n");
         return 0;
     }
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -20,8 +20,9 @@ static void usage() {
         "WinAudioCli capture --out <file.wav> [--device <id>] [--seconds N] [--loopback]\n"
         "                    [--pid N] [--exclude-tree] [--no-silent-render]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive] [--format 48000/16/2]\n"
-        "                    [--track --out <file.wav> [--device <id>] [--loopback|--pid N]\n"
-        "                              [--exclude-tree] [--format ...] [--no-silent-render]]...\n"
+        "WinAudioCli capture --track --out <file.wav> [--device <id>] [--loopback|--pid N]\n"
+        "                    [--exclude-tree] [--format ...] [--no-silent-render]\n"
+        "                    [--track --out <file.wav> ...]... [--seconds N] [--backend ...]\n"
         "WinAudioCli play    --in  <file.wav> [--device <id>]\n"
         "                    [--backend wasapi-shared|wasapi-exclusive]\n"
         "WinAudioCli probe   --format 48000/16/2 [--device <id>] [--render|--capture]\n"
@@ -32,7 +33,10 @@ static void usage() {
         "  (shared: WASAPI engine bridges sample rate on render side;\n"
         "   exclusive: render device must support capture format)\n"
         "  --loopback uses render endpoint ids for capture --device / monitor --cap.\n"
-        "  capture --track starts one Capture Track per segment; omit --track for one --out.\n"
+        "  capture: no --track + one --out = one Capture Track; repeat --track for a group.\n"
+        "  each --track needs --out; source is --pid [--exclude-tree] or --loopback or endpoint.\n"
+        "  --format and --no-silent-render are per Capture Track; --seconds and --backend once.\n"
+        "  --pid and --loopback cannot be combined in one --track segment.\n"
         "WinAudioCli caps  [--device <id>] [--render|--capture]\n");
 }
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -252,6 +252,8 @@ int wmain(int argc, wchar_t** argv) {
                                  true, {}, {}, haveFmt ? &capFmt : nullptr,
                                  loopbackOptions);
         if (!r) { std::printf("monitor start failed: %s\n", r.message.c_str()); return 2; }
+        bool sawErr = false;
+        uint32_t errCode = 0;
         for (int i = 0; i < seconds * 5; ++i) {
             Sleep(200);
             wa::MonitorStatus s = mon.poll();
@@ -260,13 +262,17 @@ int wmain(int argc, wchar_t** argv) {
                 s.fifoFillMs, (unsigned long long)s.driftFixes,
                 (unsigned long long)s.capXruns, (unsigned long long)s.renderXruns);
             std::fflush(stdout);
-            if (s.overall == wa::StreamState::Error) {
+            if (s.overall == wa::StreamState::Error && !sawErr) {
                 std::printf("\nerr=%u\n", s.errorCode);
-                mon.stop();
-                return 2;
+                sawErr = true;
+                errCode = s.errorCode;
             }
         }
         mon.stop();
+        if (sawErr) {
+            std::printf("monitor ended with err=%u\n", errCode);
+            return 2;
+        }
         std::printf("\ndone\n");
         return 0;
     }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(WinAudioCore STATIC
     Engine.cpp
     FormatSpec.cpp
     MonitorEngine.cpp
+    CaptureTrackList.cpp
     Capabilities.cpp
     Log.cpp
 )

--- a/src/core/CaptureTrackList.cpp
+++ b/src/core/CaptureTrackList.cpp
@@ -6,6 +6,8 @@
 #include "AudioFormatStr.h"
 #include "Log.h"
 #include "RingBuffer.h"
+#include "SampleConvert.h"
+#include "ScopeBuffer.h"
 #include "WasapiStream.h"
 #include "WavFile.h"
 #include <windows.h>
@@ -61,6 +63,7 @@ struct CaptureTrackList::Member {
     std::unique_ptr<IAudioBackend> backend;
     std::unique_ptr<IAudioBackend> silent;
     std::unique_ptr<RingBuffer>    ring;
+    std::unique_ptr<ScopeBuffer>   tap;
     std::thread pump;
     std::atomic<bool> running{false};
     std::mutex mtx;
@@ -80,6 +83,7 @@ struct CaptureTrackList::Member {
             backend.reset();
         }
         ring.reset();
+        tap.reset();
     }
 };
 
@@ -151,6 +155,7 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
             return r;
         }
 
+        StreamState silentSt = StreamState::Idle;
         if (spec.source.kind == CaptureSourceKind::SystemLoopback
             && spec.loopbackOptions.silentRender) {
             if (silentFactory_)
@@ -173,22 +178,34 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                     m->silent->stop();
                     m->silent->close();
                     m->silent.reset();
+                    silentSt = StreamState::Error;
                 } else {
                     WA_LOG(wa::log::Level::Info, "CaptureTrackList", "silentRender.started",
                            "", "ok");
+                    silentSt = StreamState::Running;
                 }
             }
         }
 
+        {
+            const AudioFormat fmt = m->backend->stats().actualFormat;
+            const uint32_t sr = fmt.sampleRate ? fmt.sampleRate : 48000u;
+            const uint16_t ch = fmt.channels ? fmt.channels : static_cast<uint16_t>(1);
+            const size_t scopeCap = std::max<size_t>(static_cast<size_t>(sr) * 2u, 1048576u);
+            m->tap = std::make_unique<ScopeBuffer>(scopeCap, ch);
+        }
         m->running.store(true, std::memory_order_relaxed);
         {
             std::lock_guard<std::mutex> lk(m->mtx);
             m->status.state = StreamState::Running;
             m->status.actualFormat = m->backend->stats().actualFormat;
+            m->status.silentRenderState = silentSt;
         }
         m->pump = std::thread([mem = m.get()] {
             wa::log::setThreadName("ctl-cap");
             AudioFormat fmt = mem->backend->stats().actualFormat;
+            const uint32_t frameBytes = fmt.blockAlign();
+            const uint16_t ch = fmt.channels ? fmt.channels : static_cast<uint16_t>(1);
             WavWriter writer;
             const bool wantWav = !mem->wavPath.empty();
             if (wantWav) {
@@ -204,12 +221,16 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                 }
             }
             std::vector<uint8_t> buf(16384);
+            std::vector<float> interleaved(4096u * ch, 0.f);
             while (mem->running.load(std::memory_order_relaxed)) {
                 size_t got = mem->ring->read(buf.data(), buf.size());
-                if (got == 0) {
+                if (got == 0 || frameBytes == 0) {
                     Sleep(5);
                     continue;
                 }
+                const size_t frames = got / frameBytes;
+                got = frames * frameBytes;
+                if (frames == 0) continue;
                 if (wantWav && writer.write(buf.data(), got) != got) {
                     WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.write", "", "short write");
                     std::lock_guard<std::mutex> lk(mem->mtx);
@@ -218,6 +239,15 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                     mem->running.store(false, std::memory_order_relaxed);
                     return;
                 }
+                if (mem->tap && frames > 0) {
+                    size_t done = 0;
+                    while (done < frames) {
+                        const size_t chunk = (frames - done > 4096u) ? 4096u : (frames - done);
+                        pcmToFloat(buf.data() + done * frameBytes, chunk, fmt, interleaved.data());
+                        mem->tap->pushInterleaved(interleaved.data(), chunk);
+                        done += chunk;
+                    }
+                }
                 float l = 0.f, r = 0.f;
                 computeLevels(buf.data(), got, fmt, l, r);
                 std::lock_guard<std::mutex> lk(mem->mtx);
@@ -225,6 +255,7 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                 mem->status.levelR = r;
                 mem->status.actualFormat = fmt;
                 mem->status.overruns = mem->ring->overruns();
+                mem->status.writtenFrames = mem->tap ? mem->tap->totalWritten() : 0;
             }
             if (wantWav) writer.close();
         });
@@ -270,6 +301,44 @@ void CaptureTrackList::destroyAll() {
     WA_LOG(wa::log::Level::Info, "CaptureTrackList", "destroyAll",
            "n=" + std::to_string(gone.size()), "");
     for (auto& m : gone) m->stopPumpAndBackends();
+}
+
+const CaptureTrackList::Member* CaptureTrackList::findUnlocked(TrackId id) const {
+    for (const auto& m : members_) {
+        if (m->id == id) return m.get();
+    }
+    return nullptr;
+}
+
+uint64_t CaptureTrackList::written(TrackId id) const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    const Member* m = findUnlocked(id);
+    return (m && m->tap) ? m->tap->totalWritten() : 0;
+}
+
+uint16_t CaptureTrackList::tapChannels(TrackId id) const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    const Member* m = findUnlocked(id);
+    return (m && m->tap) ? m->tap->channels() : 0;
+}
+
+bool CaptureTrackList::snapshotLatest(TrackId id, size_t n, float* out, uint64_t& endIdxOut) const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    const Member* m = findUnlocked(id);
+    return (m && m->tap) ? m->tap->snapshotLatest(n, out, endIdxOut) : false;
+}
+
+bool CaptureTrackList::snapshotEndingAt(TrackId id, uint64_t endIdx, size_t n, float* out) const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    const Member* m = findUnlocked(id);
+    return (m && m->tap) ? m->tap->snapshotEndingAt(endIdx, n, out) : false;
+}
+
+bool CaptureTrackList::snapshotChannelEndingAt(TrackId id, uint16_t channel, uint64_t endIdx,
+                                               size_t n, float* out) const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    const Member* m = findUnlocked(id);
+    return (m && m->tap) ? m->tap->snapshotChannelEndingAt(channel, endIdx, n, out) : false;
 }
 
 std::vector<CaptureTrackStatus> CaptureTrackList::poll() const {

--- a/src/core/CaptureTrackList.cpp
+++ b/src/core/CaptureTrackList.cpp
@@ -1,0 +1,286 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include "CaptureTrackList.h"
+#include "ApplicationLoopbackCapture.h"
+#include "AudioFormatStr.h"
+#include "Log.h"
+#include "RingBuffer.h"
+#include "WasapiStream.h"
+#include "WavFile.h"
+#include <windows.h>
+#include <algorithm>
+#include <cmath>
+#include <thread>
+
+namespace wa {
+
+namespace {
+constexpr size_t kRingBytes = 1u << 20;
+
+void computeLevels(const uint8_t* data, size_t bytes, const AudioFormat& fmt,
+                   float& l, float& r) {
+    l = r = 0.f;
+    if (fmt.channels == 0) return;
+    const uint16_t ch = fmt.channels;
+    if (fmt.isFloat && fmt.bitsPerSample == 32) {
+        const float* s = reinterpret_cast<const float*>(data);
+        size_t n = bytes / 4;
+        for (size_t i = 0; i + ch <= n; i += ch) {
+            l = std::max(l, std::fabs(s[i]));
+            r = std::max(r, std::fabs(s[i + (ch > 1 ? 1 : 0)]));
+        }
+    } else if (!fmt.isFloat && fmt.bitsPerSample == 16) {
+        const int16_t* s = reinterpret_cast<const int16_t*>(data);
+        size_t n = bytes / 2;
+        for (size_t i = 0; i + ch <= n; i += ch) {
+            l = std::max(l, std::fabs(s[i] / 32768.f));
+            r = std::max(r, std::fabs(s[i + (ch > 1 ? 1 : 0)] / 32768.f));
+        }
+    }
+}
+
+bool isLoopbackKind(CaptureSourceKind kind) {
+    return kind == CaptureSourceKind::SystemLoopback
+        || kind == CaptureSourceKind::ApplicationLoopback;
+}
+
+const char* sourceName(CaptureSourceKind kind) {
+    switch (kind) {
+    case CaptureSourceKind::SystemLoopback:      return "system-loopback";
+    case CaptureSourceKind::ApplicationLoopback: return "application-loopback";
+    default:                                     return "endpoint";
+    }
+}
+} // namespace
+
+struct CaptureTrackList::Member {
+    TrackId     id = 0;
+    CaptureSource source{};
+    std::wstring wavPath;
+    std::unique_ptr<IAudioBackend> backend;
+    std::unique_ptr<IAudioBackend> silent;
+    std::unique_ptr<RingBuffer>    ring;
+    std::thread pump;
+    std::atomic<bool> running{false};
+    std::mutex mtx;
+    CaptureTrackStatus status{};
+
+    void stopPumpAndBackends() {
+        running.store(false, std::memory_order_relaxed);
+        if (pump.joinable()) pump.join();
+        if (silent) {
+            silent->stop();
+            silent->close();
+            silent.reset();
+        }
+        if (backend) {
+            backend->stop();
+            backend->close();
+            backend.reset();
+        }
+        ring.reset();
+    }
+};
+
+CaptureTrackList::CaptureTrackList(BackendFactory factory, SilentRenderFactory silentFactory)
+    : factory_(std::move(factory)), silentFactory_(std::move(silentFactory)) {}
+
+CaptureTrackList::~CaptureTrackList() { destroyAll(); }
+
+static std::unique_ptr<IAudioBackend> makeDefaultCaptureBackend(BackendKind kind,
+                                                         const CaptureSource& source,
+                                                         const AudioFormat* requested) {
+    const WasapiMode mode = (kind == BackendKind::WasapiExclusive) ? WasapiMode::Exclusive
+                                                                   : WasapiMode::Shared;
+    if (source.kind == CaptureSourceKind::SystemLoopback)
+        return std::make_unique<WasapiSystemLoopbackCaptureStream>(mode, requested);
+    if (source.kind == CaptureSourceKind::ApplicationLoopback)
+        return std::make_unique<ApplicationLoopbackCaptureStream>(
+            mode, source.processId, requested, source.processLoopbackMode);
+    return std::make_unique<WasapiCaptureStream>(mode, requested);
+}
+
+Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) {
+    if (isLoopbackKind(spec.source.kind) && spec.kind == BackendKind::WasapiExclusive) {
+        WA_LOG(wa::log::Level::Err, "CaptureTrackList", "create",
+               "source=" + std::string(sourceName(spec.source.kind)),
+               "exclusive rejected");
+        return Result::Fail(-1, "WASAPI loopback requires Shared mode");
+    }
+
+    auto m = std::make_unique<Member>();
+    m->source = spec.source;
+    m->wavPath = spec.wavPath;
+    m->status.source = spec.source;
+    m->status.state = StreamState::Idle;
+
+    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "create",
+           std::string("source=") + sourceName(spec.source.kind)
+               + " id=" + (spec.source.deviceId.empty()
+                               ? std::string("(default)")
+                               : wa::narrowAscii(spec.source.deviceId))
+               + (spec.source.kind == CaptureSourceKind::ApplicationLoopback
+                      ? " pid=" + std::to_string(spec.source.processId)
+                      : std::string())
+               + (spec.requested ? " fmt=" + wa::formatAudio(*spec.requested)
+                                 : std::string()),
+           "");
+
+    try {
+        m->ring = std::make_unique<RingBuffer>(kRingBytes);
+        if (factory_)
+            m->backend = factory_(spec.source, spec.requested);
+        else
+            m->backend = makeDefaultCaptureBackend(spec.kind, spec.source, spec.requested);
+        if (!m->backend) {
+            WA_LOG(wa::log::Level::Err, "CaptureTrackList", "create", "", "factory null");
+            return Result::Fail(-1, "CaptureTrackList: capture factory returned null");
+        }
+
+        Result r = m->backend->open(spec.source.deviceId, AudioFormat{}, m->ring.get(),
+                                    StreamParams{});
+        if (!r) {
+            WA_LOG(wa::log::Level::Err, "CaptureTrackList", "create", "open", r.message);
+            return r;
+        }
+        r = m->backend->start();
+        if (!r) {
+            WA_LOG(wa::log::Level::Err, "CaptureTrackList", "create", "start", r.message);
+            m->backend->close();
+            return r;
+        }
+
+        if (spec.source.kind == CaptureSourceKind::SystemLoopback
+            && spec.loopbackOptions.silentRender) {
+            if (silentFactory_)
+                m->silent = silentFactory_(nullptr);
+            else if (!factory_)
+                m->silent = std::make_unique<WasapiSilentRenderStream>(WasapiMode::Shared,
+                                                                       nullptr);
+            if (m->silent) {
+                WA_LOG(wa::log::Level::Info, "CaptureTrackList", "silentRender.start",
+                       "dev=" + (spec.source.deviceId.empty()
+                                     ? std::string("(default)")
+                                     : wa::narrowAscii(spec.source.deviceId)),
+                       "requested");
+                Result sr = m->silent->open(spec.source.deviceId, AudioFormat{}, nullptr, {});
+                if (sr)
+                    sr = m->silent->start();
+                if (!sr) {
+                    WA_LOG(wa::log::Level::Warn, "CaptureTrackList", "silentRender", "",
+                           sr.message);
+                    m->silent->stop();
+                    m->silent->close();
+                    m->silent.reset();
+                } else {
+                    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "silentRender.started",
+                           "", "ok");
+                }
+            }
+        }
+
+        m->running.store(true, std::memory_order_relaxed);
+        {
+            std::lock_guard<std::mutex> lk(m->mtx);
+            m->status.state = StreamState::Running;
+            m->status.actualFormat = m->backend->stats().actualFormat;
+        }
+        m->pump = std::thread([mem = m.get()] {
+            wa::log::setThreadName("ctl-cap");
+            AudioFormat fmt = mem->backend->stats().actualFormat;
+            WavWriter writer;
+            const bool wantWav = !mem->wavPath.empty();
+            if (wantWav) {
+                Result wr = writer.open(mem->wavPath, fmt);
+                if (!wr) {
+                    WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.open", "", wr.message);
+                    std::lock_guard<std::mutex> lk(mem->mtx);
+                    mem->status.state = StreamState::Error;
+                    mem->status.message = wr.message.empty() ? "cannot open output wav"
+                                                             : wr.message;
+                    mem->running.store(false, std::memory_order_relaxed);
+                    return;
+                }
+            }
+            std::vector<uint8_t> buf(16384);
+            while (mem->running.load(std::memory_order_relaxed)) {
+                size_t got = mem->ring->read(buf.data(), buf.size());
+                if (got == 0) {
+                    Sleep(5);
+                    continue;
+                }
+                if (wantWav && writer.write(buf.data(), got) != got) {
+                    WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.write", "", "short write");
+                    std::lock_guard<std::mutex> lk(mem->mtx);
+                    mem->status.state = StreamState::Error;
+                    mem->status.message = "wav write failed";
+                    mem->running.store(false, std::memory_order_relaxed);
+                    return;
+                }
+                float l = 0.f, r = 0.f;
+                computeLevels(buf.data(), got, fmt, l, r);
+                std::lock_guard<std::mutex> lk(mem->mtx);
+                mem->status.levelL = l;
+                mem->status.levelR = r;
+                mem->status.actualFormat = fmt;
+                mem->status.overruns = mem->ring->overruns();
+            }
+            if (wantWav) writer.close();
+        });
+    } catch (const std::exception& e) {
+        m->stopPumpAndBackends();
+        WA_LOG(wa::log::Level::Err, "CaptureTrackList", "create", "", e.what());
+        return Result::Fail(-1, e.what());
+    }
+
+    std::lock_guard<std::mutex> lk(mtx_);
+    m->id = nextId_++;
+    m->status.id = m->id;
+    if (outId) *outId = m->id;
+    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "create",
+           "id=" + std::to_string(m->id)
+               + " fmt=" + wa::formatAudio(m->status.actualFormat),
+           "ok");
+    members_.push_back(std::move(m));
+    return Result::Ok();
+}
+
+void CaptureTrackList::destroy(TrackId id) {
+    std::unique_ptr<Member> gone;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        auto it = std::find_if(members_.begin(), members_.end(),
+                               [id](const std::unique_ptr<Member>& m) { return m->id == id; });
+        if (it == members_.end()) return;
+        gone = std::move(*it);
+        members_.erase(it);
+    }
+    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "destroy",
+           "id=" + std::to_string(id), "");
+    gone->stopPumpAndBackends();
+}
+
+void CaptureTrackList::destroyAll() {
+    std::vector<std::unique_ptr<Member>> gone;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        gone.swap(members_);
+    }
+    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "destroyAll",
+           "n=" + std::to_string(gone.size()), "");
+    for (auto& m : gone) m->stopPumpAndBackends();
+}
+
+std::vector<CaptureTrackStatus> CaptureTrackList::poll() const {
+    std::lock_guard<std::mutex> lk(mtx_);
+    std::vector<CaptureTrackStatus> out;
+    out.reserve(members_.size());
+    for (const auto& m : members_) {
+        std::lock_guard<std::mutex> mlk(m->mtx);
+        out.push_back(m->status);
+    }
+    return out;
+}
+
+} // namespace wa

--- a/src/core/CaptureTrackList.h
+++ b/src/core/CaptureTrackList.h
@@ -30,6 +30,8 @@ struct CaptureTrackStatus {
     float         levelL = 0.f;
     float         levelR = 0.f;
     uint64_t      overruns = 0;
+    uint64_t      writtenFrames = 0;
+    StreamState   silentRenderState = StreamState::Idle;
     std::string   message;
 };
 
@@ -53,6 +55,13 @@ public:
     void   destroyAll();
     std::vector<CaptureTrackStatus> poll() const;
 
+    uint64_t written(TrackId id) const;
+    uint16_t tapChannels(TrackId id) const;
+    bool snapshotLatest(TrackId id, size_t n, float* out, uint64_t& endIdxOut) const;
+    bool snapshotEndingAt(TrackId id, uint64_t endIdx, size_t n, float* out) const;
+    bool snapshotChannelEndingAt(TrackId id, uint16_t channel, uint64_t endIdx, size_t n,
+                                 float* out) const;
+
 private:
     struct Member;
     BackendFactory       factory_;
@@ -60,6 +69,8 @@ private:
     TrackId              nextId_ = 1;
     std::vector<std::unique_ptr<Member>> members_;
     mutable std::mutex   mtx_;
+
+    const Member* findUnlocked(TrackId id) const;
 };
 
 } // namespace wa

--- a/src/core/CaptureTrackList.h
+++ b/src/core/CaptureTrackList.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+#include "Engine.h"
+#include "IAudioBackend.h"
+#include "MonitorEngine.h"
+#include "Result.h"
+
+namespace wa {
+
+using TrackId = uint64_t;
+
+struct CaptureTrackCreate {
+    BackendKind     kind = BackendKind::WasapiShared;
+    CaptureSource   source{};
+    std::wstring    wavPath;
+    const AudioFormat* requested = nullptr;
+    LoopbackOptions loopbackOptions{};
+};
+
+struct CaptureTrackStatus {
+    TrackId       id = 0;
+    StreamState   state = StreamState::Idle;
+    CaptureSource source{};
+    AudioFormat   actualFormat{};
+    float         levelL = 0.f;
+    float         levelR = 0.f;
+    uint64_t      overruns = 0;
+    std::string   message;
+};
+
+// Live Capture Tracks with independent lifetime. Create starts immediately.
+// BackendFactory / SilentRenderFactory are test seams (no WASAPI).
+class CaptureTrackList {
+public:
+    using BackendFactory =
+        std::function<std::unique_ptr<IAudioBackend>(const CaptureSource&, const AudioFormat*)>;
+    using SilentRenderFactory =
+        std::function<std::unique_ptr<IAudioBackend>(const AudioFormat*)>;
+
+    explicit CaptureTrackList(BackendFactory factory = {}, SilentRenderFactory silentFactory = {});
+    ~CaptureTrackList();
+
+    CaptureTrackList(const CaptureTrackList&)            = delete;
+    CaptureTrackList& operator=(const CaptureTrackList&) = delete;
+
+    Result create(const CaptureTrackCreate& spec, TrackId* outId);
+    void   destroy(TrackId id);
+    void   destroyAll();
+    std::vector<CaptureTrackStatus> poll() const;
+
+private:
+    struct Member;
+    BackendFactory       factory_;
+    SilentRenderFactory  silentFactory_;
+    TrackId              nextId_ = 1;
+    std::vector<std::unique_ptr<Member>> members_;
+    mutable std::mutex   mtx_;
+};
+
+} // namespace wa

--- a/src/core/IAudioBackend.h
+++ b/src/core/IAudioBackend.h
@@ -71,6 +71,9 @@ public:
     // Auto-reset event a monitor pump can wait on; signaled after each capture ring write.
     // nullptr if the backend provides no such signal (default).
     virtual void* dataReadyEvent() const { return nullptr; }
+
+    // Runtime fault observed by a pump; default is healthy. Does not stop the peer stream.
+    virtual bool inError() const { return false; }
 };
 
 } // namespace wa

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -260,7 +260,7 @@ Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
     delayMsAtomic_.store(delayMs, std::memory_order_relaxed);
     capDataReadyEvent_ = capBackend_->dataReadyEvent();
 
-    // --- Optional render at start (synchronous engage -> full rollback on failure = CLI parity) ---
+    // Optional render at start. Capture stays up if render cannot engage.
     wantPlayback_.store(playbackEnabled, std::memory_order_relaxed);
     if (playbackEnabled) {
         if (Result r = engageRender(); !r) {
@@ -272,16 +272,23 @@ Result MonitorEngine::start(BackendKind kind, const CaptureSource& capSource,
                                : (code == static_cast<long>(MonitorError::LoopbackFeedback))
                                    ? MonitorError::LoopbackFeedback
                                    : MonitorError::RenderStart;
-            return rollback(StreamState::Error, err, code, std::move(msg));   // stops capture too
+            renderState_.store(StreamState::Error, std::memory_order_relaxed);
+            errorCode_.store(static_cast<uint32_t>(err), std::memory_order_relaxed);
+            overall_.store(StreamState::Error, std::memory_order_relaxed);
+            wantPlayback_.store(false, std::memory_order_relaxed);
+        } else {
+            overall_.store(StreamState::Running, std::memory_order_relaxed);
         }
+    } else {
+        overall_.store(StreamState::Running, std::memory_order_relaxed);
     }
-
-    // Capture is up -> engine Running (independent of render prefill).
-    overall_.store(StreamState::Running, std::memory_order_relaxed);
-    WA_LOG(wa::log::Level::Info, "MonitorEngine", "engine.running",
+    const StreamState overall = overall_.load(std::memory_order_relaxed);
+    WA_LOG(wa::log::Level::Info, "MonitorEngine",
+           overall == StreamState::Error ? "engine.error" : "engine.running",
            "cap=" + wa::narrowAscii(capSource.deviceId) +
            " ren=" + wa::narrowAscii(renderId) +
-           " sr=" + std::to_string(capFmt_.sampleRate), "ok");
+           " sr=" + std::to_string(capFmt_.sampleRate),
+           overall == StreamState::Error ? "render-failed-capture-up" : "ok");
 
     running_.store(true, std::memory_order_release);
     try {
@@ -410,13 +417,34 @@ void MonitorEngine::pumpLoop() {
                         ? MonitorError::LoopbackFeedback
                         : MonitorError::RenderStart),
                     std::memory_order_relaxed);
+                overall_.store(StreamState::Error, std::memory_order_relaxed);
                 wantPlayback_.store(false, std::memory_order_relaxed); // don't retry every wake
-                // capture continues untouched
+                // capture continues; DelayFifo is only created on successful engage
             }
-        } else if (!want && active) {
+        } else if (!want && active
+                   && renderState_.load(std::memory_order_relaxed) != StreamState::Error) {
             disengageRender();
         }
-        const bool renderActive = (renderBackend_ != nullptr);
+
+        if (capBackend_ && capBackend_->inError()
+            && capState_.load(std::memory_order_relaxed) != StreamState::Error) {
+            WA_LOG(wa::log::Level::Err, "MonitorEngine", "capture.runtime", "", "inError");
+            capState_.store(StreamState::Error, std::memory_order_relaxed);
+            overall_.store(StreamState::Error, std::memory_order_relaxed);
+            errorCode_.store(static_cast<uint32_t>(MonitorError::CaptureStart),
+                             std::memory_order_relaxed);
+        }
+        if (renderBackend_ && renderBackend_->inError()
+            && renderState_.load(std::memory_order_relaxed) != StreamState::Error) {
+            WA_LOG(wa::log::Level::Err, "MonitorEngine", "render.runtime", "", "inError");
+            renderState_.store(StreamState::Error, std::memory_order_relaxed);
+            overall_.store(StreamState::Error, std::memory_order_relaxed);
+            errorCode_.store(static_cast<uint32_t>(MonitorError::RenderStart),
+                             std::memory_order_relaxed);
+        }
+
+        const bool renderActive = (renderBackend_ != nullptr)
+            && renderState_.load(std::memory_order_relaxed) != StreamState::Error;
         const uint16_t renderCh         = renderCh_;
         const uint32_t renderFrameBytes = renderFrameBytes_;
 

--- a/src/core/TrackScopeReader.h
+++ b/src/core/TrackScopeReader.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "CaptureTrackList.h"
+#include "ScopeReader.h"
+
+namespace wa {
+
+class TrackScopeReader final : public ScopeReader {
+public:
+    TrackScopeReader(const CaptureTrackList& list, TrackId id) : list_(list), id_(id) {}
+
+    uint64_t written() const override { return list_.written(id_); }
+    uint16_t channels() const override { return list_.tapChannels(id_); }
+
+    bool snapshotLatest(size_t n, float* out, uint64_t& endIdxOut) const override {
+        return list_.snapshotLatest(id_, n, out, endIdxOut);
+    }
+    bool snapshotEndingAt(uint64_t endIdx, size_t n, float* out) const override {
+        return list_.snapshotEndingAt(id_, endIdx, n, out);
+    }
+    bool snapshotChannelEndingAt(uint16_t channel, uint64_t endIdx, size_t n,
+                                 float* out) const override {
+        return list_.snapshotChannelEndingAt(id_, channel, endIdx, n, out);
+    }
+
+private:
+    const CaptureTrackList& list_;
+    TrackId                 id_ = 0;
+};
+
+} // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -22,6 +23,28 @@ static std::string wtou(const std::wstring& w) {
     int n = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), nullptr, 0, nullptr, nullptr);
     std::string s(n, 0);
     WideCharToMultiByte(CP_UTF8, 0, w.c_str(), (int)w.size(), s.data(), n, nullptr, nullptr);
+    return s;
+}
+
+static std::wstring utow(const char* u) {
+    if (!u || !*u) return {};
+    int n = MultiByteToWideChar(CP_UTF8, 0, u, -1, nullptr, 0);
+    if (n <= 1) return {};
+    std::wstring w(static_cast<size_t>(n - 1), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, u, -1, w.data(), n);
+    return w;
+}
+
+static wa::MonitorStatus statusFromTrack(const wa::CaptureTrackStatus& t) {
+    wa::MonitorStatus s{};
+    s.overall = t.state;
+    s.capState = t.state;
+    s.sampleRate = t.actualFormat.sampleRate;
+    s.captureChannels = t.actualFormat.channels;
+    s.capXruns = t.overruns;
+    s.capWrittenFrames = t.writtenFrames;
+    s.capLevel = (t.levelL > t.levelR) ? t.levelL : t.levelR;
+    s.silentRenderState = t.silentRenderState;
     return s;
 }
 
@@ -113,7 +136,7 @@ void AppUi::stopAll() {
         appLoopbackStartThread_.join();
     }
     monitor_.stop();
-    loopback_.stop();
+    loopbackTracks_.destroyAll();
     if (appLoopback_) appLoopback_->stop();
 }
 
@@ -419,7 +442,6 @@ void AppUi::draw() {
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
     drainApplicationLoopbackStart();
     ms_ = monitor_.poll();
-    loopbackMs_ = loopback_.poll();
     if (!appLoopbackStartPending_ && appLoopback_)
         appLoopbackMs_ = appLoopback_->poll();
     const int curRenderState = (int)ms_.renderState;
@@ -499,8 +521,40 @@ void AppUi::drawLoopbackPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
-    drawChartHost(&loopback_, loopbackMs_, loopbackViz_, wa::chart_host::Mode::CaptureOnly,
-                  "System audio waveform + spectrogram", nullptr);
+    const auto tracks = loopbackTracks_.poll();
+    for (size_t i = 0; i < loopbackViz_.size();) {
+        bool live = false;
+        for (const auto& t : tracks) {
+            if (t.id == loopbackViz_[i].first) { live = true; break; }
+        }
+        if (!live) loopbackViz_.erase(loopbackViz_.begin() + static_cast<std::ptrdiff_t>(i));
+        else ++i;
+    }
+    if (tracks.empty()) {
+        ImGui::TextUnformatted(wa::ui_text::kLoopbackEmptyHint);
+    } else {
+        for (const auto& t : tracks) {
+            VisualState* viz = nullptr;
+            for (auto& p : loopbackViz_) {
+                if (p.first == t.id) { viz = &p.second; break; }
+            }
+            if (!viz) {
+                loopbackViz_.push_back({t.id, VisualState{}});
+                viz = &loopbackViz_.back().second;
+            }
+            ImGui::PushID(static_cast<int>(t.id));
+            std::string cap = "Track " + std::to_string(t.id);
+            if (t.actualFormat.sampleRate)
+                cap += "  " + std::to_string(t.actualFormat.sampleRate) + " Hz / "
+                    + std::to_string(t.actualFormat.channels) + " ch";
+            if (t.state == wa::StreamState::Error && !t.message.empty())
+                cap += "  [" + t.message + "]";
+            wa::TrackScopeReader reader(loopbackTracks_, t.id);
+            drawChartHost(nullptr, statusFromTrack(t), *viz, wa::chart_host::Mode::CaptureOnly,
+                          cap.c_str(), nullptr, &reader);
+            ImGui::PopID();
+        }
+    }
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -556,51 +610,54 @@ void AppUi::drawLoopbackLeftPanel() {
         ImGui::EndCombo();
     }
 
+    ImGui::InputText(wa::ui_text::kLoopbackWavOptional, loopbackWav_, sizeof(loopbackWav_));
+    ImGui::InputText(wa::ui_text::kLoopbackFormatOptional, loopbackFmt_, sizeof(loopbackFmt_));
+    ImGui::Checkbox(wa::ui_text::kLoopbackSilentRender, &loopbackSilentRender_);
+
     ImGui::SeparatorText("Control");
     const ImVec2 ctrlBtn(120.0f, ImGui::GetFrameHeight() * 1.3f);
-    if (!loopbackStarted_) {
-        if (ImGui::Button("Start", ctrlBtn)) {
-            wa::DeviceId id = renderDevices_.empty() ? L"" : renderDevices_[(size_t)loopbackDevIdx_].id;
-            wa::CaptureSource source{wa::CaptureSourceKind::SystemLoopback, id};
-            wa::LoopbackOptions loopbackOptions{};
-            loopbackOptions.silentRender = loopbackSilentRender_;
-            wa::Result r = loopback_.start(wa::BackendKind::WasapiShared, source, L"", 0,
-                                           false, {}, {}, nullptr, loopbackOptions);
-            logLines_.push_back(r ? "loopback started" : ("loopback error: " + r.message));
-            if (r) {
-                loopbackStarted_ = true;
-                resetVisuals(loopbackViz_);
-            }
+    if (ImGui::Button(wa::ui_text::kLoopbackCreate, ctrlBtn)) {
+        wa::DeviceId id = renderDevices_.empty() ? L"" : renderDevices_[(size_t)loopbackDevIdx_].id;
+        wa::CaptureTrackCreate spec{};
+        spec.kind = wa::BackendKind::WasapiShared;
+        spec.source = wa::CaptureSource{wa::CaptureSourceKind::SystemLoopback, id};
+        spec.wavPath = utow(loopbackWav_);
+        spec.loopbackOptions.silentRender = loopbackSilentRender_;
+        wa::AudioFormat fmt{};
+        if (loopbackFmt_[0] != '\0' && wa::parseFormatSpec(loopbackFmt_, fmt))
+            spec.requested = &fmt;
+        else if (loopbackFmt_[0] != '\0') {
+            logLines_.push_back("loopback create error: invalid format");
         }
-    } else {
-        if (ImGui::Button("Stop", ctrlBtn)) {
-            loopback_.stop();
-            loopbackStarted_ = false;
-            resetVisuals(loopbackViz_);
-            logLines_.push_back("loopback stopped");
+        if (loopbackFmt_[0] == '\0' || spec.requested) {
+            wa::TrackId tid = 0;
+            wa::Result r = loopbackTracks_.create(spec, &tid);
+            logLines_.push_back(r ? ("loopback track created id=" + std::to_string(tid))
+                                  : ("loopback error: " + r.message));
         }
     }
-    if (!loopbackStarted_) {
-        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
-    } else {
-        ImGui::BeginDisabled();
-        ImGui::Checkbox("Silent render keepalive", &loopbackSilentRender_);
-        ImGui::EndDisabled();
+    ImGui::SameLine();
+    if (ImGui::Button(wa::ui_text::kLoopbackDestroyAll, ctrlBtn)) {
+        loopbackTracks_.destroyAll();
+        loopbackViz_.clear();
+        logLines_.push_back("loopback destroy all");
     }
 
-    ImGui::SeparatorText("Status");
+    ImGui::SeparatorText(wa::ui_text::kLoopbackTracks);
     const char* ss[] = {"Idle", "Running", "Error"};
-    ImGui::Text("overall=%s  cap=%s  sr=%u",
-        ss[(int)loopbackMs_.overall], ss[(int)loopbackMs_.capState], loopbackMs_.sampleRate);
-    ImGui::Text("xrun=%llu", (unsigned long long)loopbackMs_.capXruns);
-    ImGui::Text("frames=%llu", (unsigned long long)loopbackMs_.capWrittenFrames);
-    ImGui::Text("silent-packet=%llu  idle-fill=%llu",
-        (unsigned long long)loopbackMs_.loopbackSilentPacketFrames,
-        (unsigned long long)loopbackMs_.loopbackIdleSilenceFrames);
-    ImGui::Text("silent render=%s",
-        ss[(int)loopbackMs_.silentRenderState]);
-    ImGui::ProgressBar(loopbackMs_.capLevel, ImVec2(-1, 0), "level");
-
+    const auto tracks = loopbackTracks_.poll();
+    for (const auto& t : tracks) {
+        ImGui::PushID(static_cast<int>(t.id));
+        ImGui::Text("id=%llu  %s  sr=%u  xrun=%llu",
+                    (unsigned long long)t.id, ss[(int)t.state],
+                    t.actualFormat.sampleRate, (unsigned long long)t.overruns);
+        ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
+        if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
+            loopbackTracks_.destroy(t.id);
+            logLines_.push_back("loopback track destroyed id=" + std::to_string(t.id));
+        }
+        ImGui::PopID();
+    }
 }
 
 void AppUi::drawApplicationLoopbackLeftPanel() {
@@ -938,7 +995,7 @@ void AppUi::drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& s
 
 void AppUi::drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& status,
                           VisualState& viz, wa::chart_host::Mode mode, const char* caption,
-                          std::vector<int>* order) {
+                          std::vector<int>* order, wa::ScopeReader* captureReader) {
     // Chart Host: ensure → freeze/zoom toolbar → panels → clear one-shot Y reset.
     const bool includeRender = (mode == wa::chart_host::Mode::DualReorderable);
     ensureRunningVisuals(status, viz, includeRender);
@@ -971,7 +1028,9 @@ void AppUi::drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& st
             }
             ImGui::SameLine();
             ImGui::TextUnformatted(chartTitle(id));
-            drawChartPanel(id, *engine, status, viz);
+            wa::MonitorScopeReader cap(*engine, wa::MonitorScopeReader::Side::Capture);
+            wa::MonitorScopeReader ren(*engine, wa::MonitorScopeReader::Side::Render);
+            drawChartPanel(id, cap, &ren, status, viz);
             if (ImGui::BeginDragDropTarget()) {
                 if (const ImGuiPayload* pl = ImGui::AcceptDragDropPayload("CHART_POS")) {
                     const int from = *(const int*)pl->Data;
@@ -987,11 +1046,14 @@ void AppUi::drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& st
             ImGui::PopID();
         }
     } else {
-        // Capture-only: single capture combo; skip draw when engine is null.
-        if (engine) {
-            const auto ids = wa::chart_host::resolvePanelIds(mode, {});
+        const auto ids = wa::chart_host::resolvePanelIds(mode, {});
+        if (captureReader) {
             for (int id : ids)
-                drawChartPanel(id, *engine, status, viz);
+                drawChartPanel(id, *captureReader, nullptr, status, viz);
+        } else if (engine) {
+            wa::MonitorScopeReader ownedCap(*engine, wa::MonitorScopeReader::Side::Capture);
+            for (int id : ids)
+                drawChartPanel(id, ownedCap, nullptr, status, viz);
         }
     }
 
@@ -1143,7 +1205,7 @@ void AppUi::drawWaveformPanel(VisualState& viz, const char* plotId, const float*
 // One combined cell per stream: waveform on top, spectrogram below (Audition-style), sharing the
 // linked time axis, with a draggable horizontal splitter between them. comboRatio_ is shared by
 // both streams so the capture and render cells stay height-aligned for side-by-side comparison.
-void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status,
+void AppUi::drawComboPanel(wa::ScopeReader& reader, const wa::MonitorStatus& status,
                            VisualState& viz, bool renderSide) {
     const uint32_t sr         = status.sampleRate;
     const bool overallRunning = (status.overall     == wa::StreamState::Running && sr > 0);
@@ -1154,9 +1216,6 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
     const bool splitCapture = !renderSide && overallRunning && capturePlan.split;
 
     // Chart Data Pipeline: hop-aligned spectrum + latest wave history; freeze gated inside.
-    wa::MonitorScopeReader reader(
-        engine, renderSide ? wa::MonitorScopeReader::Side::Render
-                           : wa::MonitorScopeReader::Side::Capture);
     wa::ChartRefreshParams refreshParams;
     refreshParams.reader = &reader;
     refreshParams.frozen = viz.chartsFrozen;
@@ -1259,14 +1318,14 @@ void AppUi::drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& s
                          renderSide ? kSlotRenSpectro : kSlotCapSpectroBase);
 }
 
-void AppUi::drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status,
-                           VisualState& viz) {
+void AppUi::drawChartPanel(int id, wa::ScopeReader& captureReader, wa::ScopeReader* renderReader,
+                           const wa::MonitorStatus& status, VisualState& viz) {
     switch (id) {
-    case 0:   // Capture waveform + spectrogram combo
-        drawComboPanel(engine, status, viz, false);
+    case 0:
+        drawComboPanel(captureReader, status, viz, false);
         break;
-    case 1:   // Render waveform + spectrogram combo — data only while playback runs
-        drawComboPanel(engine, status, viz, true);
+    case 1:
+        if (renderReader) drawComboPanel(*renderReader, status, viz, true);
         break;
     default:
         break;

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -127,17 +127,9 @@ void AppUi::refreshMonitorDevices() {
 }
 
 void AppUi::stopAll() {
-    if (appLoopbackStartPending_) {
-        if (appLoopbackStartThread_.joinable())
-            appLoopbackStartThread_.detach();
-        appLoopbackStartPending_ = false;
-        appLoopbackStartJob_.reset();
-    } else if (appLoopbackStartThread_.joinable()) {
-        appLoopbackStartThread_.join();
-    }
     monitor_.stop();
     loopbackTracks_.destroyAll();
-    if (appLoopback_) appLoopback_->stop();
+    appLoopbackTracks_.destroyAll();
 }
 
 void AppUi::refreshApplicationLoopbackSessions() {
@@ -154,64 +146,6 @@ void AppUi::refreshApplicationLoopbackSessions() {
                                             appLoopbackSessionsLoaded_,
                                             appLoopbackSessionIdx_,
                                             std::move(rows));
-}
-
-void AppUi::beginApplicationLoopbackStart(uint32_t pid, wa::ProcessLoopbackMode mode) {
-    if (appLoopbackStartThread_.joinable())
-        appLoopbackStartThread_.join();
-
-    auto job = std::make_shared<AppLoopbackStartJob>();
-    appLoopbackStartJob_ = job;
-    appLoopbackStartPending_ = true;
-    appLoopbackMode_ = mode;
-
-    appLoopbackStartThread_ = std::thread([job, pid, mode] {
-        auto engine = std::make_unique<wa::MonitorEngine>();
-        wa::CaptureSource source{wa::CaptureSourceKind::ApplicationLoopback, L"", pid, mode};
-        wa::Result r = engine->start(wa::BackendKind::WasapiShared, source, L"", 0,
-                                     false, {}, {}, nullptr, {});
-        std::lock_guard<std::mutex> lk(job->mtx);
-        job->result = std::move(r);
-        if (job->result)
-            job->engine = std::move(engine);
-        job->done = true;
-    });
-}
-
-void AppUi::drainApplicationLoopbackStart() {
-    if (!appLoopbackStartPending_ || !appLoopbackStartJob_)
-        return;
-
-    auto job = appLoopbackStartJob_;
-    wa::Result result = wa::Result::Ok();
-    std::unique_ptr<wa::MonitorEngine> startedEngine;
-    {
-        std::lock_guard<std::mutex> lk(job->mtx);
-        if (!job->done)
-            return;
-        result = job->result;
-        if (result)
-            startedEngine = std::move(job->engine);
-    }
-
-    if (appLoopbackStartThread_.joinable())
-        appLoopbackStartThread_.join();
-    appLoopbackStartPending_ = false;
-    appLoopbackStartJob_.reset();
-
-    if (result && startedEngine) {
-        if (appLoopback_)
-            appLoopback_->stop();
-        appLoopback_ = std::move(startedEngine);
-        appLoopbackStarted_ = true;
-        resetVisuals(appLoopbackViz_);
-        logLines_.push_back("application loopback started");
-    } else {
-        appLoopbackStarted_ = false;
-        logLines_.push_back("application loopback error: " +
-                            (result ? std::string("start completed without engine")
-                                    : result.message));
-    }
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -440,10 +374,7 @@ void AppUi::draw() {
                         logLines_.begin() + (logLines_.size() - kMaxLogLines));
 
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
-    drainApplicationLoopbackStart();
     ms_ = monitor_.poll();
-    if (!appLoopbackStartPending_ && appLoopback_)
-        appLoopbackMs_ = appLoopback_->poll();
     const int curRenderState = (int)ms_.renderState;
     if (prevRenderState_ == (int)wa::StreamState::Running &&
         curRenderState  != (int)wa::StreamState::Running) {
@@ -508,6 +439,49 @@ void AppUi::drawMonitorPage() {
     ImGui::EndChild();
 }
 
+void AppUi::drawStackedCaptureTrackHosts(wa::CaptureTrackList& list,
+                                         std::vector<std::pair<wa::TrackId, VisualState>>& viz,
+                                         const char* emptyHint) {
+    const auto tracks = list.poll();
+    for (size_t i = 0; i < viz.size();) {
+        bool live = false;
+        for (const auto& t : tracks) {
+            if (t.id == viz[i].first) { live = true; break; }
+        }
+        if (!live) viz.erase(viz.begin() + static_cast<std::ptrdiff_t>(i));
+        else ++i;
+    }
+    if (tracks.empty()) {
+        ImGui::TextUnformatted(emptyHint);
+        return;
+    }
+    for (const auto& t : tracks) {
+        VisualState* vs = nullptr;
+        for (auto& p : viz) {
+            if (p.first == t.id) { vs = &p.second; break; }
+        }
+        if (!vs) {
+            viz.push_back({t.id, VisualState{}});
+            vs = &viz.back().second;
+        }
+        ImGui::PushID(static_cast<int>(t.id));
+        std::string cap = "Track " + std::to_string(t.id);
+        if (t.source.kind == wa::CaptureSourceKind::ApplicationLoopback) {
+            cap += "  pid=" + std::to_string(t.source.processId);
+            cap += std::string("  ") + wa::processLoopbackModeName(t.source.processLoopbackMode);
+        }
+        if (t.actualFormat.sampleRate)
+            cap += "  " + std::to_string(t.actualFormat.sampleRate) + " Hz / "
+                + std::to_string(t.actualFormat.channels) + " ch";
+        if (t.state == wa::StreamState::Error && !t.message.empty())
+            cap += "  [" + t.message + "]";
+        wa::TrackScopeReader reader(list, t.id);
+        drawChartHost(nullptr, statusFromTrack(t), *vs, wa::chart_host::Mode::CaptureOnly,
+                      cap.c_str(), nullptr, &reader);
+        ImGui::PopID();
+    }
+}
+
 void AppUi::drawLoopbackPage() {
     constexpr float kLogHeight = 200.0f;
     const float availY = ImGui::GetContentRegionAvail().y;
@@ -521,40 +495,7 @@ void AppUi::drawLoopbackPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("loopbackCharts", ImVec2(0, 0), true);
-    const auto tracks = loopbackTracks_.poll();
-    for (size_t i = 0; i < loopbackViz_.size();) {
-        bool live = false;
-        for (const auto& t : tracks) {
-            if (t.id == loopbackViz_[i].first) { live = true; break; }
-        }
-        if (!live) loopbackViz_.erase(loopbackViz_.begin() + static_cast<std::ptrdiff_t>(i));
-        else ++i;
-    }
-    if (tracks.empty()) {
-        ImGui::TextUnformatted(wa::ui_text::kLoopbackEmptyHint);
-    } else {
-        for (const auto& t : tracks) {
-            VisualState* viz = nullptr;
-            for (auto& p : loopbackViz_) {
-                if (p.first == t.id) { viz = &p.second; break; }
-            }
-            if (!viz) {
-                loopbackViz_.push_back({t.id, VisualState{}});
-                viz = &loopbackViz_.back().second;
-            }
-            ImGui::PushID(static_cast<int>(t.id));
-            std::string cap = "Track " + std::to_string(t.id);
-            if (t.actualFormat.sampleRate)
-                cap += "  " + std::to_string(t.actualFormat.sampleRate) + " Hz / "
-                    + std::to_string(t.actualFormat.channels) + " ch";
-            if (t.state == wa::StreamState::Error && !t.message.empty())
-                cap += "  [" + t.message + "]";
-            wa::TrackScopeReader reader(loopbackTracks_, t.id);
-            drawChartHost(nullptr, statusFromTrack(t), *viz, wa::chart_host::Mode::CaptureOnly,
-                          cap.c_str(), nullptr, &reader);
-            ImGui::PopID();
-        }
-    }
+    drawStackedCaptureTrackHosts(loopbackTracks_, loopbackViz_, wa::ui_text::kLoopbackEmptyHint);
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -577,9 +518,8 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::SameLine();
 
     ImGui::BeginChild("appLoopbackCharts", ImVec2(0, 0), true);
-    drawChartHost(appLoopback_.get(), appLoopbackMs_, appLoopbackViz_,
-                  wa::chart_host::Mode::CaptureOnly,
-                  "Application audio waveform + spectrogram", nullptr);
+    drawStackedCaptureTrackHosts(appLoopbackTracks_, appLoopbackViz_,
+                                 wa::ui_text::kApplicationLoopbackEmptyHint);
     ImGui::EndChild();
     ImGui::EndChild();
 
@@ -686,9 +626,6 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     }
     ImGui::EndChild();
 
-    ImGui::SeparatorText("Control");
-    const bool freezeParams = appLoopbackStartPending_ || appLoopbackStarted_;
-    if (freezeParams) ImGui::BeginDisabled();
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted(wa::ui_text::kApplicationLoopbackPidLabel);
     ImGui::SameLine();
@@ -696,55 +633,66 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     ImGui::InputText("##appLoopbackPid", appLoopbackPid_, sizeof(appLoopbackPid_));
     ImGui::SameLine();
     ImGui::Checkbox(wa::ui_text::kApplicationLoopbackExclude, &appLoopbackExclude_);
-    if (freezeParams) ImGui::EndDisabled();
+    ImGui::InputText(wa::ui_text::kLoopbackWavOptional, appLoopbackWav_, sizeof(appLoopbackWav_));
+    ImGui::InputText(wa::ui_text::kLoopbackFormatOptional, appLoopbackFmt_, sizeof(appLoopbackFmt_));
 
+    ImGui::SeparatorText("Control");
     const ImVec2 ctrlBtn(120.0f, ImGui::GetFrameHeight() * 1.3f);
-    bool startPending = appLoopbackStartPending_;
-    if (startPending) {
-        ImGui::BeginDisabled();
-        ImGui::Button("Starting...", ctrlBtn);
-        ImGui::EndDisabled();
-    } else if (!appLoopbackStarted_) {
-        if (ImGui::Button("Start", ctrlBtn)) {
-            uint32_t pid = 0;
-            if (!wa::parseApplicationLoopbackPid(appLoopbackPid_, pid)) {
-                logLines_.push_back("application loopback error: invalid PID");
-            } else {
-                const wa::ProcessLoopbackMode mode = appLoopbackExclude_
-                    ? wa::ProcessLoopbackMode::ExcludeTree
-                    : wa::ProcessLoopbackMode::IncludeTree;
-                logLines_.push_back(std::string("application loopback starting mode=") +
-                                    wa::processLoopbackModeName(mode));
-                beginApplicationLoopbackStart(pid, mode);
+    if (ImGui::Button(wa::ui_text::kLoopbackCreate, ctrlBtn)) {
+        uint32_t pid = 0;
+        if (!wa::parseApplicationLoopbackPid(appLoopbackPid_, pid)) {
+            logLines_.push_back("application loopback create error: invalid PID");
+        } else {
+            const wa::ProcessLoopbackMode mode = appLoopbackExclude_
+                ? wa::ProcessLoopbackMode::ExcludeTree
+                : wa::ProcessLoopbackMode::IncludeTree;
+            wa::CaptureTrackCreate spec{};
+            spec.kind = wa::BackendKind::WasapiShared;
+            spec.source = wa::CaptureSource{wa::CaptureSourceKind::ApplicationLoopback, L"",
+                                            pid, mode};
+            spec.wavPath = utow(appLoopbackWav_);
+            wa::AudioFormat fmt{};
+            if (appLoopbackFmt_[0] != '\0' && wa::parseFormatSpec(appLoopbackFmt_, fmt))
+                spec.requested = &fmt;
+            else if (appLoopbackFmt_[0] != '\0') {
+                logLines_.push_back("application loopback create error: invalid format");
+            }
+            if (appLoopbackFmt_[0] == '\0' || spec.requested) {
+                wa::TrackId tid = 0;
+                wa::Result r = appLoopbackTracks_.create(spec, &tid);
+                logLines_.push_back(r
+                    ? ("application loopback track created id=" + std::to_string(tid)
+                       + " pid=" + std::to_string(pid)
+                       + " mode=" + wa::processLoopbackModeName(mode))
+                    : ("application loopback error: " + r.message));
             }
         }
-    } else {
-        if (ImGui::Button("Stop", ctrlBtn)) {
-            if (appLoopback_) appLoopback_->stop();
-            appLoopbackStarted_ = false;
-            resetVisuals(appLoopbackViz_);
-            logLines_.push_back("application loopback stopped");
-        }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(wa::ui_text::kLoopbackDestroyAll, ctrlBtn)) {
+        appLoopbackTracks_.destroyAll();
+        appLoopbackViz_.clear();
+        logLines_.push_back("application loopback destroy all");
     }
 
-    ImGui::SeparatorText("Status");
+    ImGui::SeparatorText(wa::ui_text::kLoopbackTracks);
     const char* ss[] = {"Idle", "Running", "Error"};
-    ImGui::Text("overall=%s  cap=%s  sr=%u",
-        ss[(int)appLoopbackMs_.overall], ss[(int)appLoopbackMs_.capState],
-        appLoopbackMs_.sampleRate);
-    // Running/pending: mode latched at Start; idle: preview from checkbox.
-    const wa::ProcessLoopbackMode statusMode =
-        freezeParams
-            ? appLoopbackMode_
-            : (appLoopbackExclude_ ? wa::ProcessLoopbackMode::ExcludeTree
-                                   : wa::ProcessLoopbackMode::IncludeTree);
-    ImGui::Text("mode=%s", wa::processLoopbackModeName(statusMode));
-    ImGui::Text("xrun=%llu", (unsigned long long)appLoopbackMs_.capXruns);
-    ImGui::Text("frames=%llu", (unsigned long long)appLoopbackMs_.capWrittenFrames);
-    ImGui::Text("silent-packet=%llu  idle-fill=%llu",
-        (unsigned long long)appLoopbackMs_.loopbackSilentPacketFrames,
-        (unsigned long long)appLoopbackMs_.loopbackIdleSilenceFrames);
-    ImGui::ProgressBar(appLoopbackMs_.capLevel, ImVec2(-1, 0), "level");
+    const auto tracks = appLoopbackTracks_.poll();
+    for (const auto& t : tracks) {
+        ImGui::PushID(static_cast<int>(t.id));
+        ImGui::Text("id=%llu  %s  pid=%u  %s  sr=%u  xrun=%llu",
+                    (unsigned long long)t.id, ss[(int)t.state],
+                    t.source.processId,
+                    wa::processLoopbackModeName(t.source.processLoopbackMode),
+                    t.actualFormat.sampleRate, (unsigned long long)t.overruns);
+        ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
+        if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
+            appLoopbackTracks_.destroy(t.id);
+            logLines_.push_back("application loopback track destroyed id="
+                                + std::to_string(t.id));
+        }
+        ImGui::PopID();
+    }
 }
 
 void AppUi::drawLeftPanel() {

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 #include <vector>
 #include "AudioSessionEnumerator.h"
 #include "CaptureTrackList.h"
@@ -19,13 +18,6 @@ public:
     void stopAll();       // stop engines on shutdown (idempotent)
     void pushLog(int level, const std::string& line);  // thread-safe; called from the logging pump thread
 private:
-    struct AppLoopbackStartJob {
-        std::mutex mtx;
-        bool done = false;
-        wa::Result result = wa::Result::Ok();
-        std::unique_ptr<wa::MonitorEngine> engine;
-    };
-
     struct VisualState {
         std::vector<float> capWave, renderWave;
         std::vector<std::vector<float>> capChannelWaves;
@@ -54,13 +46,14 @@ private:
 
     void refreshMonitorDevices();
     void refreshApplicationLoopbackSessions();
-    void beginApplicationLoopbackStart(uint32_t pid, wa::ProcessLoopbackMode mode);
-    void drainApplicationLoopbackStart();
     void drawMonitorPage();
     void drawLoopbackPage();
     void drawApplicationLoopbackPage();
     void drawLoopbackLeftPanel();
     void drawApplicationLoopbackLeftPanel();
+    void drawStackedCaptureTrackHosts(wa::CaptureTrackList& list,
+                                      std::vector<std::pair<wa::TrackId, VisualState>>& viz,
+                                      const char* emptyHint);
     void drawLeftPanel();
     void drawAdvancedModal();
     void drawCapsModal();
@@ -87,11 +80,10 @@ private:
 
     wa::MonitorEngine    monitor_;
     wa::CaptureTrackList loopbackTracks_;
-    std::unique_ptr<wa::MonitorEngine> appLoopback_ = std::make_unique<wa::MonitorEngine>();
+    wa::CaptureTrackList appLoopbackTracks_;
     wa::DeviceEnumerator enumerator_;
     wa::AudioSessionEnumerator sessionEnumerator_;
     wa::MonitorStatus    ms_;   // polled once per frame in draw(); shared by helper methods
-    wa::MonitorStatus    appLoopbackMs_;
 
     int  backendIdx_      = 0;
     bool playbackEnabled_ = false;
@@ -114,16 +106,13 @@ private:
     bool                        loopbackSilentRender_ = true;
     char                        loopbackWav_[260] = "";
     char                        loopbackFmt_[32] = "";
-    bool                        appLoopbackStarted_ = false;
-    bool                        appLoopbackStartPending_ = false;
-    bool                        appLoopbackExclude_ = false; // checkbox; false = IncludeTree
+    bool                        appLoopbackExclude_ = false; // create recipe; false = IncludeTree
     bool                        appLoopbackSessionsLoaded_ = false;
     std::vector<wa::AudioSessionProcess> appLoopbackSessions_;
     int                         appLoopbackSessionIdx_ = -1;
     char                        appLoopbackPid_[32] = "";
-    wa::ProcessLoopbackMode     appLoopbackMode_ = wa::ProcessLoopbackMode::IncludeTree;
-    std::thread                 appLoopbackStartThread_;
-    std::shared_ptr<AppLoopbackStartJob> appLoopbackStartJob_;
+    char                        appLoopbackWav_[260] = "";
+    char                        appLoopbackFmt_[32] = "";
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};
@@ -139,5 +128,5 @@ private:
 
     VisualState monitorViz_;
     std::vector<std::pair<wa::TrackId, VisualState>> loopbackViz_;
-    VisualState appLoopbackViz_;
+    std::vector<std::pair<wa::TrackId, VisualState>> appLoopbackViz_;
 };

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -6,10 +6,12 @@
 #include <thread>
 #include <vector>
 #include "AudioSessionEnumerator.h"
+#include "CaptureTrackList.h"
 #include "ChartHost.h"
 #include "DeviceEnumerator.h"
 #include "MonitorEngine.h"
 #include "Spectrogram.h"
+#include "TrackScopeReader.h"
 
 class AppUi {
 public:
@@ -70,10 +72,12 @@ private:
     // engine may be null (capture-only toolbar only). order non-null only for DualReorderable.
     void drawChartHost(wa::MonitorEngine* engine, const wa::MonitorStatus& status, VisualState& viz,
                        wa::chart_host::Mode mode, const char* caption = nullptr,
-                       std::vector<int>* order = nullptr);
+                       std::vector<int>* order = nullptr, wa::ScopeReader* captureReader = nullptr);
     void drawChartsFreezeToolbar(VisualState& viz, const wa::MonitorStatus& status);
-    void drawChartPanel(int id, wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz);
-    void drawComboPanel(wa::MonitorEngine& engine, const wa::MonitorStatus& status, VisualState& viz, bool renderSide);
+    void drawChartPanel(int id, wa::ScopeReader& captureReader, wa::ScopeReader* renderReader,
+                        const wa::MonitorStatus& status, VisualState& viz);
+    void drawComboPanel(wa::ScopeReader& reader, const wa::MonitorStatus& status, VisualState& viz,
+                        bool renderSide);
     void drawSpectrogramPanel(VisualState& viz, const char* plotId, wa::Spectrogram* spec, double histSec, float height, int slot);
     void drawWaveformPanel(VisualState& viz, const char* plotId, const float* wave, int n, uint32_t sr, bool haveData, float height, int slot);
     void drawLogPanel(const char* childId, bool showLevelFilter);
@@ -82,12 +86,11 @@ private:
     void resetRenderVisuals(VisualState& viz);
 
     wa::MonitorEngine    monitor_;
-    wa::MonitorEngine    loopback_;
+    wa::CaptureTrackList loopbackTracks_;
     std::unique_ptr<wa::MonitorEngine> appLoopback_ = std::make_unique<wa::MonitorEngine>();
     wa::DeviceEnumerator enumerator_;
     wa::AudioSessionEnumerator sessionEnumerator_;
     wa::MonitorStatus    ms_;   // polled once per frame in draw(); shared by helper methods
-    wa::MonitorStatus    loopbackMs_;
     wa::MonitorStatus    appLoopbackMs_;
 
     int  backendIdx_      = 0;
@@ -108,8 +111,9 @@ private:
     int                         loopbackDevIdx_ = 0;
     int                         delayMs_      = 100;
     bool                        monitorStarted_ = false;
-    bool                        loopbackStarted_ = false;
     bool                        loopbackSilentRender_ = true;
+    char                        loopbackWav_[260] = "";
+    char                        loopbackFmt_[32] = "";
     bool                        appLoopbackStarted_ = false;
     bool                        appLoopbackStartPending_ = false;
     bool                        appLoopbackExclude_ = false; // checkbox; false = IncludeTree
@@ -134,6 +138,6 @@ private:
     wa::DeviceCapabilities capsCache_{};
 
     VisualState monitorViz_;
-    VisualState loopbackViz_;
+    std::vector<std::pair<wa::TrackId, VisualState>> loopbackViz_;
     VisualState appLoopbackViz_;
 };

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -44,5 +44,7 @@ inline constexpr const char* kLoopbackSilentRender = "Silent render keepalive";
 inline constexpr const char* kLoopbackWavOptional = "WAV (optional)";
 inline constexpr const char* kLoopbackFormatOptional = "Format (optional)";
 inline constexpr const char* kLoopbackEmptyHint = "Create a Track to capture system audio.";
+inline constexpr const char* kApplicationLoopbackEmptyHint =
+    "Create a Track to capture application audio.";
 
 } // namespace wa::ui_text

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -36,4 +36,13 @@ inline constexpr const char* kChartsZoomOut = "Zoom out";
 inline constexpr const char* kChartsZoomIn = "Zoom in";
 inline constexpr const char* kChartsResetView = "Reset view";
 
+inline constexpr const char* kLoopbackCreate = "Create Track";
+inline constexpr const char* kLoopbackDestroy = "Destroy";
+inline constexpr const char* kLoopbackDestroyAll = "Destroy all";
+inline constexpr const char* kLoopbackTracks = "Tracks";
+inline constexpr const char* kLoopbackSilentRender = "Silent render keepalive";
+inline constexpr const char* kLoopbackWavOptional = "WAV (optional)";
+inline constexpr const char* kLoopbackFormatOptional = "Format (optional)";
+inline constexpr const char* kLoopbackEmptyHint = "Create a Track to capture system audio.";
+
 } // namespace wa::ui_text

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(WinAudioTests
     test_scope_reader.cpp
     test_analysis.cpp
     test_monitorengine.cpp
+    test_capture_track_list.cpp
     test_spectrogram.cpp
     test_capture_channel_view.cpp
     test_charts_freeze.cpp

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -69,6 +69,8 @@ TEST(AppLoopbackUiText, ExposesRequiredControls) {
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackPidLabel, "PID");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackExclude, "Exclude");
     EXPECT_STREQ(wa::ui_text::kApplicationLoopbackSessions, "Sessions");
+    EXPECT_STREQ(wa::ui_text::kApplicationLoopbackEmptyHint,
+                 "Create a Track to capture application audio.");
 }
 
 TEST(AdvancedOptionsUiText, ExposesExplicitClientPropertiesControls) {

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -94,6 +94,14 @@ TEST(ChartsTimeZoomUiText, ExposesZoomAndResetLabels) {
     EXPECT_STREQ(wa::ui_text::kChartsZoomOut, "Zoom out");
     EXPECT_STREQ(wa::ui_text::kChartsZoomIn, "Zoom in");
     EXPECT_STREQ(wa::ui_text::kChartsResetView, "Reset view");
+    EXPECT_STREQ(wa::ui_text::kLoopbackCreate, "Create Track");
+    EXPECT_STREQ(wa::ui_text::kLoopbackDestroy, "Destroy");
+    EXPECT_STREQ(wa::ui_text::kLoopbackDestroyAll, "Destroy all");
+    EXPECT_STREQ(wa::ui_text::kLoopbackTracks, "Tracks");
+    EXPECT_STREQ(wa::ui_text::kLoopbackSilentRender, "Silent render keepalive");
+    EXPECT_STREQ(wa::ui_text::kLoopbackWavOptional, "WAV (optional)");
+    EXPECT_STREQ(wa::ui_text::kLoopbackFormatOptional, "Format (optional)");
+    EXPECT_STREQ(wa::ui_text::kLoopbackEmptyHint, "Create a Track to capture system audio.");
 }
 
 TEST(AppLoopbackUiModel, SelectingRowCopiesPidIntoEditableBuffer) {

--- a/src/tests/test_capture_track_list.cpp
+++ b/src/tests/test_capture_track_list.cpp
@@ -1,0 +1,246 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+#include "CaptureTrackList.h"
+#include "RingBuffer.h"
+
+using namespace wa;
+
+namespace {
+
+class FakeBackend : public IAudioBackend {
+public:
+    FakeBackend(AudioFormat fmt, bool failStart, std::atomic<bool>* stoppedOut, bool failOpen)
+        : fmt_(fmt), failStart_(failStart), stoppedOut_(stoppedOut), failOpen_(failOpen) {}
+
+    Result open(const DeviceId&, const AudioFormat&, RingBuffer* ring,
+                const StreamParams&) override {
+        if (failOpen_) return Result::Fail(122, "fake: open failed");
+        ring_ = ring;
+        return Result::Ok();
+    }
+    Result start() override {
+        if (failStart_) return Result::Fail(123, "fake: start failed");
+        return Result::Ok();
+    }
+    void stop() override {
+        if (stoppedOut_) stoppedOut_->store(true, std::memory_order_relaxed);
+    }
+    void close() override {}
+    BackendStats stats() const override {
+        BackendStats s{};
+        s.actualFormat = fmt_;
+        return s;
+    }
+
+    AudioFormat        fmt_;
+    bool               failStart_ = false;
+    std::atomic<bool>* stoppedOut_ = nullptr;
+    bool               failOpen_ = false;
+    RingBuffer*        ring_ = nullptr;
+};
+
+struct ListRig {
+    AudioFormat fmt{48000, 2, 16, false};
+    bool failOpen = false;
+    bool failStart = false;
+    std::vector<FakeBackend*> caps;
+    std::vector<std::unique_ptr<std::atomic<bool>>> stopped;
+
+    CaptureTrackList::BackendFactory factory() {
+        return [this](const CaptureSource&, const AudioFormat*) {
+            stopped.push_back(std::make_unique<std::atomic<bool>>(false));
+            auto b = std::make_unique<FakeBackend>(fmt, failStart, stopped.back().get(), failOpen);
+            caps.push_back(b.get());
+            return b;
+        };
+    }
+};
+
+template <typename Pred>
+bool waitFor(Pred pred, int timeoutMs = 3000) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (pred()) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return pred();
+}
+
+std::wstring tempWav(const wchar_t* tag) {
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    return std::wstring(dir) + L"wa_ctl_" + tag + L"_" + std::to_wstring(GetTickCount64()) + L".wav";
+}
+
+} // namespace
+
+TEST(CaptureTrackList, CreateStartsLiveTrack) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    CaptureTrackCreate spec{};
+    spec.source.kind = CaptureSourceKind::Endpoint;
+    Result r = list.create(spec, &id);
+    ASSERT_TRUE(r) << r.message;
+    EXPECT_NE(id, 0u);
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_EQ(st[0].id, id);
+    EXPECT_EQ(st[0].state, StreamState::Running);
+    EXPECT_EQ(st[0].source.kind, CaptureSourceKind::Endpoint);
+    list.destroyAll();
+}
+
+TEST(CaptureTrackList, DestroyRemovesTrackAndStopsBackend) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    ASSERT_TRUE(list.create({}, &id));
+    ASSERT_EQ(list.poll().size(), 1u);
+    list.destroy(id);
+    EXPECT_TRUE(list.poll().empty());
+    ASSERT_FALSE(rig.stopped.empty());
+    EXPECT_TRUE(rig.stopped.back()->load(std::memory_order_relaxed));
+}
+
+TEST(CaptureTrackList, DestroyAllClearsEveryMember) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    ASSERT_TRUE(list.create({}, nullptr));
+    ASSERT_TRUE(list.create({}, nullptr));
+    EXPECT_EQ(list.poll().size(), 2u);
+    list.destroyAll();
+    EXPECT_TRUE(list.poll().empty());
+}
+
+TEST(CaptureTrackList, FailedOpenDoesNotLeaveMember) {
+    ListRig rig;
+    rig.failOpen = true;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 99;
+    Result r = list.create({}, &id);
+    EXPECT_FALSE(r);
+    EXPECT_TRUE(list.poll().empty());
+}
+
+TEST(CaptureTrackList, FailedStartDoesNotLeaveMember) {
+    ListRig rig;
+    rig.failStart = true;
+    CaptureTrackList list(rig.factory());
+    Result r = list.create({}, nullptr);
+    EXPECT_FALSE(r);
+    EXPECT_TRUE(list.poll().empty());
+}
+
+TEST(CaptureTrackList, EqualSourcesMayBothBeLive) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.source.kind = CaptureSourceKind::SystemLoopback;
+    spec.source.deviceId = L"same-endpoint";
+    TrackId a = 0, b = 0;
+    ASSERT_TRUE(list.create(spec, &a));
+    ASSERT_TRUE(list.create(spec, &b));
+    EXPECT_NE(a, b);
+    EXPECT_EQ(list.poll().size(), 2u);
+    list.destroyAll();
+}
+
+TEST(CaptureTrackList, CreateAllowedWhileSiblingStillListed) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId a = 0, b = 0;
+    ASSERT_TRUE(list.create({}, &a));
+    ASSERT_TRUE(list.create({}, &b));
+    list.destroy(a);
+    TrackId c = 0;
+    ASSERT_TRUE(list.create({}, &c));
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 2u);
+    list.destroyAll();
+}
+
+TEST(CaptureTrackList, WavOpenFailureDoesNotDestroySibling) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate ok{};
+    ok.wavPath = tempWav(L"ok");
+    TrackId good = 0;
+    ASSERT_TRUE(list.create(ok, &good));
+
+    CaptureTrackCreate bad{};
+    bad.wavPath = L"?:\\wa_ctl_not_a_path.wav";
+    TrackId badId = 0;
+    ASSERT_TRUE(list.create(bad, &badId));
+
+    ASSERT_TRUE(waitFor([&] {
+        auto st = list.poll();
+        if (st.size() != 2u) return false;
+        bool sawErr = false, sawRun = false;
+        for (const auto& s : st) {
+            if (s.id == badId && s.state == StreamState::Error) sawErr = true;
+            if (s.id == good && s.state == StreamState::Running) sawRun = true;
+        }
+        return sawErr && sawRun;
+    })) << "expected WAV error isolated to one Track";
+
+    list.destroyAll();
+    DeleteFileW(ok.wavPath.c_str());
+}
+
+TEST(CaptureTrackList, ExclusiveLoopbackRejected) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.kind = BackendKind::WasapiExclusive;
+    spec.source.kind = CaptureSourceKind::SystemLoopback;
+    EXPECT_FALSE(list.create(spec, nullptr));
+    EXPECT_TRUE(list.poll().empty());
+}
+
+TEST(CaptureTrackList, CreateFailureDoesNotDestroySibling) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId good = 0;
+    ASSERT_TRUE(list.create({}, &good));
+    rig.failOpen = true;
+    EXPECT_FALSE(list.create({}, nullptr));
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_EQ(st[0].id, good);
+    EXPECT_EQ(st[0].state, StreamState::Running);
+    list.destroyAll();
+}
+
+TEST(CaptureTrackList, SecondListUnaffectedByDestroyAll) {
+    ListRig a, b;
+    CaptureTrackList listA(a.factory());
+    CaptureTrackList listB(b.factory());
+    ASSERT_TRUE(listA.create({}, nullptr));
+    ASSERT_TRUE(listB.create({}, nullptr));
+    listA.destroyAll();
+    EXPECT_TRUE(listA.poll().empty());
+    ASSERT_EQ(listB.poll().size(), 1u);
+    EXPECT_EQ(listB.poll()[0].state, StreamState::Running);
+    listB.destroyAll();
+}
+
+TEST(CaptureTrackList, OptionalWavStillRuns) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.wavPath.clear();
+    TrackId id = 0;
+    ASSERT_TRUE(list.create(spec, &id));
+    EXPECT_EQ(list.poll()[0].state, StreamState::Running);
+    list.destroyAll();
+}

--- a/src/tests/test_capture_track_list.cpp
+++ b/src/tests/test_capture_track_list.cpp
@@ -212,6 +212,42 @@ TEST(CaptureTrackList, ExclusiveLoopbackRejected) {
     EXPECT_TRUE(list.poll().empty());
 }
 
+TEST(CaptureTrackList, ExclusiveApplicationLoopbackRejected) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.kind = BackendKind::WasapiExclusive;
+    spec.source.kind = CaptureSourceKind::ApplicationLoopback;
+    spec.source.processId = 4242;
+    EXPECT_FALSE(list.create(spec, nullptr));
+    EXPECT_TRUE(list.poll().empty());
+}
+
+TEST(CaptureTrackList, ApplicationLoopbackPreservesPidAndMode) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.source.kind = CaptureSourceKind::ApplicationLoopback;
+    spec.source.processId = 4242;
+    spec.source.processLoopbackMode = ProcessLoopbackMode::ExcludeTree;
+    TrackId id = 0;
+    ASSERT_TRUE(list.create(spec, &id));
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_EQ(st[0].source.kind, CaptureSourceKind::ApplicationLoopback);
+    EXPECT_EQ(st[0].source.processId, 4242u);
+    EXPECT_EQ(st[0].source.processLoopbackMode, ProcessLoopbackMode::ExcludeTree);
+
+    CaptureTrackCreate other = spec;
+    other.source.processLoopbackMode = ProcessLoopbackMode::IncludeTree;
+    TrackId b = 0;
+    ASSERT_TRUE(list.create(other, &b));
+    TrackId c = 0;
+    ASSERT_TRUE(list.create(spec, &c));
+    EXPECT_EQ(list.poll().size(), 3u);
+    list.destroyAll();
+}
+
 TEST(CaptureTrackList, CreateFailureDoesNotDestroySibling) {
     ListRig rig;
     CaptureTrackList list(rig.factory());

--- a/src/tests/test_capture_track_list.cpp
+++ b/src/tests/test_capture_track_list.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include "CaptureTrackList.h"
 #include "RingBuffer.h"
+#include "TrackScopeReader.h"
 
 using namespace wa;
 
@@ -46,6 +47,10 @@ public:
     std::atomic<bool>* stoppedOut_ = nullptr;
     bool               failOpen_ = false;
     RingBuffer*        ring_ = nullptr;
+
+    void pushPcm(const void* data, size_t bytes) {
+        if (ring_) ring_->write(data, bytes);
+    }
 };
 
 struct ListRig {
@@ -232,6 +237,41 @@ TEST(CaptureTrackList, SecondListUnaffectedByDestroyAll) {
     ASSERT_EQ(listB.poll().size(), 1u);
     EXPECT_EQ(listB.poll()[0].state, StreamState::Running);
     listB.destroyAll();
+}
+
+TEST(CaptureTrackList, TapsAreIndependent) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId a = 0, b = 0;
+    ASSERT_TRUE(list.create({}, &a));
+    ASSERT_TRUE(list.create({}, &b));
+    ASSERT_EQ(rig.caps.size(), 2u);
+
+    const int16_t one[4] = {1000, 1000, 1000, 1000};
+    const int16_t two[8] = {2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000};
+    rig.caps[0]->pushPcm(one, sizeof(one));
+    rig.caps[1]->pushPcm(two, sizeof(two));
+
+    ASSERT_TRUE(waitFor([&] { return list.written(a) >= 2 && list.written(b) >= 4; }));
+    EXPECT_GE(list.written(a), 2u);
+    EXPECT_GE(list.written(b), 4u);
+    EXPECT_EQ(list.tapChannels(a), 2);
+    float sa[2] = {};
+    float sb[4] = {};
+    uint64_t ea = 0, eb = 0;
+    ASSERT_TRUE(list.snapshotLatest(a, 2, sa, ea));
+    ASSERT_TRUE(list.snapshotLatest(b, 4, sb, eb));
+    EXPECT_NEAR(sa[0], 1000.f / 32768.f, 1e-4f);
+    EXPECT_NEAR(sb[0], 2000.f / 32768.f, 1e-4f);
+    {
+        TrackScopeReader ra(list, a);
+        EXPECT_EQ(ra.channels(), 2);
+        EXPECT_GE(ra.written(), 2u);
+    }
+    list.destroy(a);
+    EXPECT_EQ(list.written(a), 0u);
+    EXPECT_GE(list.written(b), 4u);
+    list.destroyAll();
 }
 
 TEST(CaptureTrackList, OptionalWavStillRuns) {

--- a/src/tests/test_cli_options.cpp
+++ b/src/tests/test_cli_options.cpp
@@ -1,5 +1,115 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #include <gtest/gtest.h>
+#include <atomic>
+#include <memory>
+#include <vector>
+#include "CaptureTrackList.h"
 #include "CliOptions.h"
+#include "RingBuffer.h"
+
+TEST(CliOptions, CompatSingleOutIsOneEndpointTrack) {
+    const wchar_t* argv[] = {L"WinAudioCli", L"capture", L"--out", L"a.wav", L"--device", L"mic"};
+    auto g = wa::cli::parseCaptureGroup(6, const_cast<wchar_t**>(argv));
+    ASSERT_TRUE(g.ok) << g.message;
+    ASSERT_EQ(g.tracks.size(), 1u);
+    EXPECT_EQ(g.tracks[0].out, L"a.wav");
+    EXPECT_EQ(g.tracks[0].device, L"mic");
+    EXPECT_FALSE(g.tracks[0].loopback);
+    EXPECT_FALSE(g.tracks[0].hasPid);
+    auto spec = wa::cli::captureCreateFromSegment(g.tracks[0], g.backend);
+    EXPECT_EQ(spec.source.kind, wa::CaptureSourceKind::Endpoint);
+    EXPECT_EQ(spec.wavPath, L"a.wav");
+}
+
+TEST(CliOptions, RepeatableTrackSegmentsMixKinds) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture", L"--seconds", L"3",
+        L"--track", L"--out", L"a.wav", L"--loopback", L"--device", L"spk",
+        L"--track", L"--out", L"b.wav", L"--pid", L"4242", L"--exclude-tree",
+        L"--track", L"--out", L"c.wav"
+    };
+    auto g = wa::cli::parseCaptureGroup(19, const_cast<wchar_t**>(argv));
+    ASSERT_TRUE(g.ok) << g.message;
+    ASSERT_EQ(g.tracks.size(), 3u);
+    EXPECT_EQ(g.seconds, 3);
+    EXPECT_TRUE(g.tracks[0].loopback);
+    EXPECT_EQ(g.tracks[0].device, L"spk");
+    EXPECT_TRUE(g.tracks[1].hasPid);
+    EXPECT_EQ(g.tracks[1].pid, 4242u);
+    EXPECT_TRUE(g.tracks[1].excludeTree);
+    EXPECT_FALSE(g.tracks[2].loopback);
+    EXPECT_FALSE(g.tracks[2].hasPid);
+
+    auto a = wa::cli::captureCreateFromSegment(g.tracks[0], g.backend);
+    auto b = wa::cli::captureCreateFromSegment(g.tracks[1], g.backend);
+    auto c = wa::cli::captureCreateFromSegment(g.tracks[2], g.backend);
+    EXPECT_EQ(a.source.kind, wa::CaptureSourceKind::SystemLoopback);
+    EXPECT_EQ(b.source.kind, wa::CaptureSourceKind::ApplicationLoopback);
+    EXPECT_EQ(b.source.processLoopbackMode, wa::ProcessLoopbackMode::ExcludeTree);
+    EXPECT_EQ(c.source.kind, wa::CaptureSourceKind::Endpoint);
+}
+
+TEST(CliOptions, PidAndLoopbackInOneTrackIsUsageError) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture", L"--track", L"--out", L"a.wav",
+        L"--pid", L"8", L"--loopback"
+    };
+    auto g = wa::cli::parseCaptureGroup(8, const_cast<wchar_t**>(argv));
+    EXPECT_FALSE(g.ok);
+    EXPECT_TRUE(g.tracks.empty());
+}
+
+TEST(CliOptions, TrackWithoutOutIsUsageError) {
+    const wchar_t* argv[] = {L"WinAudioCli", L"capture", L"--track", L"--loopback"};
+    auto g = wa::cli::parseCaptureGroup(4, const_cast<wchar_t**>(argv));
+    EXPECT_FALSE(g.ok);
+}
+
+TEST(CliOptions, PerSegmentFormatAndSilentRender) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture", L"--backend", L"wasapi-shared",
+        L"--track", L"--out", L"a.wav", L"--loopback", L"--format", L"48000/16/2",
+        L"--track", L"--out", L"b.wav", L"--loopback", L"--no-silent-render"
+    };
+    auto g = wa::cli::parseCaptureGroup(15, const_cast<wchar_t**>(argv));
+    ASSERT_TRUE(g.ok) << g.message;
+    EXPECT_EQ(g.backend, wa::BackendKind::WasapiShared);
+    ASSERT_EQ(g.tracks.size(), 2u);
+    EXPECT_TRUE(g.tracks[0].hasFormat);
+    EXPECT_EQ(g.tracks[0].format.sampleRate, 48000u);
+    EXPECT_FALSE(g.tracks[0].noSilentRender);
+    EXPECT_TRUE(g.tracks[1].noSilentRender);
+    EXPECT_FALSE(g.tracks[1].hasFormat);
+    auto a = wa::cli::captureCreateFromSegment(g.tracks[0], g.backend);
+    auto b = wa::cli::captureCreateFromSegment(g.tracks[1], g.backend);
+    EXPECT_TRUE(a.loopbackOptions.silentRender);
+    EXPECT_FALSE(b.loopbackOptions.silentRender);
+    ASSERT_NE(a.requested, nullptr);
+    EXPECT_EQ(a.requested->sampleRate, 48000u);
+}
+
+TEST(CliOptions, EqualRecipesAllowedByParser) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture",
+        L"--track", L"--out", L"a.wav", L"--loopback", L"--device", L"spk",
+        L"--track", L"--out", L"b.wav", L"--loopback", L"--device", L"spk"
+    };
+    auto g = wa::cli::parseCaptureGroup(14, const_cast<wchar_t**>(argv));
+    ASSERT_TRUE(g.ok) << g.message;
+    ASSERT_EQ(g.tracks.size(), 2u);
+    EXPECT_EQ(g.tracks[0].device, g.tracks[1].device);
+}
+
+TEST(CliOptions, RejectsZeroPid) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture", L"--track", L"--out", L"a.wav", L"--pid", L"0"
+    };
+    auto g = wa::cli::parseCaptureGroup(7, const_cast<wchar_t**>(argv));
+    EXPECT_FALSE(g.ok);
+}
 
 TEST(CliOptions, LoopbackSilentRenderDefaultsEnabled) {
     const wchar_t* argv[] = {L"WinAudioCli", L"capture", L"--loopback"};
@@ -19,4 +129,73 @@ TEST(CliOptions, NoSilentRenderDisablesHelper) {
         wa::cli::parseLoopbackOptions(4, const_cast<wchar_t**>(argv));
 
     EXPECT_FALSE(opts.silentRender);
+}
+
+namespace {
+
+class FakeCap : public wa::IAudioBackend {
+public:
+    explicit FakeCap(std::atomic<bool>* stopped) : stopped_(stopped) {}
+    wa::Result open(const wa::DeviceId&, const wa::AudioFormat&, wa::RingBuffer*,
+                    const wa::StreamParams&) override {
+        return wa::Result::Ok();
+    }
+    wa::Result start() override { return wa::Result::Ok(); }
+    void stop() override {
+        if (stopped_) stopped_->store(true);
+    }
+    void close() override {}
+    wa::BackendStats stats() const override {
+        wa::BackendStats s{};
+        s.actualFormat = {48000, 2, 16, false};
+        return s;
+    }
+    std::atomic<bool>* stopped_ = nullptr;
+};
+
+} // namespace
+
+TEST(CliOptions, ParsedGroupCreatesIndependentTracks) {
+    const wchar_t* argv[] = {
+        L"WinAudioCli", L"capture",
+        L"--track", L"--out", L"?:\\bad_a.wav", L"--loopback",
+        L"--track", L"--out", L"?:\\bad_b.wav", L"--pid", L"99"
+    };
+    auto g = wa::cli::parseCaptureGroup(11, const_cast<wchar_t**>(argv));
+    ASSERT_TRUE(g.ok) << g.message;
+    ASSERT_EQ(g.tracks.size(), 2u);
+
+    std::atomic<bool> stop0{false};
+    std::atomic<bool> stop1{false};
+    int n = 0;
+    wa::CaptureTrackList list(
+        [&](const wa::CaptureSource&, const wa::AudioFormat*) {
+            auto* flag = (n++ == 0) ? &stop0 : &stop1;
+            return std::unique_ptr<wa::IAudioBackend>(new FakeCap(flag));
+        });
+
+    bool anyFail = false;
+    for (const auto& seg : g.tracks) {
+        auto spec = wa::cli::captureCreateFromSegment(seg, g.backend);
+        if (!list.create(spec, nullptr)) anyFail = true;
+    }
+    EXPECT_FALSE(anyFail);
+    EXPECT_EQ(list.poll().size(), 2u);
+
+    ASSERT_TRUE([&] {
+        for (int i = 0; i < 200; ++i) {
+            auto st = list.poll();
+            if (st.size() == 2
+                && st[0].state == wa::StreamState::Error
+                && st[1].state == wa::StreamState::Error)
+                return true;
+            Sleep(5);
+        }
+        return false;
+    }());
+
+    list.destroyAll();
+    EXPECT_TRUE(list.poll().empty());
+    EXPECT_TRUE(stop0.load());
+    EXPECT_TRUE(stop1.load());
 }

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -64,6 +64,8 @@ public:
         return s;
     }
     void* dataReadyEvent() const override { return evt_; }
+    bool inError() const override { return runtimeError_.load(std::memory_order_relaxed); }
+    void failRuntime() { runtimeError_.store(true, std::memory_order_relaxed); }
 
     // Test driver: push raw interleaved PCM bytes into the capture ring + wake pump.
     void pushPcm(const void* data, size_t bytes) {
@@ -83,6 +85,7 @@ public:
     StreamParams      lastOpenParams_{};
     RingBuffer*       ring_ = nullptr;
     HANDLE            evt_  = nullptr;
+    std::atomic<bool> runtimeError_{false};
     AudioFormat       lastRequested_{};
     bool              sawRequested_ = false;
 };
@@ -185,15 +188,15 @@ TEST(MonitorEngine, RateMismatchFails) {
     MonitorEngine eng(rig.factory());
     Result r = eng.start(BackendKind::WasapiShared, L"", L"", 50);
 
-    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_TRUE(static_cast<bool>(r)) << "capture stays up when render cannot engage";
     MonitorStatus st = eng.poll();
-    EXPECT_NE(st.overall, StreamState::Running);
     EXPECT_EQ(st.overall, StreamState::Error);
     EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::RateMismatch));
-    EXPECT_EQ(st.capState, StreamState::Idle); // capture rolled back
-    // Clean rollback: both fakes were stopped.
+    EXPECT_EQ(st.capState, StreamState::Running);
+    EXPECT_EQ(st.renderState, StreamState::Error);
+    EXPECT_FALSE(rig.capStopped.load()) << "capture must not auto-stop";
+    eng.stop();
     EXPECT_TRUE(rig.capStopped.load());
-    EXPECT_TRUE(rig.renderStopped.load());
 }
 
 TEST(MonitorEngine, PrefillThenRunning) {
@@ -439,11 +442,15 @@ TEST(MonitorEngine, StartRollbackOnRenderFail) {
     MonitorEngine eng(rig.factory());
     Result r = eng.start(BackendKind::WasapiShared, L"", L"", 50);
 
-    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_TRUE(static_cast<bool>(r));
     MonitorStatus st = eng.poll();
-    EXPECT_EQ(st.overall, StreamState::Error); // engage failure -> Error (capture rolled back)
+    EXPECT_EQ(st.overall, StreamState::Error);
     EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::RenderStart));
-    EXPECT_TRUE(rig.capStopped.load()) << "capture backend must be stopped on rollback";
+    EXPECT_EQ(st.capState, StreamState::Running);
+    EXPECT_EQ(st.renderState, StreamState::Error);
+    EXPECT_FALSE(rig.capStopped.load()) << "capture must not auto-stop on render Error";
+    eng.stop();
+    EXPECT_TRUE(rig.capStopped.load());
 }
 
 TEST(MonitorEngine, StopJoinsCleanly) {
@@ -610,7 +617,7 @@ TEST(MonitorEngine, EnablePlaybackRateMismatch) {
     EXPECT_EQ(st.renderState, StreamState::Error);
     EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::RateMismatch));
     EXPECT_EQ(st.capState, StreamState::Running) << "capture must continue after render engage failure";
-    EXPECT_EQ(st.overall, StreamState::Running);
+    EXPECT_EQ(st.overall, StreamState::Error);
 
     eng.stop();
 }
@@ -910,10 +917,66 @@ TEST(MonitorEngine, LoopbackRuntimePlaybackRejectsSameRenderDevice) {
     })) << "runtime playback feedback guard did not reject render engage";
 
     MonitorStatus st = eng.poll();
-    EXPECT_EQ(st.overall, StreamState::Running);
+    EXPECT_EQ(st.overall, StreamState::Error);
     EXPECT_EQ(st.capState, StreamState::Running);
     EXPECT_EQ(st.renderState, StreamState::Error);
     EXPECT_EQ(st.errorCode, static_cast<uint32_t>(MonitorError::LoopbackFeedback));
     EXPECT_EQ(rig.renderOpenCount.load(), 0);
     eng.stop();
+}
+
+TEST(MonitorEngine, RuntimeCaptureErrorDoesNotStopRender) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, L"", L"", 50, true));
+    ASSERT_NE(rig.capPtr, nullptr);
+    ASSERT_NE(rig.renderPtr, nullptr);
+
+    std::vector<int16_t> ramp(4000, 9);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.poll().fifoFillMs > 0.f; }));
+
+    rig.capPtr->failRuntime();
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.poll().capState == StreamState::Error; }));
+
+    MonitorStatus st = eng.poll();
+    EXPECT_EQ(st.overall, StreamState::Error);
+    EXPECT_EQ(st.capState, StreamState::Error);
+    EXPECT_EQ(st.renderState, StreamState::Running);
+    EXPECT_FALSE(rig.renderStopped.load());
+    EXPECT_GT(st.fifoFillMs, 0.f) << "DelayFifo must survive capture Error";
+
+    eng.stop();
+    EXPECT_TRUE(rig.capStopped.load());
+    EXPECT_TRUE(rig.renderStopped.load());
+}
+
+TEST(MonitorEngine, RuntimeRenderErrorDoesNotStopCaptureOrFifo) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(eng.start(BackendKind::WasapiShared, L"", L"", 50, true));
+    ASSERT_NE(rig.capPtr, nullptr);
+    ASSERT_NE(rig.renderPtr, nullptr);
+
+    std::vector<int16_t> ramp(4000, 11);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.poll().fifoFillMs > 0.f; }));
+
+    rig.renderPtr->failRuntime();
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.poll().renderState == StreamState::Error; }));
+
+    MonitorStatus st = eng.poll();
+    EXPECT_EQ(st.overall, StreamState::Error);
+    EXPECT_EQ(st.renderState, StreamState::Error);
+    EXPECT_EQ(st.capState, StreamState::Running);
+    EXPECT_FALSE(rig.capStopped.load());
+    EXPECT_GT(st.fifoFillMs, 0.f) << "DelayFifo must survive render Error";
+
+    eng.stop();
+    EXPECT_TRUE(rig.capStopped.load());
+    EXPECT_TRUE(rig.renderStopped.load());
 }


### PR DESCRIPTION
## What / Why

Loopback and Application Loopback could only run one capture at a time. This adds **Capture Tracks**: independent live captures, each with its own picture and optional WAV. Monitor stays one pair. CLI `capture` can start a group in one process.

Design: [docs/superpowers/specs/2026-08-14-winaudio-multi-track-loopback-design.md](https://github.com/peilinok/winaudio/blob/feat/multi-track-loopback/docs/superpowers/specs/2026-08-14-winaudio-multi-track-loopback-design.md)

## How

- `CaptureTrackList` is the list seam (create starts immediately, destroy / destroy-all, poll). Fake backends keep tests off hardware.
- GUI Loopback and Application Loopback each own a page-scoped list and stack one Capture-only Chart Host per live Track (per-Track freeze and time axis). Session list / PID stay discovery. Destroy-all does not touch the other page or Monitor.
- CLI `capture --track` is one process-lifetime group; no `--track` + one `--out` stays one Track. `--pid` / `--exclude-tree` / `--loopback` / endpoint are per segment. Failures stay on that Track; group exit is non-zero if any member failed.
- Monitor one-side Error no longer auto-stops the peer. No mixdown, no product-side concurrent cap, Shared-only loopback.

## Testing

- Local Debug ctest: **191/191** passed
- Local Release ctest: **191/191** passed
- New coverage: `CaptureTrackList.*`, CLI `--track` parser, per-Track scope taps, Monitor one-side Error, UI text
- Real-device smoke: **passed** (requester) — multi-path GUI pages, same-PID modes, destroy-all isolation, `capture --track` group

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally (191/191 each)
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots still show the previous single-session chrome (docs/images not refreshed)
- [x] Real-device behavior touched: manual smoke done, result stated above