### PR TITLE
feat(core): extract Shared Stream init

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -81,3 +81,15 @@ _Avoid_: Record side, mic only
 **Render side**:
 The delayed playback leg of a Monitor when sync playback is engaged — at most one Render Track.
 _Avoid_: Output only, speaker path alone
+
+**Stream params**:
+Advanced open-time settings for one Track: category, option, offload, ducking, buffer length, and user-overridable stream flags. All-default means follow the system and the current Stream init recipe.
+_Avoid_: StreamOption (that is only the APO / raw / match-format field), client properties alone, AUDCLNT_STREAMFLAGS
+
+**Stream flags**:
+Initialize flags consumed by Stream init. User-overridable flags live in stream params (AutoConvert). Event-driven callback is locked on. Loopback extras stay caller-supplied, not in stream params.
+_Avoid_: StreamOption, AUDCLNT_STREAMOPTIONS, extraSharedInitFlags
+
+**Stream init**:
+The share-mode recipe shared by every Track and by silent-render: mix vs requested conversion, exclusive probe and align-retry, duration, and stream flags. Loopback extras are supplied by the caller; Stream init does not inspect the Capture source. Endpoint or Application Loopback activation sits outside it, as do client properties, ducking, and the pump.
+_Avoid_: Client Init, prepareClient, format negotiation (that is only the format half)

--- a/docs/adr/0001-stream-init-shared-recipe.md
+++ b/docs/adr/0001-stream-init-shared-recipe.md
@@ -1,0 +1,19 @@
+# Stream init is a shared recipe, not share-mode subclasses
+
+`prepareClient` mixed Shared mix/requested, Exclusive probe, align-retry, and hardcoded Initialize flags in one function, with a cloned Shared path in Application Loopback. We deepen **Stream init** as one callable recipe used by every Track and silent-render: mix vs requested conversion, exclusive probe and align-retry, duration, and stream flags. Direction subclasses (Capture / Render / System Loopback / silent-render) stay the one inheritance axis. Share mode is policy inside Stream init, not a second class hierarchy.
+
+## Considered Options
+
+- **Shared/Exclusive subclasses of WasapiStream** — rejected. Orthogonal to Capture source / direction, would duplicate the worker-thread scaffold, fails the deletion test.
+- **Private `prepareShared` / `prepareExclusive` on WasapiStream** — rejected. Application Loopback is not a WasapiStream subclass; a private split would be extracted again.
+- **Put the Application Loopback 44100 mix-fallback inside Stream init** — rejected. Ordinary Tracks would start silently degrading on mix failure. Fallback stays on the Application Loopback activate adapter as a second Stream init call with that format requested.
+- **A new flags type beside Stream params** — rejected. GUI Advanced already writes Stream params; a parallel bag is a third channel. User-overridable flags go in Stream params. Loopback extras stay caller-supplied so Stream init does not inspect Capture source. `extraSharedInitFlags` is deleted.
+- **Expose EVENTCALLBACK, NOPERSIST, RATEADJUST, or pull this round** — rejected. The pump is event-driven; EVENTCALLBACK is locked on. This round Stream params only gains AutoConvert (`Default` = today's rule; `Force`/`Off` decouple conversion from “has requested format”). Exclusive `Force` fails; no silent downgrade. `AUTOCONVERT` stays paired with `SRC_DEFAULT_QUALITY`.
+- **Wire SetClientProperties / ducking into Application Loopback in the same change** — rejected. That path never made those calls. This round it only switches Initialize to Stream init (`bufferMs`, AutoConvert, caller `LOOPBACK`). Client properties and ducking stay on the WasapiStream scaffold.
+
+## Consequences
+
+- Stream init sits after endpoint or Application Loopback activation and before ducking / Start. It does not own the pump.
+- Tests hit Stream init through an internal fake audio-client adapter (record/inject `GetMixFormat`, `IsFormatSupported`, `Initialize`, and one `AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED` rebuild). That seam is not `IAudioBackend`.
+- GUI Advanced does not gain new checkboxes in this change. AutoConvert is expressible in Stream params so a later UI can write it.
+- Reopens device-params spec §8 only for AutoConvert; remaining `AUDCLNT_STREAMFLAGS_*` stay out until a later Stream params field.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(WinAudioCore STATIC
     ApplicationLoopbackCapture.cpp
     DeviceEnumerator.cpp
     WasapiStream.cpp
+    StreamInit.cpp
     Engine.cpp
     FormatSpec.cpp
     MonitorEngine.cpp

--- a/src/core/StreamInit.cpp
+++ b/src/core/StreamInit.cpp
@@ -1,0 +1,73 @@
+#include "StreamInit.h"
+#include "ComUtil.h"
+#include "Log.h"
+#include "AudioFormatStr.h"
+
+namespace wa {
+
+AudioClientInitAdapter::AudioClientInitAdapter(IAudioClient* client) : client_(client) {}
+
+HRESULT AudioClientInitAdapter::getMixFormat(WAVEFORMATEX** mix) {
+    return client_->GetMixFormat(mix);
+}
+
+HRESULT AudioClientInitAdapter::initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
+                                           REFERENCE_TIME bufferDuration,
+                                           REFERENCE_TIME periodicity,
+                                           const WAVEFORMATEX* format) {
+    return client_->Initialize(shareMode, streamFlags, bufferDuration, periodicity,
+                               format, nullptr);
+}
+
+Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
+                        StreamInitOutcome& out) {
+    const REFERENCE_TIME dur = req.params.bufferMs
+        ? static_cast<REFERENCE_TIME>(req.params.bufferMs) * 10'000
+        : 10'000'000 / 10; // default: 100 ms buffer
+    const DWORD extraFlags = req.extraFlags;
+
+    if (req.requested) {
+        out.actualFormat = *req.requested;
+        out.frameBytes = out.actualFormat.blockAlign();
+        WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(*req.requested);
+        const DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                            AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                            AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY |
+                            extraFlags;
+        HRESULT hr = client.initialize(AUDCLNT_SHAREMODE_SHARED, flags, dur, 0,
+                                       reinterpret_cast<WAVEFORMATEX*>(&wfx));
+        WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(shared,requested)",
+               "fmt=" + wa::formatAudio(*req.requested), wa::log::hrName(hr));
+        if (FAILED(hr)) {
+            WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(shared,requested)",
+                   "fmt=" + wa::formatAudio(*req.requested), wa::log::hrName(hr));
+            return HrToResult(hr, "WasapiStream: Initialize(shared, requested)");
+        }
+        return Result::Ok();
+    }
+
+    WAVEFORMATEX* mix = nullptr;
+    HRESULT hr = client.getMixFormat(&mix);
+    WA_LOG(wa::log::Level::Debug, "StreamInit", "GetMixFormat", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "StreamInit", "GetMixFormat", "", wa::log::hrName(hr));
+        return HrToResult(hr, "WasapiStream: GetMixFormat");
+    }
+    if (!mix) return Result::Fail(-1, "WasapiStream: GetMixFormat returned null");
+    out.actualFormat = fromWaveFormat(mix);
+    out.frameBytes = out.actualFormat.blockAlign();
+    hr = client.initialize(AUDCLNT_SHAREMODE_SHARED,
+                           AUDCLNT_STREAMFLAGS_EVENTCALLBACK | extraFlags,
+                           dur, 0, mix);
+    WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(shared)",
+           "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+    CoTaskMemFree(mix);
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(shared)",
+               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+        return HrToResult(hr, "WasapiStream: Initialize(shared)");
+    }
+    return Result::Ok();
+}
+
+} // namespace wa

--- a/src/core/StreamInit.h
+++ b/src/core/StreamInit.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "AudioFormat.h"
+#include "Result.h"
+#include "StreamParams.h"
+#include <audioclient.h>
+
+namespace wa {
+
+// Narrow WASAPI Initialize seam used by Stream init. Production wraps IAudioClient;
+// tests use a recording fake. Not IAudioBackend.
+class AudioClientInit {
+public:
+    virtual ~AudioClientInit() = default;
+    virtual HRESULT getMixFormat(WAVEFORMATEX** mix) = 0;
+    virtual HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
+                               REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
+                               const WAVEFORMATEX* format) = 0;
+};
+
+class AudioClientInitAdapter : public AudioClientInit {
+public:
+    explicit AudioClientInitAdapter(IAudioClient* client);
+    HRESULT getMixFormat(WAVEFORMATEX** mix) override;
+    HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
+                       REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
+                       const WAVEFORMATEX* format) override;
+private:
+    IAudioClient* client_ = nullptr;
+};
+
+struct StreamInitRequest {
+    const AudioFormat* requested = nullptr; // null = use mix format
+    StreamParams params{};
+    uint32_t extraFlags = 0;
+};
+
+struct StreamInitOutcome {
+    AudioFormat actualFormat{};
+    uint32_t frameBytes = 0;
+};
+
+Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
+                        StreamInitOutcome& out);
+
+} // namespace wa

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -1,6 +1,7 @@
 #include "WasapiStream.h"
 #include "RingBuffer.h"
 #include "FormatSpec.h"
+#include "StreamInit.h"
 #include <audiopolicy.h>
 #include <system_error>
 #include <cstring>
@@ -192,46 +193,18 @@ Result WasapiStream::applyDucking() {
 
 Result WasapiStream::prepareClient(IMMDevice* dev) {
     if (mode_ == WasapiMode::Shared) {
-        REFERENCE_TIME dur = params_.bufferMs
-            ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10'000
-            : 10'000'000 / 10; // default: 100 ms buffer
-        const DWORD extraFlags = extraSharedInitFlags();
-
-        if (hasRequested_) {
-            // Caller specified a format: ask WASAPI's engine to convert via AUTOCONVERTPCM.
-            // Without these flags Initialize returns AUDCLNT_E_UNSUPPORTED_FORMAT for any
-            // non-mix format even in shared mode.
-            actualFormat_ = requestedFormat_;
-            frameBytes_ = actualFormat_.blockAlign();
-            WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(requestedFormat_);
-            HRESULT hr = client_->Initialize(
-                AUDCLNT_SHAREMODE_SHARED,
-                AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
-                AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
-                AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY |
-                extraFlags,
-                dur, 0,
-                reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
-            WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared,requested)", "fmt=" + wa::formatAudio(requestedFormat_), wa::log::hrName(hr));
-            if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(shared,requested)", "fmt=" + wa::formatAudio(requestedFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(shared, requested)"); }
-            return Result::Ok();
+        AudioClientInitAdapter adapter(client_.Get());
+        StreamInitRequest req;
+        req.requested = hasRequested_ ? &requestedFormat_ : nullptr;
+        req.params = params_;
+        req.extraFlags = extraInitFlags_;
+        StreamInitOutcome out;
+        Result r = streamInitShared(adapter, req, out);
+        if (r) {
+            actualFormat_ = out.actualFormat;
+            frameBytes_ = out.frameBytes;
         }
-
-        // Default: use the device mix format (no conversion flags needed).
-        WAVEFORMATEX* mix = nullptr;
-        HRESULT hr = client_->GetMixFormat(&mix);
-        WA_LOG(wa::log::Level::Debug, "WasapiStream", "GetMixFormat", "", wa::log::hrName(hr));
-        if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "GetMixFormat", "", wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: GetMixFormat"); }
-        if (!mix) return Result::Fail(-1, "WasapiStream: GetMixFormat returned null");
-        actualFormat_ = fromWaveFormat(mix);
-        frameBytes_ = actualFormat_.blockAlign();
-        hr = client_->Initialize(AUDCLNT_SHAREMODE_SHARED,
-                                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK | extraFlags,
-                                 dur, 0, mix, nullptr);
-        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
-        CoTaskMemFree(mix);
-        if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(shared)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(shared)"); }
-        return Result::Ok();
+        return r;
     }
     // ---- Exclusive ----
     // Candidate formats: the explicitly requested one, else (capture only) a fallback list.
@@ -446,7 +419,9 @@ void WasapiCaptureStream::runLoop() {
 
 WasapiSystemLoopbackCaptureStream::WasapiSystemLoopbackCaptureStream(
     WasapiMode mode, const AudioFormat* requested)
-    : WasapiCaptureStream(mode, requested) {}
+    : WasapiCaptureStream(mode, requested) {
+    extraInitFlags_ = AUDCLNT_STREAMFLAGS_LOOPBACK;
+}
 
 Result WasapiSystemLoopbackCaptureStream::open(const DeviceId& id, const AudioFormat& fmt,
                                                RingBuffer* ring, const StreamParams& params) {

--- a/src/core/WasapiStream.h
+++ b/src/core/WasapiStream.h
@@ -43,7 +43,6 @@ protected:
     virtual void   preRoll() {}           // render: one silent buffer; capture: nothing
     virtual void   runLoop() = 0;         // drain/feed loop; runs while running_
     virtual void   resetService() = 0;    // Reset() the service ComPtr (called from close())
-    virtual DWORD  extraSharedInitFlags() const { return 0; }
 
     bool isExclusive() const { return mode_ == WasapiMode::Exclusive; }
 
@@ -57,6 +56,7 @@ protected:
     std::atomic<uint64_t> silentPacketFrames_{0};
     void*       hEvent_ = nullptr;        // HANDLE
     ComPtr<IAudioClient> client_;
+    DWORD extraInitFlags_ = 0; // caller-supplied extras (e.g. LOOPBACK)
 
 private:
     void   threadMain();
@@ -103,7 +103,6 @@ public:
                 const StreamParams& params) override;
 protected:
     EDataFlow dataFlow() const override { return eRender; }
-    DWORD extraSharedInitFlags() const override { return AUDCLNT_STREAMFLAGS_LOOPBACK; }
     uint32_t idleSilenceFrames(uint32_t timeoutMs) const override {
         return loopbackSilenceFramesForTimeout(actualFormat_.sampleRate, timeoutMs);
     }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(WinAudioTests
     test_delayfifo.cpp
     test_streamparams.cpp
+    test_stream_init.cpp
     test_smoke.cpp
     test_audioformat.cpp
     test_fft.cpp

--- a/src/tests/test_stream_init.cpp
+++ b/src/tests/test_stream_init.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include "StreamInit.h"
+#include "AudioFormat.h"
+#include <objbase.h>
+
+using namespace wa;
+
+namespace {
+
+constexpr REFERENCE_TIME kSharedDefaultDuration = 1'000'000; // 100 ms in 100-ns units
+
+class FakeAudioClientInit : public AudioClientInit {
+public:
+    AudioFormat mixFormat{48000, 2, 16, false};
+    HRESULT mixHr = S_OK;
+    HRESULT initHr = S_OK;
+
+    AUDCLNT_SHAREMODE lastShareMode = AUDCLNT_SHAREMODE_SHARED;
+    DWORD lastFlags = 0;
+    REFERENCE_TIME lastDuration = 0;
+    REFERENCE_TIME lastPeriodicity = -1;
+    AudioFormat lastFormat{};
+    int initializeCount = 0;
+
+    HRESULT getMixFormat(WAVEFORMATEX** mix) override {
+        if (FAILED(mixHr)) return mixHr;
+        auto* wfx = static_cast<WAVEFORMATEX*>(CoTaskMemAlloc(sizeof(WAVEFORMATEX)));
+        if (!wfx) return E_OUTOFMEMORY;
+        ZeroMemory(wfx, sizeof(*wfx));
+        wfx->wFormatTag = WAVE_FORMAT_PCM;
+        wfx->nChannels = mixFormat.channels;
+        wfx->nSamplesPerSec = mixFormat.sampleRate;
+        wfx->wBitsPerSample = mixFormat.bitsPerSample;
+        wfx->nBlockAlign = static_cast<WORD>(mixFormat.blockAlign());
+        wfx->nAvgBytesPerSec = mixFormat.avgBytesPerSec();
+        *mix = wfx;
+        return S_OK;
+    }
+
+    HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
+                       REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
+                       const WAVEFORMATEX* format) override {
+        ++initializeCount;
+        lastShareMode = shareMode;
+        lastFlags = streamFlags;
+        lastDuration = bufferDuration;
+        lastPeriodicity = periodicity;
+        if (format) lastFormat = fromWaveFormat(format);
+        return initHr;
+    }
+};
+
+} // namespace
+
+TEST(StreamInitShared, MixDefaultUsesEventCallbackOnly) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_SHARED);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(fake.lastDuration, kSharedDefaultDuration);
+    EXPECT_EQ(fake.lastPeriodicity, 0);
+    EXPECT_EQ(out.actualFormat, fake.mixFormat);
+    EXPECT_EQ(out.frameBytes, fake.mixFormat.blockAlign());
+    EXPECT_EQ(fake.lastFormat, out.actualFormat);
+}
+
+TEST(StreamInitShared, RequestedDefaultAddsAutoconvertAndSrc) {
+    FakeAudioClientInit fake;
+    AudioFormat want{44100, 2, 16, false};
+    StreamInitRequest req;
+    req.requested = &want;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_SHARED);
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    EXPECT_EQ(fake.lastFlags, expected);
+    EXPECT_EQ(out.actualFormat, want);
+    EXPECT_EQ(out.frameBytes, want.blockAlign());
+    EXPECT_EQ(fake.lastFormat, want);
+}
+
+TEST(StreamInitShared, CallerLoopbackExtraAppearsInFlags) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    req.extraFlags = AUDCLNT_STREAMFLAGS_LOOPBACK;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                                                 AUDCLNT_STREAMFLAGS_LOOPBACK));
+}
+
+TEST(StreamInitShared, RequestedPlusLoopbackExtraORsAutoconvert) {
+    FakeAudioClientInit fake;
+    AudioFormat want{44100, 2, 16, false};
+    StreamInitRequest req;
+    req.requested = &want;
+    req.extraFlags = AUDCLNT_STREAMFLAGS_LOOPBACK;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY |
+                           AUDCLNT_STREAMFLAGS_LOOPBACK;
+    EXPECT_EQ(fake.lastFlags, expected);
+    EXPECT_EQ(out.actualFormat, want);
+}
+
+TEST(StreamInitShared, BufferMsSetsDuration) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    req.params.bufferMs = 50;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastDuration, static_cast<REFERENCE_TIME>(50) * 10'000);
+    EXPECT_EQ(fake.lastPeriodicity, 0);
+}


### PR DESCRIPTION
## What / Why

Shared 打开路径把 mix / requested 配方、硬编码 stream flags、System Loopback 的 `LOOPBACK` 挤在 `prepareClient` 里，且没有无设备测试缝。抽出 **Stream init**，让 Shared Initialize 可测、可复用，并为后续 Exclusive（#44）、AutoConvert（#45）、Application Loopback（#46）留好 seam。

Refs #43. ADR: `docs/adr/0001-stream-init-shared-recipe.md`.

## How

- `streamInitShared` 拥有 Shared 配方：mix vs requested+AUTOCONVERT+SRC、100 ms / `bufferMs`、锁死的 EVENTCALLBACK、调用者传入的 extras。
- 测试走假 `AudioClientInit` adapter，不打 `IAudioBackend`、不碰真设备。
- System Loopback 构造时写入 `LOOPBACK` extras；删除 `extraSharedInitFlags` 虚钩。Stream init 不查看 Capture source。
- Exclusive 仍留在 `prepareClient`（#44）。

## Testing

- `test.bat Debug`：195 passed
- `test.bat Release`：195 passed
- 新增 `StreamInitShared.*`（mix Default、requested+AUTOCONVERT、LOOPBACK extras、requested+LOOPBACK、bufferMs）
- 无真设备行为改动，未做 CLI/GUI 冒烟

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
