### PR TITLE
feat(core): add AutoConvert to Stream params

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,7 +83,7 @@ The delayed playback leg of a Monitor when sync playback is engaged — at most 
 _Avoid_: Output only, speaker path alone
 
 **Stream params**:
-Advanced open-time settings for one Track: category, option, offload, ducking, buffer length, and user-overridable stream flags. All-default means follow the system and the current Stream init recipe.
+Advanced open-time settings for one Track: category, option, offload, ducking, buffer length, and user-overridable stream flags including AutoConvert (`Default` | `Force` | `Off`). All-default means follow the system and the current Stream init recipe.
 _Avoid_: StreamOption (that is only the APO / raw / match-format field), client properties alone, AUDCLNT_STREAMFLAGS
 
 **Stream flags**:

--- a/docs/superpowers/specs/2026-07-02-winaudio-device-params-design.md
+++ b/docs/superpowers/specs/2026-07-02-winaudio-device-params-design.md
@@ -124,7 +124,8 @@ void   setRenderParams(const StreamParams& p);   // 运行中可调,下次 engag
 
 - 参数持久化(重启回"跟随系统")。
 - CLI 暴露高级参数。
-- loopback、其余 `AUDCLNT_STREAMFLAGS_*`、会话音量/静音、通知回调。
+- loopback extras、除 AutoConvert 以外的其余 `AUDCLNT_STREAMFLAGS_*`、会话音量/静音、通知回调。
+  AutoConvert（Default / Force / Off）已进入 Stream params，由 Stream init 合成 Initialize flags；见 ADR-0001。EVENTCALLBACK 锁定；LOOPBACK 仍由调用者 extras 传入。
 - 运行中热改**采集**参数(必须 Stop/Start)。
 - 弹窗内格式(采样率/位深)配置——Exclusive 格式仍由现有 CLI `--format`/候选协商逻辑负责。
 

--- a/src/core/StreamInit.cpp
+++ b/src/core/StreamInit.cpp
@@ -2,10 +2,32 @@
 #include "FormatSpec.h"
 #include "Log.h"
 #include "AudioFormatStr.h"
+#include <cstdio>
 #include <string>
 #include <vector>
 
 namespace wa {
+namespace {
+
+DWORD sharedInitFlags(const StreamInitRequest& req) {
+    DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | req.extraFlags;
+    const bool addAutoConvert =
+        req.params.autoConvert == AutoConvert::Force ||
+        (req.params.autoConvert == AutoConvert::Default && req.requested != nullptr);
+    if (addAutoConvert) {
+        flags |= AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                 AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    }
+    return flags;
+}
+
+std::string initArgs(const AudioFormat& fmt, DWORD flags) {
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "0x%X", static_cast<unsigned>(flags));
+    return "fmt=" + wa::formatAudio(fmt) + " flags=" + buf;
+}
+
+} // namespace
 
 AudioClientInitAdapter::AudioClientInitAdapter(ComPtr<IAudioClient>& client, IMMDevice* device)
     : client_(client), device_(device) {}
@@ -50,23 +72,19 @@ Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
     const REFERENCE_TIME dur = req.params.bufferMs
         ? static_cast<REFERENCE_TIME>(req.params.bufferMs) * 10'000
         : 10'000'000 / 10; // default: 100 ms buffer
-    const DWORD extraFlags = req.extraFlags;
+    const DWORD flags = sharedInitFlags(req);
 
     if (req.requested) {
         out.actualFormat = *req.requested;
         out.frameBytes = out.actualFormat.blockAlign();
         WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(*req.requested);
-        const DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
-                            AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
-                            AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY |
-                            extraFlags;
         HRESULT hr = client.initialize(AUDCLNT_SHAREMODE_SHARED, flags, dur, 0,
                                        reinterpret_cast<WAVEFORMATEX*>(&wfx));
         WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(shared,requested)",
-               "fmt=" + wa::formatAudio(*req.requested), wa::log::hrName(hr));
+               initArgs(*req.requested, flags), wa::log::hrName(hr));
         if (FAILED(hr)) {
             WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(shared,requested)",
-                   "fmt=" + wa::formatAudio(*req.requested), wa::log::hrName(hr));
+                   initArgs(*req.requested, flags), wa::log::hrName(hr));
             return HrToResult(hr, "WasapiStream: Initialize(shared, requested)");
         }
         return Result::Ok();
@@ -82,15 +100,13 @@ Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
     if (!mix) return Result::Fail(-1, "WasapiStream: GetMixFormat returned null");
     out.actualFormat = fromWaveFormat(mix);
     out.frameBytes = out.actualFormat.blockAlign();
-    hr = client.initialize(AUDCLNT_SHAREMODE_SHARED,
-                           AUDCLNT_STREAMFLAGS_EVENTCALLBACK | extraFlags,
-                           dur, 0, mix);
+    hr = client.initialize(AUDCLNT_SHAREMODE_SHARED, flags, dur, 0, mix);
     WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(shared)",
-           "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+           initArgs(out.actualFormat, flags), wa::log::hrName(hr));
     CoTaskMemFree(mix);
     if (FAILED(hr)) {
         WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(shared)",
-               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+               initArgs(out.actualFormat, flags), wa::log::hrName(hr));
         return HrToResult(hr, "WasapiStream: Initialize(shared)");
     }
     return Result::Ok();
@@ -98,6 +114,12 @@ Result streamInitShared(AudioClientInit& client, const StreamInitRequest& req,
 
 Result streamInitExclusive(AudioClientInit& client, const StreamInitRequest& req,
                            StreamInitOutcome& out) {
+    if (req.params.autoConvert == AutoConvert::Force) {
+        WA_LOG(wa::log::Level::Debug, "StreamInit", "AutoConvert",
+               "mode=exclusive value=Force", "rejected");
+        return Result::Fail(-1, "WasapiStream: exclusive AutoConvert Force is not supported");
+    }
+
     std::vector<AudioFormat> candidates;
     if (req.requested) {
         candidates.push_back(*req.requested);
@@ -137,7 +159,7 @@ Result streamInitExclusive(AudioClientInit& client, const StreamInitRequest& req
     HRESULT hr = client.initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags, dur, dur,
                                    reinterpret_cast<WAVEFORMATEX*>(&wfx));
     WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(exclusive)",
-           "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+           initArgs(out.actualFormat, flags), wa::log::hrName(hr));
     if (hr == AUDCLNT_E_BUFFER_SIZE_NOT_ALIGNED) {
         UINT32 aligned = 0;
         HRESULT hrGBS = client.getBufferSize(&aligned);
@@ -156,11 +178,11 @@ Result streamInitExclusive(AudioClientInit& client, const StreamInitRequest& req
         hr = client.initialize(AUDCLNT_SHAREMODE_EXCLUSIVE, flags, dur, dur,
                                reinterpret_cast<WAVEFORMATEX*>(&wfx2));
         WA_LOG(wa::log::Level::Debug, "StreamInit", "Initialize(exclusive,realign)",
-               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+               initArgs(out.actualFormat, flags), wa::log::hrName(hr));
     }
     if (FAILED(hr)) {
         WA_LOG(wa::log::Level::Err, "StreamInit", "Initialize(exclusive)",
-               "fmt=" + wa::formatAudio(out.actualFormat), wa::log::hrName(hr));
+               initArgs(out.actualFormat, flags), wa::log::hrName(hr));
         return HrToResult(hr, "WasapiStream: Initialize(exclusive)");
     }
     return Result::Ok();

--- a/src/core/StreamParams.h
+++ b/src/core/StreamParams.h
@@ -10,6 +10,7 @@ enum class AudioCategory : uint8_t { Other, Communications, Media, Movie,
 enum class StreamOption  : uint8_t { None, Raw, MatchFormat, Ambisonics,
                                      PostVolumeLoopback };          // AUDCLNT_STREAMOPTIONS
 enum class DuckingMode   : uint8_t { Default, OptOut };            // render-only
+enum class AutoConvert   : uint8_t { Default, Force, Off };        // AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
 
 struct ClientProperties {
     bool          enabled  = false;                          // false = do not call SetClientProperties
@@ -22,10 +23,12 @@ struct StreamParams {
     ClientProperties clientProperties{};
     DuckingMode      ducking  = DuckingMode::Default;
     uint32_t         bufferMs = 0;                    // 0 = current behavior (Shared 100 ms / Excl minPer)
+    AutoConvert      autoConvert = AutoConvert::Default;
 
     bool anyClientProps() const { return clientProperties.enabled; }
     bool isDefault() const {
-        return !anyClientProps() && ducking == DuckingMode::Default && bufferMs == 0;
+        return !anyClientProps() && ducking == DuckingMode::Default && bufferMs == 0
+            && autoConvert == AutoConvert::Default;
     }
 };
 

--- a/src/tests/test_stream_init.cpp
+++ b/src/tests/test_stream_init.cpp
@@ -107,7 +107,7 @@ TEST(StreamInitShared, MixDefaultUsesEventCallbackOnly) {
     EXPECT_EQ(fake.lastFormat, out.actualFormat);
 }
 
-TEST(StreamInitShared, RequestedDefaultAddsAutoconvertAndSrc) {
+TEST(StreamInitShared, RequestedDefaultAddsAutoConvertAndSrc) {
     FakeAudioClientInit fake;
     AudioFormat want{44100, 2, 16, false};
     StreamInitRequest req;
@@ -136,7 +136,7 @@ TEST(StreamInitShared, CallerLoopbackExtraAppearsInFlags) {
                                                  AUDCLNT_STREAMFLAGS_LOOPBACK));
 }
 
-TEST(StreamInitShared, RequestedPlusLoopbackExtraORsAutoconvert) {
+TEST(StreamInitShared, RequestedPlusLoopbackExtraORsAutoConvert) {
     FakeAudioClientInit fake;
     AudioFormat want{44100, 2, 16, false};
     StreamInitRequest req;
@@ -151,6 +151,37 @@ TEST(StreamInitShared, RequestedPlusLoopbackExtraORsAutoconvert) {
                            AUDCLNT_STREAMFLAGS_LOOPBACK;
     EXPECT_EQ(fake.lastFlags, expected);
     EXPECT_EQ(out.actualFormat, want);
+}
+
+TEST(StreamInitShared, RequestedOffOmitsAutoConvert) {
+    FakeAudioClientInit fake;
+    AudioFormat want{44100, 2, 16, false};
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.autoConvert = AutoConvert::Off;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_SHARED);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(out.actualFormat, want);
+    EXPECT_EQ(fake.lastFormat, want);
+}
+
+TEST(StreamInitShared, MixForceAddsAutoConvertAndSrc) {
+    FakeAudioClientInit fake;
+    StreamInitRequest req;
+    req.params.autoConvert = AutoConvert::Force;
+    StreamInitOutcome out;
+    Result r = streamInitShared(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_SHARED);
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    EXPECT_EQ(fake.lastFlags, expected);
+    EXPECT_EQ(out.actualFormat, fake.mixFormat);
+    EXPECT_EQ(fake.lastFormat, fake.mixFormat);
 }
 
 TEST(StreamInitShared, BufferMsSetsDuration) {
@@ -256,6 +287,58 @@ TEST(StreamInitExclusive, CaptureNoneSupportedFailsWithoutInitialize) {
     EXPECT_FALSE(static_cast<bool>(r));
     EXPECT_EQ(r.code, static_cast<long>(AUDCLNT_E_UNSUPPORTED_FORMAT));
     EXPECT_EQ(fake.initializeCount, 0);
+}
+
+TEST(StreamInitExclusive, AutoConvertForceFailsWithoutInitialize) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.autoConvert = AutoConvert::Force;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_EQ(fake.initializeCount, 0);
+    EXPECT_EQ(fake.rebuildCount, 0);
+    EXPECT_TRUE(fake.probedFormats.empty());
+}
+
+TEST(StreamInitExclusive, AutoConvertOffKeepsProbeAndEventCallback) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.autoConvert = AutoConvert::Off;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_EXCLUSIVE);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(out.actualFormat, want);
+    EXPECT_EQ(fake.initializeCount, 1);
+}
+
+TEST(StreamInitExclusive, AutoConvertOffNotAlignedRebuildsThenRetries) {
+    FakeAudioClientInit fake;
+    AudioFormat want{48000, 2, 16, false};
+    fake.supportedFormats.push_back(want);
+    fake.failFirstInitWithNotAligned = true;
+    fake.minPeriod = 300000;
+    fake.alignedFrames = 480;
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.autoConvert = AutoConvert::Off;
+    StreamInitOutcome out;
+    Result r = streamInitExclusive(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.rebuildCount, 1);
+    EXPECT_EQ(fake.initializeCount, 2);
+    EXPECT_EQ(fake.lastDuration, 100000);
+    EXPECT_EQ(fake.lastPeriodicity, 100000);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK));
+    EXPECT_EQ(out.actualFormat, want);
 }
 
 TEST(StreamInitExclusive, BufferMsSetsEqualDurationAndPeriodicity) {

--- a/src/tests/test_streamparams.cpp
+++ b/src/tests/test_streamparams.cpp
@@ -13,6 +13,7 @@ TEST(StreamParams, DefaultIsAllDefault) {
     EXPECT_TRUE(p.isDefault());
     EXPECT_FALSE(p.anyClientProps());
     EXPECT_EQ(p.bufferMs, 0u);
+    EXPECT_EQ(p.autoConvert, AutoConvert::Default);
 }
 
 TEST(StreamParams, Predicates) {
@@ -24,10 +25,15 @@ TEST(StreamParams, Predicates) {
     b.clientProperties.offload = true;
     EXPECT_FALSE(b.anyClientProps()); EXPECT_TRUE(b.isDefault());
 
-    StreamParams d; d.ducking = DuckingMode::OptOut;      // ducking 不属于 client-props
+    StreamParams d; d.ducking = DuckingMode::OptOut;      // ducking is not a client-props field
     EXPECT_FALSE(d.anyClientProps()); EXPECT_FALSE(d.isDefault());
-    StreamParams e; e.bufferMs = 50;                       // bufferMs 也不属于
+    StreamParams e; e.bufferMs = 50;                       // bufferMs is not either
     EXPECT_FALSE(e.anyClientProps()); EXPECT_FALSE(e.isDefault());
+
+    StreamParams force; force.autoConvert = AutoConvert::Force;
+    EXPECT_FALSE(force.anyClientProps()); EXPECT_FALSE(force.isDefault());
+    StreamParams off; off.autoConvert = AutoConvert::Off;
+    EXPECT_FALSE(off.anyClientProps()); EXPECT_FALSE(off.isDefault());
 }
 
 TEST(StreamParams, CategoryMapping) {


### PR DESCRIPTION
﻿## What / Why

Stream params 增加用户可覆盖的 AutoConvert（Default / Force / Off），让 Shared Initialize flags 不再绑死「有没有 requested 格式」。Exclusive 上 Force 显式失败，不静默降级。GUI Advanced 与 CLI 本轮不加控件，全默认打开路径与今天一致。

Closes #45
Parent: #42
ADR: `docs/adr/0001-stream-init-shared-recipe.md`

## How

Stream init 按 AutoConvert 合成 stream flags：Default 保持今天的规则（Shared + requested → AUTOCONVERT + SRC_DEFAULT_QUALITY）；Force / Off 与有没有 requested 格式解耦。AUTOCONVERT 与 SRC_DEFAULT_QUALITY 始终同加同不加。Exclusive Default / Off 忽略该字段，探测与对齐重试不变。Application Loopback 仍走自己的 Initialize 副本（#46）。

## Testing

- `WinAudioTests --gtest_filter=StreamParams.*:StreamInit*`（假 audio client，无真设备）
- Debug ctest: 209/209
- Release ctest: 208/208（补 Exclusive Off + 对齐重试用例前；之后 Debug 全量含新用例为 209/209）
- 无 GUI / CLI 改动；Default 路径行为保持，不需要真设备冒烟

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices
- [x] GUI changes: screenshots attached (N/A — no GUI change)
- [x] Real-device behavior touched: manual smoke done (N/A — Default Initialize flags unchanged)
