### PR TITLE
feat(core): run Application Loopback through Stream init

### DIFF
--- a/src/core/ApplicationLoopbackCapture.cpp
+++ b/src/core/ApplicationLoopbackCapture.cpp
@@ -13,9 +13,9 @@
 #include <wrl/implements.h>
 #include "AudioFormat.h"
 #include "AudioFormatStr.h"
-#include "FormatSpec.h"
 #include "Log.h"
 #include "RingBuffer.h"
+#include "StreamInit.h"
 
 namespace wa {
 namespace {
@@ -135,17 +135,16 @@ AudioFormat defaultApplicationLoopbackFormat() {
     return AudioFormat{44100, 2, 16, false};
 }
 
-Result initializeApplicationLoopbackClient(ComPtr<IAudioClient>& client, const AudioFormat& fmt,
-                                           DWORD flags, REFERENCE_TIME dur,
-                                           const char* where) {
-    WAVEFORMATEXTENSIBLE wfx = toWaveFormatExtensible(fmt);
-    HRESULT hr = client->Initialize(
-        AUDCLNT_SHAREMODE_SHARED,
-        flags | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
-            AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
-        dur, 0, reinterpret_cast<WAVEFORMATEX*>(&wfx), nullptr);
-    if (FAILED(hr)) return HrToResult(hr, where);
-    return Result::Ok();
+Result streamInitApplicationLoopback(AudioClientInit& client, StreamInitRequest req,
+                                     StreamInitOutcome& out) {
+    req.extraFlags |= AUDCLNT_STREAMFLAGS_LOOPBACK;
+    Result r = streamInitShared(client, req, out);
+    if (r || req.requested) return r;
+    AudioFormat fallback = defaultApplicationLoopbackFormat();
+    req.requested = &fallback;
+    WA_LOG(wa::log::Level::Warn, "ApplicationLoopbackCaptureStream", "streamInit(mix)",
+           r.message, "fallback 44100/2/16");
+    return streamInitShared(client, req, out);
 }
 
 ApplicationLoopbackCaptureStream::~ApplicationLoopbackCaptureStream() { close(); }
@@ -235,33 +234,18 @@ Result ApplicationLoopbackCaptureStream::activateClient() {
 }
 
 Result ApplicationLoopbackCaptureStream::initializeClient() {
-    REFERENCE_TIME dur = params_.bufferMs
-        ? static_cast<REFERENCE_TIME>(params_.bufferMs) * 10000
-        : 1000000; // 100 ms
-    DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_LOOPBACK;
-
-    if (hasRequested_) {
-        actualFormat_ = requestedFormat_;
-        frameBytes_ = actualFormat_.blockAlign();
-        return initializeApplicationLoopbackClient(client_, actualFormat_, flags, dur,
-            "ApplicationLoopbackCaptureStream: Initialize(requested)");
+    AudioClientInitAdapter adapter(client_, nullptr);
+    StreamInitRequest req;
+    req.requested = hasRequested_ ? &requestedFormat_ : nullptr;
+    req.params = params_;
+    req.direction = StreamInitDirection::Capture;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(adapter, req, out);
+    if (r) {
+        actualFormat_ = out.actualFormat;
+        frameBytes_ = out.frameBytes;
     }
-
-    WAVEFORMATEX* mix = nullptr;
-    HRESULT hr = client_->GetMixFormat(&mix);
-    if (SUCCEEDED(hr) && mix) {
-        actualFormat_ = fromWaveFormat(mix);
-        frameBytes_ = actualFormat_.blockAlign();
-        hr = client_->Initialize(AUDCLNT_SHAREMODE_SHARED, flags, dur, 0, mix, nullptr);
-        CoTaskMemFree(mix);
-        if (SUCCEEDED(hr)) return Result::Ok();
-    }
-    if (mix) CoTaskMemFree(mix);
-
-    actualFormat_ = defaultApplicationLoopbackFormat();
-    frameBytes_ = actualFormat_.blockAlign();
-    return initializeApplicationLoopbackClient(client_, actualFormat_, flags, dur,
-        "ApplicationLoopbackCaptureStream: Initialize(fallback)");
+    return r;
 }
 
 Result ApplicationLoopbackCaptureStream::createService() {

--- a/src/core/ApplicationLoopbackCapture.h
+++ b/src/core/ApplicationLoopbackCapture.h
@@ -15,11 +15,18 @@
 #include <vector>
 #include "ComUtil.h"
 #include "IAudioBackend.h"
+#include "StreamInit.h"
 #include "WasapiStream.h"
 
 namespace wa {
 
 AudioFormat defaultApplicationLoopbackFormat();
+
+// Application Loopback adapter around Shared Stream init: always supplies LOOPBACK
+// extras, and on mix failure retries once with 44100/2/16 requested. Ordinary
+// Tracks call Stream init directly and do not get this fallback.
+Result streamInitApplicationLoopback(AudioClientInit& client, StreamInitRequest req,
+                                     StreamInitOutcome& out);
 
 class ApplicationLoopbackCaptureStream : public IAudioBackend {
 public:

--- a/src/tests/test_loopback.cpp
+++ b/src/tests/test_loopback.cpp
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
 #include <string>
 #include "ApplicationLoopbackCapture.h"
+#include "AudioFormat.h"
 #include "IAudioBackend.h"
 #include "RingBuffer.h"
+#include "StreamInit.h"
 #include "WasapiStream.h"
+#include <objbase.h>
 #include <windows.h>
 
 using namespace wa;
@@ -126,4 +129,164 @@ TEST(ApplicationLoopbackCaptureStream, DefaultFormatMatchesProcessLoopbackSample
     EXPECT_EQ(fmt.channels, 2u);
     EXPECT_EQ(fmt.bitsPerSample, 16u);
     EXPECT_FALSE(fmt.isFloat);
+}
+
+namespace {
+
+constexpr REFERENCE_TIME kSharedDefaultDuration = 1'000'000;
+
+class FakeAppLoopbackClient : public AudioClientInit {
+public:
+    AudioFormat mixFormat{48000, 2, 16, false};
+    HRESULT mixHr = S_OK;
+    HRESULT initHr = S_OK;
+    bool failFirstInit = false;
+
+    AUDCLNT_SHAREMODE lastShareMode = AUDCLNT_SHAREMODE_SHARED;
+    DWORD lastFlags = 0;
+    REFERENCE_TIME lastDuration = 0;
+    REFERENCE_TIME lastPeriodicity = -1;
+    AudioFormat lastFormat{};
+    int initializeCount = 0;
+
+    HRESULT getMixFormat(WAVEFORMATEX** mix) override {
+        if (FAILED(mixHr)) return mixHr;
+        auto* wfx = static_cast<WAVEFORMATEX*>(CoTaskMemAlloc(sizeof(WAVEFORMATEX)));
+        if (!wfx) return E_OUTOFMEMORY;
+        ZeroMemory(wfx, sizeof(*wfx));
+        wfx->wFormatTag = WAVE_FORMAT_PCM;
+        wfx->nChannels = mixFormat.channels;
+        wfx->nSamplesPerSec = mixFormat.sampleRate;
+        wfx->wBitsPerSample = mixFormat.bitsPerSample;
+        wfx->nBlockAlign = static_cast<WORD>(mixFormat.blockAlign());
+        wfx->nAvgBytesPerSec = mixFormat.avgBytesPerSec();
+        *mix = wfx;
+        return S_OK;
+    }
+
+    HRESULT initialize(AUDCLNT_SHAREMODE shareMode, DWORD streamFlags,
+                       REFERENCE_TIME bufferDuration, REFERENCE_TIME periodicity,
+                       const WAVEFORMATEX* format) override {
+        ++initializeCount;
+        lastShareMode = shareMode;
+        lastFlags = streamFlags;
+        lastDuration = bufferDuration;
+        lastPeriodicity = periodicity;
+        if (format) lastFormat = fromWaveFormat(format);
+        if (failFirstInit && initializeCount == 1) return E_FAIL;
+        return initHr;
+    }
+
+    HRESULT isFormatSupported(AUDCLNT_SHAREMODE, const WAVEFORMATEX*) override {
+        return E_NOTIMPL;
+    }
+    HRESULT getDevicePeriod(REFERENCE_TIME*, REFERENCE_TIME*) override { return E_NOTIMPL; }
+    HRESULT getBufferSize(UINT32*) override { return E_NOTIMPL; }
+    HRESULT rebuild() override { return E_NOTIMPL; }
+};
+
+} // namespace
+
+TEST(ApplicationLoopbackStreamInit, MixDefaultUsesEventCallbackAndLoopback) {
+    FakeAppLoopbackClient fake;
+    StreamInitRequest req;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastShareMode, AUDCLNT_SHAREMODE_SHARED);
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                                                 AUDCLNT_STREAMFLAGS_LOOPBACK));
+    EXPECT_EQ(fake.lastDuration, kSharedDefaultDuration);
+    EXPECT_EQ(fake.lastPeriodicity, 0);
+    EXPECT_EQ(out.actualFormat, fake.mixFormat);
+    EXPECT_EQ(out.frameBytes, fake.mixFormat.blockAlign());
+    EXPECT_EQ(fake.initializeCount, 1);
+}
+
+TEST(ApplicationLoopbackStreamInit, MixInitFailureRetriesWith44100Requested) {
+    FakeAppLoopbackClient fake;
+    fake.failFirstInit = true;
+    StreamInitRequest req;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    const AudioFormat fallback = defaultApplicationLoopbackFormat();
+    EXPECT_EQ(fake.initializeCount, 2);
+    EXPECT_EQ(fake.lastFormat, fallback);
+    EXPECT_EQ(out.actualFormat, fallback);
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_LOOPBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    EXPECT_EQ(fake.lastFlags, expected);
+}
+
+TEST(ApplicationLoopbackStreamInit, MixGetMixFormatFailureRetriesWith44100Requested) {
+    FakeAppLoopbackClient fake;
+    fake.mixHr = E_FAIL;
+    StreamInitRequest req;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    const AudioFormat fallback = defaultApplicationLoopbackFormat();
+    EXPECT_EQ(fake.initializeCount, 1);
+    EXPECT_EQ(fake.lastFormat, fallback);
+    EXPECT_EQ(out.actualFormat, fallback);
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_LOOPBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    EXPECT_EQ(fake.lastFlags, expected);
+}
+
+TEST(ApplicationLoopbackStreamInit, RequestedInitFailureDoesNotFallback) {
+    FakeAppLoopbackClient fake;
+    fake.initHr = E_FAIL;
+    AudioFormat want{48000, 1, 16, false};
+    StreamInitRequest req;
+    req.requested = &want;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    EXPECT_FALSE(static_cast<bool>(r));
+    EXPECT_EQ(fake.initializeCount, 1);
+    EXPECT_EQ(fake.lastFormat, want);
+}
+
+TEST(ApplicationLoopbackStreamInit, RequestedOffOmitsAutoConvertKeepsLoopback) {
+    FakeAppLoopbackClient fake;
+    AudioFormat want{48000, 2, 24, false};
+    StreamInitRequest req;
+    req.requested = &want;
+    req.params.autoConvert = AutoConvert::Off;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastFlags, static_cast<DWORD>(AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                                                 AUDCLNT_STREAMFLAGS_LOOPBACK));
+    EXPECT_EQ(out.actualFormat, want);
+}
+
+TEST(ApplicationLoopbackStreamInit, BufferMsSetsDuration) {
+    FakeAppLoopbackClient fake;
+    StreamInitRequest req;
+    req.params.bufferMs = 50;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    EXPECT_EQ(fake.lastDuration, static_cast<REFERENCE_TIME>(50) * 10'000);
+}
+
+TEST(ApplicationLoopbackStreamInit, MixForceAddsAutoConvertAndLoopback) {
+    FakeAppLoopbackClient fake;
+    StreamInitRequest req;
+    req.params.autoConvert = AutoConvert::Force;
+    StreamInitOutcome out;
+    Result r = streamInitApplicationLoopback(fake, req, out);
+    ASSERT_TRUE(static_cast<bool>(r)) << r.message;
+    const DWORD expected = AUDCLNT_STREAMFLAGS_EVENTCALLBACK |
+                           AUDCLNT_STREAMFLAGS_LOOPBACK |
+                           AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+                           AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+    EXPECT_EQ(fake.lastFlags, expected);
+    EXPECT_EQ(fake.initializeCount, 1);
 }


### PR DESCRIPTION
## What / Why

Application Loopback still cloned Shared Initialize (`EVENTCALLBACK` / `AUTOCONVERT` / `LOOPBACK`, buffer duration, mix-then-44100 fallback) instead of using Stream init. That meant AutoConvert and `bufferMs` diverged from ordinary Tracks, and a flag-policy change had to be made twice.

This PR routes Application Loopback Initialize through the same Shared Stream init recipe. Mix failure still retries once with 44100/2/16 requested; a user-requested format still fails once. PID / IncludeTree / ExcludeTree activation is unchanged. No client properties or ducking.

Closes #46.

## How

`streamInitApplicationLoopback` is the Application Loopback adapter: it ORs caller `LOOPBACK` extras, calls Shared Stream init, and on mix failure issues a second Stream init with `defaultApplicationLoopbackFormat()` requested. Stream init still does not inspect Capture source. Exclusive Application Loopback remains rejected at `open`.

## Testing

- `WinAudioTests` Debug: 216 tests, all passed
- `WinAudioTests` Release: 216 tests, all passed
- New `ApplicationLoopbackStreamInit.*` tests hit the adapter through a fake audio client (no hardware)
- Existing Application Loopback PID / Shared-only tests still pass
- No real-device smoke (Initialize path refactor; latency / exclusive negotiation unchanged)

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
