### PR TITLE
feat(core): extract Exclusive Stream init

### DIFF
--- a/src/core/StreamInit.cpp
+++ b/src/core/StreamInit.cpp
@@ -1,11 +1,14 @@
 #include "StreamInit.h"
-#include "ComUtil.h"
+#include "FormatSpec.h"
 #include "Log.h"
 #include "AudioFormatStr.h"
+#include <string>
+#include <vector>
 
 namespace wa {
 
-AudioClientInitAdapter::AudioClientInitAdapter(IAudioClient* client) : client_(client) {}
+AudioClientInitAdapter::AudioClientInitAdapter(ComPtr<IAudioClient>& client, IMMDevice* device)
+    : client_(client), device_(device) {}
 
 HRESULT AudioClientInitAdapter::getMixFormat(WAVEFORMATEX** mix) {
     return client_->GetMixFormat(mix);
@@ -17,6 +20,29 @@ HRESULT AudioClientInitAdapter::initialize(AUDCLNT_SHAREMODE shareMode, DWORD st
                                            const WAVEFORMATEX* format) {
     return client_->Initialize(shareMode, streamFlags, bufferDuration, periodicity,
                                format, nullptr);
+}
+
+HRESULT AudioClientInitAdapter::isFormatSupported(AUDCLNT_SHAREMODE shareMode,
+                                                  const WAVEFORMATEX* format) {
+    return client_->IsFormatSupported(shareMode, format, nullptr);
+}
+
+HRESULT AudioClientInitAdapter::getDevicePeriod(REFERENCE_TIME* defaultPeriod,
+                                                REFERENCE_TIME* minimumPeriod) {
+    return client_->GetDevicePeriod(defaultPeriod, minimumPeriod);
+}
+
+HRESULT AudioClientInitAdapter::getBufferSize(UINT32* frames) {
+    return client_->GetBufferSize(frames);
+}
+
+HRESULT AudioClientInitAdapter::rebuild() {
+    if (!device_) return E_POINTER;
+    // Exclusive NOT_ALIGNED requires a fresh IAudioClient before retry.
+    // Exclusive open rejects client properties, so re-Activate does not drop them.
+    client_.Reset();
+    return device_->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                             reinterpret_cast<void**>(client_.GetAddressOf()));
 }
 
 Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
@@ -68,6 +94,83 @@ Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
         return HrToResult(hr, "WasapiStream: Initialize(shared)");
     }
     return Result::Ok();
+}
+
+Result streamInitExclusive(AudioClientInit& client, const StreamInitRequest& req,
+                           StreamInitOutcome& out) {
+    std::vector<AudioFormat> candidates;
+    if (req.requested) {
+        candidates.push_back(*req.requested);
+    } else if (req.direction == StreamInitDirection::Capture) {
+        candidates = defaultExclusiveCaptureCandidates();
+    } else {
+        return Result::Fail(-1, "WasapiStream: exclusive render requires an explicit format");
+    }
+
+    const int idx = selectSupportedFormat(candidates, [&](const AudioFormat& cand) {
+        WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(cand);
+        HRESULT probeHr = client.isFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
+                                                   reinterpret_cast<WAVEFORMATEX*>(&wfx));
+        WA_LOG(wa::log::Level::Debug, "StreamInit", "IsFormatSupported(exclusive)",
+               "fmt=" + wa::formatAudio(cand), wa::log::hrName(probeHr));
+        return probeHr == S_OK;
+    });
+    if (idx < 0) {
+        return Result::Fail(static_cast<long>(AUDCLNT_E_UNSUPPORTED_FORMAT),
+                            "WasapiStream: no supported exclusive format");
+    }
+
+    out.actualFormat = candidates[static_cast<size_t>(idx)];
+    out.frameBytes = out.actualFormat.blockAlign();
+
+    REFERENCE_TIME defPer = 0, minPer = 0;
+    HRESULT hrGP = client.getDevicePeriod(&defPer, &minPer);
+    WA_LOG(wa::log::Level::Warn, "StreamInit", "GetDevicePeriod",
+           "def=" + std::to_string(defPer) + " min=" + std::to_string(minPer),
+           wa::log::hrName(hrGP));
+    REFERENCE_TIME dur = req.params.bufferMs
+        ? static_cast<REFERENCE_TIME>(req.params.bufferMs) * 10'000
+        : minPer;
+
+    const DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | req.extraFlags;
+    WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(out.actualFormat);
+    HRESULT hr = client.initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags, dur, dur,
+                                   reinterpret_cast<WAVEFORMATEX*>(&wfx));
+    WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(exclusive)",
+           "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+    if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
+        UINT32 aligned = 0;
+        HRESULT hrGBS = client.getBufferSize(&aligned);
+        WA_LOG(wa::log::Level::Warn, "StreamInit", "GetBufferSize(realign)",
+               "frames=" + std::to_string(aligned), wa::log::hrName(hrGBS));
+        dur = alignedBufferDuration100ns(out.actualFormat.sampleRate, aligned);
+        HRESULT hr2 = client.rebuild();
+        WA_LOG(wa::log::Level::Debug, "StreamInit", "Activate(realign)", "",
+               wa::log::hrName(hr2));
+        if (FAILED(hr2)) {
+            WA_LOG(wa::log::Level::Err, "StreamInit", "Activate(realign)", "",
+                   wa::log::hrName(hr2));
+            return HrToResult(hr2, "WasapiStream: exclusive realign Activate");
+        }
+        WAVEFORMATEXTENSIBLE wfx2 = toWaveFormatExtensible(out.actualFormat);
+        hr = client.initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags, dur, dur,
+                               reinterpret_cast<WAVEFORMATEX*>(&wfx2));
+        WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(exclusive,realign)",
+               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+    }
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(exclusive)",
+               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+        return HrToResult(hr, "WasapiStream: Initialize(exclusive)");
+    }
+    return Result::Ok();
+}
+
+Result streamInit(AUDCLNT_SHAREMODE shareMode, AudioClientInit& client,
+                  const StreamInitRequest& req, StreamInitOutcome& out) {
+    if (shareMode == AUDCLNT_SHAREMODE_EXCLUSIVE)
+        return streamInitExclusive(client, req, out);
+    return streamInitShared(client, req, out);
 }
 
 } // namespace wa

--- a/src/core/StreamInit.h
+++ b/src/core/StreamInit.h
@@ -1,8 +1,10 @@
 #pragma once
 #include "AudioFormat.h"
+#include "ComUtil.h"
 #include "Result.h"
 #include "StreamParams.h"
 #include <audioclient.h>
+#include <mmdeviceapi.h>
 
 namespace wa {
 
@@ -15,23 +17,39 @@ public:
     virtual HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
                                REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
                                const WAVEFORMATEX* format) = 0;
+    virtual HRESULT isFormatSupported(AUDCLNT_SHAREMODE shareMode,
+                                      const WAVEFORMATEX* format) = 0;
+    virtual HRESULT getDevicePeriod(REFERENCE_TIME* defaultPeriod,
+                                    REFERENCE_TIME* minimumPeriod) = 0;
+    virtual HRESULT getBufferSize(UINT32* frames) = 0;
+    virtual HRESULT rebuild() = 0;
 };
 
 class AudioClientInitAdapter : public AudioClientInit {
 public:
-    explicit AudioClientInitAdapter(IAudioClient* client);
+    AudioClientInitAdapter(ComPtr<IAudioClient>& client, IMMDevice* device);
     HRESULT getMixFormat(WAVEFORMATEX** mix) override;
     HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
                        REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
                        const WAVEFORMATEX* format) override;
+    HRESULT isFormatSupported(AUDCLNT_SHAREMODE shareMode,
+                              const WAVEFORMATEX* format) override;
+    HRESULT getDevicePeriod(REFERENCE_TIME* defaultPeriod,
+                            REFERENCE_TIME* minimumPeriod) override;
+    HRESULT getBufferSize(UINT32* frames) override;
+    HRESULT rebuild() override;
 private:
-    IAudioClient* client_ = nullptr;
+    ComPtr<IAudioClient>& client_;
+    IMMDevice* device_ = nullptr;
 };
 
+enum class StreamInitDirection : uint8_t { Capture, Render };
+
 struct StreamInitRequest {
-    const AudioFormat* requested = nullptr; // null = use mix format
+    const AudioFormat* requested = nullptr; // null = mix (Shared) or exclusive candidates
     StreamParams params{};
     uint32_t extraFlags = 0;
+    StreamInitDirection direction = StreamInitDirection::Capture;
 };
 
 struct StreamInitOutcome {
@@ -41,5 +59,9 @@ struct StreamInitOutcome {
 
 Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
                         StreamInitOutcome& out);
+Result streamInitExclusive(AudioClientInit& client, const StreamInitRequest& req,
+                           StreamInitOutcome& out);
+Result streamInit(AUDCLNT_SHAREMODE shareMode, AudioClientInit& client,
+                  const StreamInitRequest& req, StreamInitOutcome& out);
 
 } // namespace wa

--- a/src/core/WasapiStream.cpp
+++ b/src/core/WasapiStream.cpp
@@ -1,6 +1,5 @@
 #include "WasapiStream.h"
 #include "RingBuffer.h"
-#include "FormatSpec.h"
 #include "StreamInit.h"
 #include <audiopolicy.h>
 #include <system_error>
@@ -192,74 +191,24 @@ Result WasapiStream::applyDucking() {
 }
 
 Result WasapiStream::prepareClient(IMMDevice* dev) {
-    if (mode_ == WasapiMode::Shared) {
-        AudioClientInitAdapter adapter(client_.Get());
-        StreamInitRequest req;
-        req.requested = hasRequested_ ? &requestedFormat_ : nullptr;
-        req.params = params_;
-        req.extraFlags = extraInitFlags_;
-        StreamInitOutcome out;
-        Result r = streamInitShared(adapter, req, out);
-        if (r) {
-            actualFormat_ = out.actualFormat;
-            frameBytes_ = out.frameBytes;
-        }
-        return r;
+    AudioClientInitAdapter adapter(client_, dev);
+    StreamInitRequest req;
+    req.requested = hasRequested_ ? &requestedFormat_ : nullptr;
+    req.params = params_;
+    req.extraFlags = extraInitFlags_;
+    req.direction = (dataFlow() == eCapture)
+        ? StreamInitDirection::Capture
+        : StreamInitDirection::Render;
+    StreamInitOutcome out;
+    const AUDCLNT_SHAREMODE shareMode = isExclusive()
+        ? AUDCLNT_SHAREMODE_EXCLUSIVE
+        : AUDCLNT_SHAREMODE_SHARED;
+    Result r = streamInit(shareMode, adapter, req, out);
+    if (r) {
+        actualFormat_ = out.actualFormat;
+        frameBytes_ = out.frameBytes;
     }
-    // ---- Exclusive ----
-    // Candidate formats: the explicitly requested one, else (capture only) a fallback list.
-    std::vector<AudioFormat> candidates;
-    if (hasRequested_) candidates.push_back(requestedFormat_);
-    else if (dataFlow() == eCapture) candidates = defaultExclusiveCaptureCandidates();
-    else return Result::Fail(-1, "WasapiStream: exclusive render requires an explicit format");
-
-    int idx = selectSupportedFormat(candidates, [this](const AudioFormat& cand) {
-        WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(cand);
-        HRESULT hr = client_->IsFormatSupported(AUDCLNT_SHAREMODE_EXCLUSIVE,
-                         reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
-        WA_LOG(wa::log::Level::Debug, "WasapiStream", "IsFormatSupported(exclusive)", "fmt=" + wa::formatAudio(cand), wa::log::hrName(hr));
-        return hr == S_OK;
-    });
-    if (idx < 0)
-        return Result::Fail(static_cast<long>(AUDCLNT_E_UNSUPPORTED_FORMAT),
-                            "WasapiStream: no supported exclusive format");
-
-    actualFormat_ = candidates[idx];
-    frameBytes_ = actualFormat_.blockAlign();
-
-    REFERENCE_TIME defPer = 0, minPer = 0;
-    HRESULT hrGP = client_->GetDevicePeriod(&defPer, &minPer);
-    WA_LOG(wa::log::Level::Warn, "WasapiStream", "GetDevicePeriod", "", wa::log::hrName(hrGP));
-    REFERENCE_TIME dur = params_.bufferMs
-        ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10'000
-        : minPer;
-
-    WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(actualFormat_);
-    HRESULT hr = client_->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE,
-                     AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, dur,
-                     reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
-    WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(exclusive)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
-    if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
-        UINT32 aligned = 0;
-        HRESULT hrGBS = client_->GetBufferSize(&aligned);
-        WA_LOG(wa::log::Level::Warn, "WasapiStream", "GetBufferSize(realign)", "", wa::log::hrName(hrGBS));
-        dur = alignedBufferDuration100ns(actualFormat_.sampleRate, aligned);
-        // MSDN: the client must be rebuilt before re-Initializing with the aligned size.
-        // Note: advanced client props (category/option/offload) are rejected in open() for
-        // exclusive mode, so re-Activate here does not lose any SetClientProperties state.
-        client_.Reset();
-        HRESULT hr2 = dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
-                          reinterpret_cast<void**>(client_.GetAddressOf()));
-        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Activate(realign)", "", wa::log::hrName(hr2));
-        if (FAILED(hr2)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Activate(realign)", "", wa::log::hrName(hr2)); return HrToResult(hr2, "WasapiStream: exclusive realign Activate"); }
-        WAVEFORMATEXTENSIBLE wfx2 = toWaveFormatExtensible(actualFormat_);
-        hr = client_->Initialize(AUDCLNT_SHAREMODE_EXCLUSIVE,
-                 AUDCLNT_STREAMFLAGS_EVENTCALLBACK, dur, dur,
-                 reinterpret_cast<WAVEFORMATEX*>(&wfx2), nullptr);
-        WA_LOG(wa::log::Level::Debug, "WasapiStream", "Initialize(exclusive,realign)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr));
-    }
-    if (FAILED(hr)) { WA_LOG(wa::log::Level::Err, "WasapiStream", "Initialize(exclusive)", "fmt=" + wa::formatAudio(actualFormat_), wa::log::hrName(hr)); return HrToResult(hr, "WasapiStream: Initialize(exclusive)"); }
-    return Result::Ok();
+    return r;
 }
 
 void WasapiStream::threadMain() {

--- a/src/tests/test_stream_init.cpp
+++ b/src/tests/test_stream_init.cpp
@@ -2,18 +2,26 @@
 #include "StreamInit.h"
 #include "AudioFormat.h"
 #include <objbase.h>
+#include <vector>
 
 using namespace wa;
 
 namespace {
 
 constexpr REFERENCE_TIME kSharedDefaultDuration = 1'000'000; // 100 ms in 100-ns units
+constexpr REFERENCE_TIME kExclusiveMinPeriod = 100'000;      // 10 ms in 100-ns units
 
 class FakeAudioClientInit : public AudioClientInit {
 public:
     AudioFormat mixFormat{48000, 2, 16, false};
     HRESULT mixHr = S_OK;
     HRESULT initHr = S_OK;
+    HRESULT rebuildHr = S_OK;
+    std::vector<AudioFormat> supportedFormats;
+    REFERENCE_TIME minPeriod = kExclusiveMinPeriod;
+    REFERENCE_TIME deviceDefaultPeriod = kExclusiveMinPeriod;
+    UINT32 alignedFrames = 480;
+    bool failFirstInitWithNotAligned = false;
 
     AUDCLNT_SHAREMODE lastShareMode = AUDCLNT_SHAREMODE_SHARED;
     DWORD lastFlags = 0;
@@ -21,6 +29,8 @@ public:
     REFERENCE_TIME lastPeriodicity = -1;
     AudioFormat lastFormat{};
     int initializeCount = 0;
+    int rebuildCount = 0;
+    std::vector<AudioFormat> probedFormats;
 
     HRESULT getMixFormat(WAVEFORMATEX** mix) override {
         if (FAILED(mixHr)) return mixHr;
@@ -46,7 +56,37 @@ public:
         lastDuration = bufferDuration;
         lastPeriodicity = periodicity;
         if (format) lastFormat = fromWaveFormat(format);
+        if (failFirstInitWithNotAligned && initializeCount == 1)
+            return AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED;
         return initHr;
+    }
+
+    HRESULT isFormatSupported(AUDCLNT_SHAREMODE /*shareMode*/,
+                              const WAVEFORMATEX* format) override {
+        if (!format) return E_POINTER;
+        AudioFormat f = fromWaveFormat(format);
+        probedFormats.push_back(f);
+        for (const auto& s : supportedFormats) {
+            if (s == f) return S_OK;
+        }
+        return AUDCLNT_E_UNSUPPORTED_FORMAT;
+    }
+
+    HRESULT getDevicePeriod(REFERENCE_TIME* defaultPeriod,
+                            REFERENCE_TIME* minimumPeriod) override {
+        if (defaultPeriod) *defaultPeriod = deviceDefaultPeriod;
+        if (minimumPeriod) *minimumPeriod = minPeriod;
+        return S_OK;
+    }
+
+    HRESULT getBufferSize(UINT32* frames) override {
+        if (frames) *frames = alignedFrames;
+        return S_OK;
+    }
+
+    HRESULT rebuild() override {
+        ++rebuildCount;
+        return rebuildHr;
     }
 };
 
@@ -122,4 +162,124 @@ TEST(StreamInitShared, BufferMsSetsDuration) {
     ASSERT_TRUE(static_cast<bool>(r)) << r.message;
     EXPECT_EQ(fake.lastDuration, static_cast<REFERENCE_TIME>(50) * 10'000);
     EXPECT_EQ(fake.lastPeriodicity, 0);
+}
+
+TEST(StreamInitExclusive, RequestedSupportedUsesEventCallbackAndEqualPeriod) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    StreamInitRequest req;
+    req.requested = &want;
+    req.direction = StreamInitDirection::Render;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_EXCLUSIVE);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(fake.lastDuration, kExclusiveMinPeriod);
+    EXPECT_EQ(fake.lastPeriodicity, kExclusiveMinPeriod);
+    EXPECT_EQ(out.actualFormat, want);
+    EXPECT_EQ(out.frameBytes, want.blockAlign());
+    EXPECT_EQ(fake.lastFormat, want);
+    EXPECT_EQ(fake.initializeCount, 1);
+}
+
+TEST(StreamInitExclusive, RenderWithoutRequestedFails) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    req.direction = StreamInitDirection::Render;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_EQ(fake.initializeCount, 0);
+}
+
+TEST(StreamInitExclusive, CaptureWithoutRequestedUsesDefaultCandidates) {
+    FakeAudioClientInit fake;
+    const AudioFormat second{44100, 2, 16, false};
+    fake.supportedFormats.push_back(second); // skip 48000/2/16, take next candidate
+    StreamInitRequest req;
+    req.direction = StreamInitDirection::Capture;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(out.actualFormat, second);
+    EXPECT_EQ(fake.lastFormat, second);
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_EXCLUSIVE);
+    ASSERT_GE(fake.probedFormats.size(), 2u);
+    EXPECT_EQ(fake.probedFormats[0], (AudioFormat{48000, 2, 16, false}));
+    EXPECT_EQ(fake.probedFormats[1], second);
+}
+
+TEST(StreamInitExclusive, NotAlignedRebuildsThenRetriesEqualDuration) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    fake.failFirstInitWithNotAligned = true;
+    fake.minPeriod = 300000;     // 30 ms; first Initialize would use this
+    fake.alignedFrames = 480;    // 480 frames @ 48 kHz = 10 ms = 100000
+    StreamInitRequest req;
+    req.requested = &want;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.rebuildCount, 1);
+    EXPECT_EQ(fake.initializeCount, 2);
+    EXPECT_EQ(fake.lastDuration, 100000);
+    EXPECT_EQ(fake.lastPeriodicity, 100000);
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_EXCLUSIVE);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(out.actualFormat, want);
+}
+
+TEST(StreamInitExclusive, NotAlignedRebuildFailurePropagates) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    fake.failFirstInitWithNotAligned = true;
+    fake.rebuildHr = E_FAIL;
+    StreamInitRequest req;
+    req.requested = &want;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_EQ(fake.rebuildCount, 1);
+    EXPECT_EQ(fake.initializeCount, 1);
+}
+
+TEST(StreamInitExclusive, CaptureNoneSupportedFailsWithoutInitialize) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    req.direction = StreamInitDirection::Capture;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_EQ(r.code, static_cast<long>(AUDCLNT_E_UNSUPPORTED_FORMAT));
+    EXPECT_EQ(fake.initializeCount, 0);
+}
+
+TEST(StreamInitExclusive, BufferMsSetsEqualDurationAndPeriodicity) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.bufferMs = 50;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastDuration, 500000);
+    EXPECT_EQ(fake.lastPeriodicity, 500000);
+}
+
+TEST(StreamInitExclusive, DispatcherRoutesExclusiveShareMode) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    StreamInitRequest req;
+    req.requested = &want;
+    StreamInitOutcome out;
+    Result r = streamInit(AUDCLNT_SHAREMODE_EXCLUSIVE, fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_EXCLUSIVE);
 }


### PR DESCRIPTION
## What / Why

Exclusive 打开配方（格式探测、`duration = periodicity`、一次 `BUFFER_SIZE_NOT_ALIGNED` 对齐重建）从 `WasapiStream::prepareClient` 抽进 **Stream init**，让 Shared 与 Exclusive 走同一调用。行为保持抽取，不改 GUI / CLI。

Closes #44. Parent: #42.

## How

`AudioClientInit` 接缝补上 `IsFormatSupported` / `GetDevicePeriod` / `GetBufferSize` / `rebuild`。`streamInitExclusive` 按 requested 或默认 Exclusive capture 候选列表探测，Initialize 只用 `EVENTCALLBACK`（可 OR caller extras），失败一次 `NOT_ALIGNED` 则重建 client 并用对齐 duration 重试。`prepareClient` 对两种 share mode 只调 `streamInit(...)`。AutoConvert（#45）和 Application Loopback 接线（#46）不在本 PR。

## Testing

- `WinAudioTests` Debug：203/203 通过（含 8 个 Exclusive Stream init 用例：探测、render 无格式失败、capture 候选列表、`NOT_ALIGNED` 对齐 duration 与 min period 可区分、rebuild 失败传播）。测试不依赖真音频设备。
- Exclusive 拒绝 System Loopback / silent-render / 高级 client properties 的现有测试仍通过。
- Release 由 CI 矩阵覆盖。独占格式协商仍需真设备冒烟，本 PR 为配方搬家，未改协商规则。

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` passes locally (203/203)
- [ ] `test.bat Release` — CI matrix
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached (N/A)
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above (N/A — extract only)
