### PR TITLE
feat(gui): live per-track WAV dump with folder picker

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ Windows audio test tool: capture, loopback, delayed monitor pass-through, and ch
 ### Capture and monitor
 
 **Monitor**:
-A dual-stream session that pairs exactly one Capture Track with at most one Render Track after a fixed delay, with scope taps for charts.
+A dual-stream session that pairs exactly one Capture Track with at most one Render Track after a fixed delay, with scope taps for charts. Each side may own a live WAV sink (GUI Dump capture / Dump render).
 _Avoid_: Engine session (when meaning the product feature), pass-through alone, Track (when meaning the whole pair)
 
 **System Loopback**:
@@ -67,7 +67,7 @@ The kind and identity of what a Capture Track captures: a capture endpoint, a Sy
 _Avoid_: Track, device (when meaning the whole instance)
 
 **Capture Track**:
-A Track that binds one Capture source and may own a WAV sink (optional on the GUI; required per Track on CLI capture).
+A Track that binds one Capture source and may own a WAV sink (GUI: live start/stop Dump; CLI capture: required path at create).
 _Avoid_: record track, input track, Capture side (when meaning the Track itself)
 
 **Render Track**:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cd winaudio
 
 运行 `WinAudioGui.exe`，包含 **Monitor** / **Loopback** / **Application Loopback** 三个 tab。日志默认写运行目录下的 `winaudio.log`（双击启动即 exe 目录），左栏日志面板可运行时切换级别、清空、自动滚动。
 
-领域用语：**Track** 是一路可单独创建/销毁的单向流（采集或播放），Create 立即开流，没有 idle Track；**Capture source** 是配方（设备 / PID+mode），不是正在跑的那一路；**Capture Track** 绑定一个 Capture source，GUI 上 WAV 可选；**Monitor** 是唯一的双流会话名；**Chart Host** 是一路图的工具栏 + 面板。两个 loopback 页各自一份列表，每次启动为空；切走 tab 不会停采集。
+领域用语：**Track** 是一路可单独创建/销毁的单向流（采集或播放），Create 立即开流，没有 idle Track；**Capture source** 是配方（设备 / PID+mode），不是正在跑的那一路；**Capture Track** 绑定一个 Capture source，GUI 上可随时 Dump / Stop dump；**Monitor** 是唯一的双流会话名；**Chart Host** 是一路图的工具栏 + 面板。两个 loopback 页各自一份列表，每次启动为空；切走 tab 不会停采集。
 
 ### Monitor（双流延迟监听）
 
@@ -58,7 +58,7 @@ cd winaudio
 
 - **Devices**：选择采集设备（默认系统默认设备）与后端（Shared / Exclusive）；「Capture caps…」弹窗显示该设备的三来源格式与 Shared/Exclusive 能力矩阵。
 - **Format**：显示当前将用格式（如 `48000 Hz, 16-bit, 2-ch`）；候选下拉第一项为 System default，随后是当前后端支持的候选格式，末项 Custom 可手动输入；切换设备或后端时自动重算默认值。
-- **Control**：「Options」弹窗配置高级流参数——capture/render 各自的 `SetClientProperties` 总开关、category、offload、stream option（None / Raw / MatchFormat / Ambisonics / Post-volume loopback）、ducking（仅 render）、buffer ms；弹窗仅 Start 前可改。「同步播放」checkbox 实时启停 render 直通流（Exclusive 模式要求渲染设备支持采集格式）。
+- **Control**：「Options」弹窗配置高级流参数——capture/render 各自的 `SetClientProperties` 总开关、category、offload、stream option（None / Raw / MatchFormat / Ambisonics / Post-volume loopback）、ducking（仅 render）、buffer ms；弹窗仅 Start 前可改。「同步播放」checkbox 实时启停 render 直通流（Exclusive 模式要求渲染设备支持采集格式）。**Dump capture** / **Dump render** 各自随时开停 WAV sink（选文件夹、自动命名；播放未开时 Dump render 禁用）。
 - **Status**：实时显示 fifo ms / drift，方便观察跨设备时钟漂移。
 - Monitor 保持单一会话：Start / Stop 控制这一对，没有「Destroy all」跨页清列表。DelayFifo 属于 Monitor，不是 Track。
 
@@ -66,14 +66,14 @@ cd winaudio
 
 本页是一份 System Loopback **Capture Track** 列表（Shared-only），不是单路 Start/Stop。
 
-- **Create Track**：选一个 render device 作为 Capture source，可选填 WAV 与 format，「Silent render keepalive」默认开启（该路 live 期间不可改）。Create 立即开流，没有第二步 Start。同一 render device 允许同时开多路。
-- **Destroy** / **Destroy all**：Destroy 只拆这一路（采集、silent render helper、该路 WAV、该路图）。Destroy all 只清本页，不动 Application Loopback 或 Monitor。
+- **Create Track**：选一个 render device 作为 Capture source，可选填 format，「Silent render keepalive」默认开启（该路 live 期间不可改）。Create 立即开流，没有第二步 Start。同一 render device 允许同时开多路。
+- **Destroy** / **Destroy all**：Destroy 只拆这一路（采集、silent render helper、该路若在 dump 则收尾 WAV、该路图）。Destroy all 只清本页，不动 Application Loopback 或 Monitor。
 - 右侧为每路独立的 Capture-only **Chart Host**（波形 + 声谱图；2ch+ 时 `Ch N` 拆分仍在该 Track 内，最多前 8 个 channel）。Chart freeze 与 linked time axis 按 Track，路与路不共享时间轴或格式。
-- WAV 可选：不填只看图；填了则该路单独写文件。多路不会混成一个流或一个文件。
+- **Dump** / **Stop dump**：每路独立、运行中随时开停的 WAV sink。Start dump 选保存文件夹，文件名按固定 prefix、实际格式和时间戳生成；Stop dump（或 Destroy）成功后用资源管理器选中该文件。多路不会混成一个流或一个文件。
 
 ### Application Loopback（按进程回采）
 
-本页是一份 Application Loopback Capture Track 列表（Create / Destroy / Destroy all、堆叠 Chart Host、可选 WAV / format）。Capture source 是 **PID + IncludeTree / ExcludeTree**。Destroy 只拆这一路；Destroy all 只清本页的 Application Loopback Capture Track，不动 Loopback 页或 Monitor。
+本页是一份 Application Loopback Capture Track 列表（Create / Destroy / Destroy all、堆叠 Chart Host、可选 format、每路独立 Dump）。Capture source 是 **PID + IncludeTree / ExcludeTree**。Destroy 只拆这一路；Destroy all 只清本页的 Application Loopback Capture Track，不动 Loopback 页或 Monitor。
 
 打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举。Session 列表只做发现：点击一行把 PID 填入输入框，也可手输任意非零 PID（不必出现在列表中）。点列表不会开流。
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cd winaudio
 
 ### Application Loopback（按进程回采）
 
-本页是一份 Application Loopback Capture Track 列表（Create / Destroy / Destroy all、堆叠 Chart Host、可选 format、每路独立 Dump）。Capture source 是 **PID + IncludeTree / ExcludeTree**。Destroy 只拆这一路；Destroy all 只清本页的 Application Loopback Capture Track，不动 Loopback 页或 Monitor。
+本页是一份 Application Loopback Capture Track 列表（Create / Destroy / Destroy all、堆叠 Chart Host、可选 format、每路独立 Dump）。Capture source 是 **PID + IncludeTree / ExcludeTree**。Dump 文件名带进程名和 PID。Destroy 只拆这一路；Destroy all 只清本页的 Application Loopback Capture Track，不动 Loopback 页或 Monitor。
 
 打开 tab 后自动枚举当前有 Audio Session 的进程（进程名 + PID，按进程名排序），「Refresh」重新枚举。Session 列表只做发现：点击一行把 PID 填入输入框，也可手输任意非零 PID（不必出现在列表中）。点列表不会开流。
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(WinAudioCore STATIC
     RingBuffer.cpp
     SampleConvert.cpp
     WavFile.cpp
+    WavSink.cpp
     AudioSessionEnumerator.cpp
     ApplicationLoopbackCapture.cpp
     DeviceEnumerator.cpp

--- a/src/core/CaptureTrackList.cpp
+++ b/src/core/CaptureTrackList.cpp
@@ -9,7 +9,7 @@
 #include "SampleConvert.h"
 #include "ScopeBuffer.h"
 #include "WasapiStream.h"
-#include "WavFile.h"
+#include "WavSink.h"
 #include <windows.h>
 #include <algorithm>
 #include <cmath>
@@ -54,6 +54,14 @@ const char* sourceName(CaptureSourceKind kind) {
     default:                                     return "endpoint";
     }
 }
+
+const char* dumpPrefix(CaptureSourceKind kind) {
+    switch (kind) {
+    case CaptureSourceKind::SystemLoopback:      return "loopback";
+    case CaptureSourceKind::ApplicationLoopback: return "app-loopback";
+    default:                                     return "capture";
+    }
+}
 } // namespace
 
 struct CaptureTrackList::Member {
@@ -64,6 +72,8 @@ struct CaptureTrackList::Member {
     std::unique_ptr<IAudioBackend> silent;
     std::unique_ptr<RingBuffer>    ring;
     std::unique_ptr<ScopeBuffer>   tap;
+    WavSink sink;
+    bool wavFatal = false;
     std::thread pump;
     std::atomic<bool> running{false};
     std::mutex mtx;
@@ -72,6 +82,7 @@ struct CaptureTrackList::Member {
     void stopPumpAndBackends() {
         running.store(false, std::memory_order_relaxed);
         if (pump.joinable()) pump.join();
+        else sink.stop();
         if (silent) {
             silent->stop();
             silent->close();
@@ -193,33 +204,34 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
             const uint16_t ch = fmt.channels ? fmt.channels : static_cast<uint16_t>(1);
             const size_t scopeCap = std::max<size_t>(static_cast<size_t>(sr) * 2u, 1048576u);
             m->tap = std::make_unique<ScopeBuffer>(scopeCap, ch);
+            if (!spec.wavPath.empty()) {
+                m->wavFatal = true;
+                Result wr = m->sink.startExact(spec.wavPath, fmt);
+                if (!wr) {
+                    WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.open", "", wr.message);
+                    std::lock_guard<std::mutex> lk(m->mtx);
+                    m->status.state = StreamState::Error;
+                    m->status.message = wr.message.empty() ? "cannot open output wav"
+                                                           : wr.message;
+                    m->wavFatal = false;
+                }
+            }
         }
-        m->running.store(true, std::memory_order_relaxed);
+        const bool wavOpenFailed = m->status.state == StreamState::Error;
+        m->running.store(!wavOpenFailed, std::memory_order_relaxed);
         {
             std::lock_guard<std::mutex> lk(m->mtx);
-            m->status.state = StreamState::Running;
+            if (!wavOpenFailed)
+                m->status.state = StreamState::Running;
             m->status.actualFormat = m->backend->stats().actualFormat;
             m->status.silentRenderState = silentSt;
         }
+        if (!wavOpenFailed)
         m->pump = std::thread([mem = m.get()] {
             wa::log::setThreadName("ctl-cap");
             AudioFormat fmt = mem->backend->stats().actualFormat;
             const uint32_t frameBytes = fmt.blockAlign();
             const uint16_t ch = fmt.channels ? fmt.channels : static_cast<uint16_t>(1);
-            WavWriter writer;
-            const bool wantWav = !mem->wavPath.empty();
-            if (wantWav) {
-                Result wr = writer.open(mem->wavPath, fmt);
-                if (!wr) {
-                    WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.open", "", wr.message);
-                    std::lock_guard<std::mutex> lk(mem->mtx);
-                    mem->status.state = StreamState::Error;
-                    mem->status.message = wr.message.empty() ? "cannot open output wav"
-                                                             : wr.message;
-                    mem->running.store(false, std::memory_order_relaxed);
-                    return;
-                }
-            }
             std::vector<uint8_t> buf(16384);
             std::vector<float> interleaved(4096u * ch, 0.f);
             while (mem->running.load(std::memory_order_relaxed)) {
@@ -231,13 +243,15 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                 const size_t frames = got / frameBytes;
                 got = frames * frameBytes;
                 if (frames == 0) continue;
-                if (wantWav && writer.write(buf.data(), got) != got) {
-                    WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.write", "", "short write");
-                    std::lock_guard<std::mutex> lk(mem->mtx);
-                    mem->status.state = StreamState::Error;
-                    mem->status.message = "wav write failed";
-                    mem->running.store(false, std::memory_order_relaxed);
-                    return;
+                if (mem->sink.isRunning()) {
+                    const size_t wn = mem->sink.push(buf.data(), got);
+                    if (wn != got && mem->wavFatal) {
+                        WA_LOG(wa::log::Level::Err, "CaptureTrackList", "wav.write", "",
+                               "short write");
+                        std::lock_guard<std::mutex> lk(mem->mtx);
+                        mem->status.state = StreamState::Error;
+                        mem->status.message = "wav write failed";
+                    }
                 }
                 if (mem->tap && frames > 0) {
                     size_t done = 0;
@@ -257,7 +271,7 @@ Result CaptureTrackList::create(const CaptureTrackCreate& spec, TrackId* outId) 
                 mem->status.overruns = mem->ring->overruns();
                 mem->status.writtenFrames = mem->tap ? mem->tap->totalWritten() : 0;
             }
-            if (wantWav) writer.close();
+            mem->sink.stop();
         });
     } catch (const std::exception& e) {
         m->stopPumpAndBackends();
@@ -303,11 +317,60 @@ void CaptureTrackList::destroyAll() {
     for (auto& m : gone) m->stopPumpAndBackends();
 }
 
+CaptureTrackList::Member* CaptureTrackList::findUnlocked(TrackId id) {
+    return const_cast<Member*>(
+        static_cast<const CaptureTrackList*>(this)->findUnlocked(id));
+}
+
 const CaptureTrackList::Member* CaptureTrackList::findUnlocked(TrackId id) const {
     for (const auto& m : members_) {
         if (m->id == id) return m.get();
     }
     return nullptr;
+}
+
+Result CaptureTrackList::startDump(TrackId id, const std::wstring& folder) {
+    Member* m = nullptr;
+    AudioFormat fmt{};
+    CaptureSourceKind kind = CaptureSourceKind::Endpoint;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        m = findUnlocked(id);
+        if (!m) return Result::Fail(-1, "CaptureTrackList: unknown track");
+        std::lock_guard<std::mutex> mlk(m->mtx);
+        if (m->status.state != StreamState::Running)
+            return Result::Fail(-1, "CaptureTrackList: track not running");
+        if (m->sink.isRunning())
+            return Result::Fail(-1, "CaptureTrackList: dump already running");
+        fmt = m->status.actualFormat;
+        kind = m->source.kind;
+    }
+    Result r = m->sink.start(folder, dumpPrefix(kind), fmt);
+    if (!r) {
+        WA_LOG(wa::log::Level::Err, "CaptureTrackList", "dump.start",
+               "id=" + std::to_string(id), r.message);
+        return r;
+    }
+    m->wavFatal = false;
+    WA_LOG(wa::log::Level::Info, "CaptureTrackList", "dump.start",
+           "id=" + std::to_string(id) + " prefix=" + dumpPrefix(kind), "ok");
+    return Result::Ok();
+}
+
+Result CaptureTrackList::stopDump(TrackId id) {
+    Member* m = nullptr;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        m = findUnlocked(id);
+        if (!m) return Result::Fail(-1, "CaptureTrackList: unknown track");
+    }
+    const bool wasRunning = m->sink.isRunning();
+    Result r = m->sink.stop();
+    WA_LOG(r ? wa::log::Level::Info : wa::log::Level::Err, "CaptureTrackList", "dump.stop",
+           "id=" + std::to_string(id), r ? "ok" : r.message);
+    if (!wasRunning && r)
+        return Result::Fail(-1, "CaptureTrackList: dump not running");
+    return r;
 }
 
 uint64_t CaptureTrackList::written(TrackId id) const {
@@ -347,7 +410,14 @@ std::vector<CaptureTrackStatus> CaptureTrackList::poll() const {
     out.reserve(members_.size());
     for (const auto& m : members_) {
         std::lock_guard<std::mutex> mlk(m->mtx);
-        out.push_back(m->status);
+        CaptureTrackStatus s = m->status;
+        const WavSinkStatus ds = m->sink.poll();
+        s.dumping = ds.state == WavSinkState::Running;
+        s.dumpError = ds.state == WavSinkState::Error;
+        s.dumpPath = ds.path;
+        s.dumpFileName = ds.fileName;
+        s.dumpMessage = ds.message;
+        out.push_back(std::move(s));
     }
     return out;
 }

--- a/src/core/CaptureTrackList.cpp
+++ b/src/core/CaptureTrackList.cpp
@@ -55,12 +55,45 @@ const char* sourceName(CaptureSourceKind kind) {
     }
 }
 
-const char* dumpPrefix(CaptureSourceKind kind) {
+const wchar_t* dumpPrefixKind(CaptureSourceKind kind) {
     switch (kind) {
-    case CaptureSourceKind::SystemLoopback:      return "loopback";
-    case CaptureSourceKind::ApplicationLoopback: return "app-loopback";
-    default:                                     return "capture";
+    case CaptureSourceKind::SystemLoopback:      return L"loopback";
+    case CaptureSourceKind::ApplicationLoopback: return L"app-loopback";
+    default:                                     return L"capture";
     }
+}
+
+std::wstring sanitizeDumpToken(std::wstring s) {
+    for (wchar_t& c : s) {
+        if (c < 32 || c == L'<' || c == L'>' || c == L':' || c == L'"' ||
+            c == L'/' || c == L'\\' || c == L'|' || c == L'?' || c == L'*')
+            c = L'_';
+    }
+    while (!s.empty() && (s.back() == L' ' || s.back() == L'.'))
+        s.pop_back();
+    return s.empty() ? L"unknown" : s;
+}
+
+std::wstring processDumpName(uint32_t pid) {
+    HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!h) return L"unknown";
+    wchar_t path[MAX_PATH] = {};
+    DWORD n = MAX_PATH;
+    std::wstring name;
+    if (QueryFullProcessImageNameW(h, 0, path, &n) && n > 0) {
+        const std::wstring p(path, n);
+        const size_t slash = p.find_last_of(L"\\/");
+        name = (slash == std::wstring::npos) ? p : p.substr(slash + 1);
+    }
+    CloseHandle(h);
+    return sanitizeDumpToken(std::move(name));
+}
+
+std::wstring dumpPrefixFor(const CaptureSource& src) {
+    std::wstring p = dumpPrefixKind(src.kind);
+    if (src.kind == CaptureSourceKind::ApplicationLoopback)
+        p += L'_' + processDumpName(src.processId) + L'_' + std::to_wstring(src.processId);
+    return p;
 }
 } // namespace
 
@@ -332,7 +365,7 @@ const CaptureTrackList::Member* CaptureTrackList::findUnlocked(TrackId id) const
 Result CaptureTrackList::startDump(TrackId id, const std::wstring& folder) {
     Member* m = nullptr;
     AudioFormat fmt{};
-    CaptureSourceKind kind = CaptureSourceKind::Endpoint;
+    CaptureSource source{};
     {
         std::lock_guard<std::mutex> lk(mtx_);
         m = findUnlocked(id);
@@ -343,9 +376,10 @@ Result CaptureTrackList::startDump(TrackId id, const std::wstring& folder) {
         if (m->sink.isRunning())
             return Result::Fail(-1, "CaptureTrackList: dump already running");
         fmt = m->status.actualFormat;
-        kind = m->source.kind;
+        source = m->source;
     }
-    Result r = m->sink.start(folder, dumpPrefix(kind), fmt);
+    const std::wstring prefix = dumpPrefixFor(source);
+    Result r = m->sink.start(folder, prefix, fmt);
     if (!r) {
         WA_LOG(wa::log::Level::Err, "CaptureTrackList", "dump.start",
                "id=" + std::to_string(id), r.message);
@@ -353,7 +387,7 @@ Result CaptureTrackList::startDump(TrackId id, const std::wstring& folder) {
     }
     m->wavFatal = false;
     WA_LOG(wa::log::Level::Info, "CaptureTrackList", "dump.start",
-           "id=" + std::to_string(id) + " prefix=" + dumpPrefix(kind), "ok");
+           "id=" + std::to_string(id) + " prefix=" + wa::narrowAscii(prefix), "ok");
     return Result::Ok();
 }
 

--- a/src/core/CaptureTrackList.h
+++ b/src/core/CaptureTrackList.h
@@ -33,6 +33,11 @@ struct CaptureTrackStatus {
     uint64_t      writtenFrames = 0;
     StreamState   silentRenderState = StreamState::Idle;
     std::string   message;
+    bool          dumping = false;
+    bool          dumpError = false;
+    std::wstring  dumpPath;
+    std::wstring  dumpFileName;
+    std::string   dumpMessage;
 };
 
 // Live Capture Tracks with independent lifetime. Create starts immediately.
@@ -53,6 +58,8 @@ public:
     Result create(const CaptureTrackCreate& spec, TrackId* outId);
     void   destroy(TrackId id);
     void   destroyAll();
+    Result startDump(TrackId id, const std::wstring& folder);
+    Result stopDump(TrackId id);
     std::vector<CaptureTrackStatus> poll() const;
 
     uint64_t written(TrackId id) const;
@@ -70,6 +77,7 @@ private:
     std::vector<std::unique_ptr<Member>> members_;
     mutable std::mutex   mtx_;
 
+    Member*       findUnlocked(TrackId id);
     const Member* findUnlocked(TrackId id) const;
 };
 

--- a/src/core/MonitorEngine.cpp
+++ b/src/core/MonitorEngine.cpp
@@ -366,6 +366,7 @@ Result MonitorEngine::engageRender() {
 
 void MonitorEngine::disengageRender() {
     WA_LOG(wa::log::Level::Info, "MonitorEngine", "render.disengaged", "", "");
+    renderSink_.stop();
     if (renderBackend_) renderBackend_->stop();
     renderBackend_.reset();
     renderRing_.reset();
@@ -381,6 +382,42 @@ void MonitorEngine::disengageRender() {
 
 void MonitorEngine::setPlaybackEnabled(bool enabled) {
     wantPlayback_.store(enabled, std::memory_order_release);   // pump converges to this next iteration
+}
+
+Result MonitorEngine::startDumpCapture(const std::wstring& folder) {
+    if (capState_.load(std::memory_order_acquire) != StreamState::Running)
+        return Result::Fail(-1, "MonitorEngine: capture not running");
+    Result r = capSink_.start(folder, "monitor-cap", capFmt_);
+    WA_LOG(r ? wa::log::Level::Info : wa::log::Level::Err, "MonitorEngine", "dump.cap.start",
+           "", r ? "ok" : r.message);
+    return r;
+}
+
+Result MonitorEngine::stopDumpCapture() {
+    const bool was = capSink_.isRunning();
+    Result r = capSink_.stop();
+    if (!was && r) return Result::Fail(-1, "MonitorEngine: capture dump not running");
+    WA_LOG(r ? wa::log::Level::Info : wa::log::Level::Err, "MonitorEngine", "dump.cap.stop",
+           "", r ? "ok" : r.message);
+    return r;
+}
+
+Result MonitorEngine::startDumpRender(const std::wstring& folder) {
+    if (renderState_.load(std::memory_order_acquire) != StreamState::Running)
+        return Result::Fail(-1, "MonitorEngine: render not running");
+    Result r = renderSink_.start(folder, "monitor-ren", renderFmt_);
+    WA_LOG(r ? wa::log::Level::Info : wa::log::Level::Err, "MonitorEngine", "dump.ren.start",
+           "", r ? "ok" : r.message);
+    return r;
+}
+
+Result MonitorEngine::stopDumpRender() {
+    const bool was = renderSink_.isRunning();
+    Result r = renderSink_.stop();
+    if (!was && r) return Result::Fail(-1, "MonitorEngine: render dump not running");
+    WA_LOG(r ? wa::log::Level::Info : wa::log::Level::Err, "MonitorEngine", "dump.ren.stop",
+           "", r ? "ok" : r.message);
+    return r;
 }
 
 void MonitorEngine::setRenderParams(const StreamParams& p) {
@@ -458,6 +495,8 @@ void MonitorEngine::pumpLoop() {
             downmixMono(capFloat_.data(), frames, capCh, capMono_.data());
             captureScope_->pushInterleaved(capFloat_.data(), frames);
             capLevel_.store(peakLevel(capMono_.data(), frames), std::memory_order_relaxed);
+            if (capSink_.isRunning())
+                capSink_.push(capScratch_.data(), frames * capFrameBytes);
 
             if (!renderActive) continue;   // capture-only: do not touch FIFO / render
 
@@ -473,6 +512,9 @@ void MonitorEngine::pumpLoop() {
                     renderLevel_.store(peakLevel(renderMono_.data(), popped), std::memory_order_relaxed);
                     adaptChannels(popBuf_.data(), capCh, renderAdapt_.data(), renderCh, popped);
                     floatToPcm(renderAdapt_.data(), popped, renderFmt_, renderBytes_.data());
+                    if (renderSink_.isRunning())
+                        renderSink_.push(renderBytes_.data(),
+                                         popped * static_cast<size_t>(renderFrameBytes));
                     const size_t wantBytes = static_cast<size_t>(popped) * renderFrameBytes;
                     const size_t freeBytes = renderRing_->availableWrite();
                     const size_t safeBytes = (std::min(wantBytes, freeBytes) / renderFrameBytes) * renderFrameBytes;
@@ -492,6 +534,8 @@ void MonitorEngine::pumpLoop() {
                 renderXruns_.store(renderDropped_.load(std::memory_order_relaxed), std::memory_order_relaxed);
         }
     }
+    capSink_.stop();
+    renderSink_.stop();
 }
 
 void MonitorEngine::teardown() {
@@ -549,6 +593,18 @@ MonitorStatus MonitorEngine::poll() {
     s.capLevel    = capLevel_.load(std::memory_order_relaxed);
     s.renderLevel = renderLevel_.load(std::memory_order_relaxed);
     s.errorCode   = errorCode_.load(std::memory_order_relaxed);
+    {
+        const WavSinkStatus cs = capSink_.poll();
+        s.capDumping = cs.state == WavSinkState::Running;
+        s.capDumpError = cs.state == WavSinkState::Error;
+        s.capDumpPath = cs.path;
+        s.capDumpFileName = cs.fileName;
+        const WavSinkStatus rs = renderSink_.poll();
+        s.renderDumping = rs.state == WavSinkState::Running;
+        s.renderDumpError = rs.state == WavSinkState::Error;
+        s.renderDumpPath = rs.path;
+        s.renderDumpFileName = rs.fileName;
+    }
     return s;
 }
 

--- a/src/core/MonitorEngine.h
+++ b/src/core/MonitorEngine.h
@@ -12,6 +12,7 @@
 #include "IAudioBackend.h" // IAudioBackend, DataFlow, DeviceId
 #include "Result.h"
 #include "StreamParams.h"
+#include "WavSink.h"
 
 namespace wa {
 
@@ -56,6 +57,14 @@ struct MonitorStatus {
     float       capLevel    = 0.f;
     float       renderLevel = 0.f;
     uint32_t    errorCode   = 0;     // MonitorError
+    bool          capDumping = false;
+    bool          capDumpError = false;
+    std::wstring  capDumpPath;
+    std::wstring  capDumpFileName;
+    bool          renderDumping = false;
+    bool          renderDumpError = false;
+    std::wstring  renderDumpPath;
+    std::wstring  renderDumpFileName;
 };
 
 // Dual-stream delayed monitor pass-through: capture -> frame-domain DelayFifo
@@ -96,6 +105,10 @@ public:
     MonitorStatus poll();
     void   setPlaybackEnabled(bool enabled);                        // 运行期实时开关（GUI 线程）
     void   setRenderParams(const StreamParams& p);                  // 运行中可调;下次 engage 取快照生效
+    Result startDumpCapture(const std::wstring& folder);
+    Result stopDumpCapture();
+    Result startDumpRender(const std::wstring& folder);
+    Result stopDumpRender();
 
     bool snapshotCapture(size_t n, float* out, uint64_t& endIdxOut);
     bool snapshotCaptureAt(uint64_t endIdx, size_t n, float* out);
@@ -188,6 +201,9 @@ private:
     std::vector<float>   renderAdapt_;
     std::vector<float>   renderMono_;
     std::vector<uint8_t> renderBytes_;
+
+    WavSink capSink_;
+    WavSink renderSink_;
 };
 
 } // namespace wa

--- a/src/core/WavFile.cpp
+++ b/src/core/WavFile.cpp
@@ -46,6 +46,11 @@ Result WavWriter::open(const std::wstring& path, const AudioFormat& fmt) {
     return Result::Ok();
 }
 
+void WavWriter::setStdioBuffer(size_t bytes) {
+    if (file_ && bytes > 0)
+        std::setvbuf(file_, nullptr, _IOFBF, bytes);
+}
+
 size_t WavWriter::write(const void* data, size_t bytes) {
     if (!file_) return 0;
     size_t n = std::fwrite(data, 1, bytes, file_);

--- a/src/core/WavFile.h
+++ b/src/core/WavFile.h
@@ -11,6 +11,7 @@ class WavWriter {
 public:
     ~WavWriter();
     Result open(const std::wstring& path, const AudioFormat& fmt);
+    void   setStdioBuffer(size_t bytes);          // setvbuf; no-op if not open
     size_t write(const void* data, size_t bytes); // returns bytes written
     Result close();                               // patches sizes
 private:

--- a/src/core/WavSink.cpp
+++ b/src/core/WavSink.cpp
@@ -52,8 +52,8 @@ std::wstring typeToken(const AudioFormat& fmt) {
     return t;
 }
 
-std::wstring autoStem(const char* prefix, const AudioFormat& fmt, const SYSTEMTIME& st) {
-    return wideAscii(prefix) + L'_' + std::to_wstring(fmt.sampleRate) + L'_' +
+std::wstring autoStem(const std::wstring& prefix, const AudioFormat& fmt, const SYSTEMTIME& st) {
+    return prefix + L'_' + std::to_wstring(fmt.sampleRate) + L'_' +
            std::to_wstring(fmt.channels) + L"ch_" + typeToken(fmt) + L'_' +
            std::to_wstring(st.wYear) +
            (st.wMonth < 10 ? L"0" : L"") + std::to_wstring(st.wMonth) +
@@ -77,12 +77,17 @@ std::wstring uniqueWavPath(const std::wstring& folder, const std::wstring& stem)
 WavSink::WavSink() = default;
 WavSink::~WavSink() { stop(); }
 
-Result WavSink::start(const std::wstring& folder, const char* prefix, const AudioFormat& fmt) {
-    if (folder.empty() || !prefix || !*prefix)
+Result WavSink::start(const std::wstring& folder, const std::wstring& prefix,
+                      const AudioFormat& fmt) {
+    if (folder.empty() || prefix.empty())
         return Result::Fail(-1, "WavSink: folder and prefix required");
     SYSTEMTIME st{};
     GetLocalTime(&st);
     return begin(uniqueWavPath(folder, autoStem(prefix, fmt, st)), fmt);
+}
+
+Result WavSink::start(const std::wstring& folder, const char* prefix, const AudioFormat& fmt) {
+    return start(folder, wideAscii(prefix), fmt);
 }
 
 Result WavSink::startExact(const std::wstring& path, const AudioFormat& fmt) {

--- a/src/core/WavSink.cpp
+++ b/src/core/WavSink.cpp
@@ -1,0 +1,245 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include "WavSink.h"
+#include "AudioFormatStr.h"
+#include "Log.h"
+#include "RingBuffer.h"
+#include "WavFile.h"
+#include <windows.h>
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+namespace wa {
+
+namespace {
+constexpr size_t kFlushBytes = 256u * 1024u;
+constexpr size_t kRingMin    = 1u << 20;
+constexpr size_t kRingMax    = 16u << 20;
+
+size_t ringBytesFor(const AudioFormat& fmt) {
+    const uint32_t bps = fmt.avgBytesPerSec();
+    size_t n = static_cast<size_t>(bps) * 4u;
+    if (n < kRingMin) n = kRingMin;
+    if (n > kRingMax) n = kRingMax;
+    return n;
+}
+
+std::wstring fileNameOf(const std::wstring& path) {
+    const size_t slash = path.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return path;
+    return path.substr(slash + 1);
+}
+
+std::wstring wideAscii(const char* s) {
+    std::wstring w;
+    if (!s) return w;
+    for (; *s; ++s) w.push_back(static_cast<wchar_t>(static_cast<unsigned char>(*s)));
+    return w;
+}
+
+std::wstring joinPath(const std::wstring& folder, const std::wstring& name) {
+    if (folder.empty()) return name;
+    const wchar_t last = folder.back();
+    if (last == L'\\' || last == L'/') return folder + name;
+    return folder + L'\\' + name;
+}
+
+std::wstring typeToken(const AudioFormat& fmt) {
+    std::wstring t = std::to_wstring(fmt.bitsPerSample);
+    if (fmt.isFloat) t += L'f';
+    return t;
+}
+
+std::wstring autoStem(const char* prefix, const AudioFormat& fmt, const SYSTEMTIME& st) {
+    return wideAscii(prefix) + L'_' + std::to_wstring(fmt.sampleRate) + L'_' +
+           std::to_wstring(fmt.channels) + L"ch_" + typeToken(fmt) + L'_' +
+           std::to_wstring(st.wYear) +
+           (st.wMonth < 10 ? L"0" : L"") + std::to_wstring(st.wMonth) +
+           (st.wDay < 10 ? L"0" : L"") + std::to_wstring(st.wDay) + L'_' +
+           (st.wHour < 10 ? L"0" : L"") + std::to_wstring(st.wHour) +
+           (st.wMinute < 10 ? L"0" : L"") + std::to_wstring(st.wMinute) +
+           (st.wSecond < 10 ? L"0" : L"") + std::to_wstring(st.wSecond);
+}
+
+std::wstring uniqueWavPath(const std::wstring& folder, const std::wstring& stem) {
+    std::wstring path = joinPath(folder, stem + L".wav");
+    int n = 2;
+    while (GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES) {
+        path = joinPath(folder, stem + L'_' + std::to_wstring(n) + L".wav");
+        if (++n > 10000) break;
+    }
+    return path;
+}
+} // namespace
+
+WavSink::WavSink() = default;
+WavSink::~WavSink() { stop(); }
+
+Result WavSink::start(const std::wstring& folder, const char* prefix, const AudioFormat& fmt) {
+    if (folder.empty() || !prefix || !*prefix)
+        return Result::Fail(-1, "WavSink: folder and prefix required");
+    SYSTEMTIME st{};
+    GetLocalTime(&st);
+    return begin(uniqueWavPath(folder, autoStem(prefix, fmt, st)), fmt);
+}
+
+Result WavSink::startExact(const std::wstring& path, const AudioFormat& fmt) {
+    return begin(path, fmt);
+}
+
+Result WavSink::begin(const std::wstring& path, const AudioFormat& fmt) {
+    if (state_.load(std::memory_order_acquire) == WavSinkState::Running)
+        return Result::Fail(-1, "WavSink: already running");
+    if (path.empty())
+        return Result::Fail(-1, "WavSink: empty path");
+
+    stop();
+
+    fmt_ = fmt;
+    overflow_.store(false, std::memory_order_relaxed);
+    writeError_.store(false, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        path_ = path;
+        fileName_ = fileNameOf(path);
+        message_.clear();
+    }
+    ring_ = std::make_unique<RingBuffer>(ringBytesFor(fmt));
+    running_.store(true, std::memory_order_release);
+    state_.store(WavSinkState::Idle, std::memory_order_release);
+    writer_ = std::thread(&WavSink::writerLoop, this);
+
+    for (int i = 0; i < 2000; ++i) {
+        const WavSinkState st = state_.load(std::memory_order_acquire);
+        if (st == WavSinkState::Running) {
+            WA_LOG(wa::log::Level::Info, "WavSink", "start",
+                   wa::narrowAscii(path) + " fmt=" + wa::formatAudio(fmt), "ok");
+            return Result::Ok();
+        }
+        if (st == WavSinkState::Error) {
+            joinWriter();
+            std::lock_guard<std::mutex> lk(mtx_);
+            return Result::Fail(-1, message_.empty() ? "WavSink: open failed" : message_);
+        }
+        Sleep(1);
+    }
+    running_.store(false, std::memory_order_release);
+    joinWriter();
+    state_.store(WavSinkState::Idle, std::memory_order_release);
+    return Result::Fail(-1, "WavSink: timed out waiting for writer");
+}
+
+size_t WavSink::push(const void* data, size_t bytes) {
+    if (!data || bytes == 0) return 0;
+    if (state_.load(std::memory_order_acquire) != WavSinkState::Running) return 0;
+    if (!running_.load(std::memory_order_acquire) || !ring_) return 0;
+    const size_t n = ring_->write(data, bytes);
+    if (n < bytes) {
+        overflow_.store(true, std::memory_order_release);
+        running_.store(false, std::memory_order_release);
+    }
+    return n;
+}
+
+Result WavSink::stop() {
+    running_.store(false, std::memory_order_release);
+    joinWriter();
+    ring_.reset();
+    const bool failed = overflow_.load(std::memory_order_relaxed)
+                        || writeError_.load(std::memory_order_relaxed)
+                        || state_.load(std::memory_order_relaxed) == WavSinkState::Error;
+    if (failed) {
+        state_.store(WavSinkState::Error, std::memory_order_release);
+        WA_LOG(wa::log::Level::Info, "WavSink", "stop",
+               wa::narrowAscii(path_), "error");
+        return Result::Fail(-1, message_.empty() ? "WavSink: failed" : message_);
+    }
+    state_.store(WavSinkState::Idle, std::memory_order_release);
+    if (!path_.empty())
+        WA_LOG(wa::log::Level::Info, "WavSink", "stop", wa::narrowAscii(path_), "ok");
+    return Result::Ok();
+}
+
+bool WavSink::isRunning() const {
+    return state_.load(std::memory_order_acquire) == WavSinkState::Running;
+}
+
+WavSinkStatus WavSink::poll() const {
+    WavSinkStatus s;
+    s.state = state_.load(std::memory_order_acquire);
+    std::lock_guard<std::mutex> lk(mtx_);
+    s.path = path_;
+    s.fileName = fileName_;
+    s.message = message_;
+    return s;
+}
+
+void WavSink::joinWriter() {
+    if (writer_.joinable()) writer_.join();
+}
+
+void WavSink::writerLoop() {
+    wa::log::setThreadName("wav");
+    WavWriter writer;
+    Result wr = writer.open(path_, fmt_);
+    if (!wr) {
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            message_ = wr.message.empty() ? "WavSink: cannot open file" : wr.message;
+        }
+        WA_LOG(wa::log::Level::Err, "WavSink", "open", wa::narrowAscii(path_), message_);
+        running_.store(false, std::memory_order_release);
+        state_.store(WavSinkState::Error, std::memory_order_release);
+        return;
+    }
+    writer.setStdioBuffer(kFlushBytes);
+    state_.store(WavSinkState::Running, std::memory_order_release);
+
+    std::vector<uint8_t> chunk(kFlushBytes);
+    bool failed = false;
+    for (;;) {
+        const bool stop = !running_.load(std::memory_order_acquire);
+        const bool overflow = overflow_.load(std::memory_order_acquire);
+        const size_t avail = ring_ ? ring_->availableRead() : 0;
+        const bool drain = stop || overflow;
+        if (!drain && avail < kFlushBytes) {
+            Sleep(5);
+            continue;
+        }
+        if (avail == 0) {
+            if (drain) break;
+            Sleep(5);
+            continue;
+        }
+        const size_t want = (std::min)(avail, kFlushBytes);
+        const size_t got = ring_->read(chunk.data(), want);
+        if (got == 0) {
+            if (drain) break;
+            continue;
+        }
+        if (writer.write(chunk.data(), got) != got) {
+            WA_LOG(wa::log::Level::Err, "WavSink", "write", wa::narrowAscii(path_),
+                   "short write");
+            writeError_.store(true, std::memory_order_release);
+            failed = true;
+            break;
+        }
+        if (overflow && (!ring_ || ring_->availableRead() == 0)) break;
+    }
+    writer.close();
+    if (failed || overflow_.load(std::memory_order_relaxed)) {
+        const bool ovf = overflow_.load(std::memory_order_relaxed);
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            if (message_.empty())
+                message_ = ovf ? "WavSink: ring overflow" : "WavSink: write failed";
+        }
+        if (ovf)
+            WA_LOG(wa::log::Level::Err, "WavSink", "write", wa::narrowAscii(path_), "overflow");
+        state_.store(WavSinkState::Error, std::memory_order_release);
+    }
+}
+
+} // namespace wa

--- a/src/core/WavSink.h
+++ b/src/core/WavSink.h
@@ -31,6 +31,7 @@ public:
     WavSink& operator=(const WavSink&) = delete;
 
     Result startExact(const std::wstring& path, const AudioFormat& fmt);
+    Result start(const std::wstring& folder, const std::wstring& prefix, const AudioFormat& fmt);
     Result start(const std::wstring& folder, const char* prefix, const AudioFormat& fmt);
     size_t push(const void* data, size_t bytes);
     Result stop();

--- a/src/core/WavSink.h
+++ b/src/core/WavSink.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include "AudioFormat.h"
+#include "Result.h"
+
+namespace wa {
+
+class RingBuffer;
+
+enum class WavSinkState { Idle, Running, Error };
+
+struct WavSinkStatus {
+    WavSinkState state = WavSinkState::Idle;
+    std::wstring path;
+    std::wstring fileName;
+    std::string  message;
+};
+
+// Side WAV writer: producer push() is non-blocking (preallocated ring only).
+// File open/write/close run on a dedicated writer thread.
+class WavSink {
+public:
+    WavSink();
+    ~WavSink();
+
+    WavSink(const WavSink&)            = delete;
+    WavSink& operator=(const WavSink&) = delete;
+
+    Result startExact(const std::wstring& path, const AudioFormat& fmt);
+    Result start(const std::wstring& folder, const char* prefix, const AudioFormat& fmt);
+    size_t push(const void* data, size_t bytes);
+    Result stop();
+    WavSinkStatus poll() const;
+    bool isRunning() const;
+
+private:
+    Result begin(const std::wstring& path, const AudioFormat& fmt);
+    void   writerLoop();
+    void   joinWriter();
+
+    AudioFormat                 fmt_{};
+    std::unique_ptr<RingBuffer> ring_;
+    std::thread                 writer_;
+    std::atomic<bool>           running_{false};
+    std::atomic<bool>           overflow_{false};
+    std::atomic<bool>           writeError_{false};
+    std::atomic<WavSinkState>   state_{WavSinkState::Idle};
+    std::wstring                path_;
+    std::wstring                fileName_;
+    std::string                 message_;
+    mutable std::mutex          mtx_;
+};
+
+} // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -6,6 +6,7 @@
 #include "ChartsFreezePolicy.h"
 #include "ChartsTimeZoomPolicy.h"
 #include "ComUtil.h"
+#include "DumpUi.h"
 #include "MonitorScopeReader.h"
 #include "imgui.h"
 #include "implot.h"
@@ -529,6 +530,40 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::EndChild();
 }
 
+void AppUi::drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t) {
+    if (t.dumping) {
+        if (ImGui::Button(wa::ui_text::kDumpStop)) {
+            const std::wstring path = t.dumpPath;
+            wa::Result r = list.stopDump(t.id);
+            logLines_.push_back(r ? ("dump stopped " + wtou(path))
+                                  : ("dump stop error: " + r.message));
+            if (r) wa::dump_ui::revealDumpFile(path);
+        }
+        if (!t.dumpFileName.empty()) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("%s", wtou(t.dumpFileName).c_str());
+        }
+    } else {
+        ImGui::BeginDisabled(t.state != wa::StreamState::Running);
+        if (ImGui::Button(wa::ui_text::kDump)) {
+            std::wstring folder = wa::dump_ui::loadDumpFolder();
+            if (wa::dump_ui::pickDumpFolder(folder)) {
+                wa::dump_ui::saveDumpFolder(folder);
+                wa::Result r = list.startDump(t.id, folder);
+                if (r) {
+                    std::wstring path;
+                    for (const auto& s : list.poll())
+                        if (s.id == t.id) path = s.dumpPath;
+                    logLines_.push_back("dump started " + wtou(path));
+                } else {
+                    logLines_.push_back("dump start error: " + r.message);
+                }
+            }
+        }
+        ImGui::EndDisabled();
+    }
+}
+
 void AppUi::drawLoopbackLeftPanel() {
     if (!monitorDevicesLoaded_) refreshMonitorDevices();
 
@@ -550,7 +585,6 @@ void AppUi::drawLoopbackLeftPanel() {
         ImGui::EndCombo();
     }
 
-    ImGui::InputText(wa::ui_text::kLoopbackWavOptional, loopbackWav_, sizeof(loopbackWav_));
     ImGui::InputText(wa::ui_text::kLoopbackFormatOptional, loopbackFmt_, sizeof(loopbackFmt_));
     ImGui::Checkbox(wa::ui_text::kLoopbackSilentRender, &loopbackSilentRender_);
 
@@ -561,7 +595,6 @@ void AppUi::drawLoopbackLeftPanel() {
         wa::CaptureTrackCreate spec{};
         spec.kind = wa::BackendKind::WasapiShared;
         spec.source = wa::CaptureSource{wa::CaptureSourceKind::SystemLoopback, id};
-        spec.wavPath = utow(loopbackWav_);
         spec.loopbackOptions.silentRender = loopbackSilentRender_;
         wa::AudioFormat fmt{};
         if (loopbackFmt_[0] != '\0' && wa::parseFormatSpec(loopbackFmt_, fmt))
@@ -578,8 +611,12 @@ void AppUi::drawLoopbackLeftPanel() {
     }
     ImGui::SameLine();
     if (ImGui::Button(wa::ui_text::kLoopbackDestroyAll, ctrlBtn)) {
+        std::vector<std::wstring> dumpPaths;
+        for (const auto& t : loopbackTracks_.poll())
+            if (t.dumping) dumpPaths.push_back(t.dumpPath);
         loopbackTracks_.destroyAll();
         loopbackViz_.clear();
+        for (const auto& p : dumpPaths) wa::dump_ui::revealDumpFile(p);
         logLines_.push_back("loopback destroy all");
     }
 
@@ -592,8 +629,11 @@ void AppUi::drawLoopbackLeftPanel() {
                     (unsigned long long)t.id, ss[(int)t.state],
                     t.actualFormat.sampleRate, (unsigned long long)t.overruns);
         ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
+        drawDumpControls(loopbackTracks_, t);
         if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
+            const std::wstring dumpPath = t.dumping ? t.dumpPath : std::wstring{};
             loopbackTracks_.destroy(t.id);
+            if (!dumpPath.empty()) wa::dump_ui::revealDumpFile(dumpPath);
             logLines_.push_back("loopback track destroyed id=" + std::to_string(t.id));
         }
         ImGui::PopID();
@@ -633,7 +673,6 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     ImGui::InputText("##appLoopbackPid", appLoopbackPid_, sizeof(appLoopbackPid_));
     ImGui::SameLine();
     ImGui::Checkbox(wa::ui_text::kApplicationLoopbackExclude, &appLoopbackExclude_);
-    ImGui::InputText(wa::ui_text::kLoopbackWavOptional, appLoopbackWav_, sizeof(appLoopbackWav_));
     ImGui::InputText(wa::ui_text::kLoopbackFormatOptional, appLoopbackFmt_, sizeof(appLoopbackFmt_));
 
     ImGui::SeparatorText("Control");
@@ -650,7 +689,6 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
             spec.kind = wa::BackendKind::WasapiShared;
             spec.source = wa::CaptureSource{wa::CaptureSourceKind::ApplicationLoopback, L"",
                                             pid, mode};
-            spec.wavPath = utow(appLoopbackWav_);
             wa::AudioFormat fmt{};
             if (appLoopbackFmt_[0] != '\0' && wa::parseFormatSpec(appLoopbackFmt_, fmt))
                 spec.requested = &fmt;
@@ -670,8 +708,12 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
     }
     ImGui::SameLine();
     if (ImGui::Button(wa::ui_text::kLoopbackDestroyAll, ctrlBtn)) {
+        std::vector<std::wstring> dumpPaths;
+        for (const auto& t : appLoopbackTracks_.poll())
+            if (t.dumping) dumpPaths.push_back(t.dumpPath);
         appLoopbackTracks_.destroyAll();
         appLoopbackViz_.clear();
+        for (const auto& p : dumpPaths) wa::dump_ui::revealDumpFile(p);
         logLines_.push_back("application loopback destroy all");
     }
 
@@ -686,8 +728,11 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
                     wa::processLoopbackModeName(t.source.processLoopbackMode),
                     t.actualFormat.sampleRate, (unsigned long long)t.overruns);
         ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
+        drawDumpControls(appLoopbackTracks_, t);
         if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
+            const std::wstring dumpPath = t.dumping ? t.dumpPath : std::wstring{};
             appLoopbackTracks_.destroy(t.id);
+            if (!dumpPath.empty()) wa::dump_ui::revealDumpFile(dumpPath);
             logLines_.push_back("application loopback track destroyed id="
                                 + std::to_string(t.id));
         }
@@ -757,9 +802,13 @@ void AppUi::drawLeftPanel() {
         }
     } else {
         if (ImGui::Button("Stop", ctrlBtn)) {
+            const std::wstring capDump = ms_.capDumping ? ms_.capDumpPath : std::wstring{};
+            const std::wstring renDump = ms_.renderDumping ? ms_.renderDumpPath : std::wstring{};
             monitor_.stop();
             monitorStarted_ = false;
             resetVisuals(monitorViz_);
+            if (!capDump.empty()) wa::dump_ui::revealDumpFile(capDump);
+            if (!renDump.empty()) wa::dump_ui::revealDumpFile(renDump);
             logLines_.push_back("monitor stopped");
         }
     }
@@ -769,8 +818,68 @@ void AppUi::drawLeftPanel() {
 
     // Playback checkbox — always toggleable; applies live while running, else takes effect on next Start.
     if (ImGui::Checkbox("同步播放 (playback)", &playbackEnabled_)) {
+        if (monitorStarted_ && !playbackEnabled_ && ms_.renderDumping) {
+            const std::wstring path = ms_.renderDumpPath;
+            wa::Result r = monitor_.stopDumpRender();
+            logLines_.push_back(r ? ("dump stopped " + wtou(path))
+                                  : ("dump stop error: " + r.message));
+            if (r) wa::dump_ui::revealDumpFile(path);
+        }
         if (monitorStarted_) monitor_.setPlaybackEnabled(playbackEnabled_);
     }
+
+    ImGui::BeginDisabled(!monitorStarted_ || ms_.capState != wa::StreamState::Running);
+    ImGui::PushID("capDump");
+    if (ms_.capDumping) {
+        if (ImGui::Button(wa::ui_text::kDumpStop)) {
+            const std::wstring path = ms_.capDumpPath;
+            wa::Result r = monitor_.stopDumpCapture();
+            logLines_.push_back(r ? ("dump stopped " + wtou(path))
+                                  : ("dump stop error: " + r.message));
+            if (r) wa::dump_ui::revealDumpFile(path);
+        }
+        if (!ms_.capDumpFileName.empty()) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("%s", wtou(ms_.capDumpFileName).c_str());
+        }
+    } else if (ImGui::Button(wa::ui_text::kDumpCapture)) {
+        std::wstring folder = wa::dump_ui::loadDumpFolder();
+        if (wa::dump_ui::pickDumpFolder(folder)) {
+            wa::dump_ui::saveDumpFolder(folder);
+            wa::Result r = monitor_.startDumpCapture(folder);
+            logLines_.push_back(r ? ("dump started " + wtou(monitor_.poll().capDumpPath))
+                                  : ("dump start error: " + r.message));
+        }
+    }
+    ImGui::PopID();
+    ImGui::EndDisabled();
+
+    ImGui::BeginDisabled(!monitorStarted_ || !playbackEnabled_
+                         || ms_.renderState != wa::StreamState::Running);
+    ImGui::PushID("renDump");
+    if (ms_.renderDumping) {
+        if (ImGui::Button(wa::ui_text::kDumpStop)) {
+            const std::wstring path = ms_.renderDumpPath;
+            wa::Result r = monitor_.stopDumpRender();
+            logLines_.push_back(r ? ("dump stopped " + wtou(path))
+                                  : ("dump stop error: " + r.message));
+            if (r) wa::dump_ui::revealDumpFile(path);
+        }
+        if (!ms_.renderDumpFileName.empty()) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("%s", wtou(ms_.renderDumpFileName).c_str());
+        }
+    } else if (ImGui::Button(wa::ui_text::kDumpRender)) {
+        std::wstring folder = wa::dump_ui::loadDumpFolder();
+        if (wa::dump_ui::pickDumpFolder(folder)) {
+            wa::dump_ui::saveDumpFolder(folder);
+            wa::Result r = monitor_.startDumpRender(folder);
+            logLines_.push_back(r ? ("dump started " + wtou(monitor_.poll().renderDumpPath))
+                                  : ("dump start error: " + r.message));
+        }
+    }
+    ImGui::PopID();
+    ImGui::EndDisabled();
 
     // --- Status ---
     ImGui::SeparatorText("Status");

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -374,6 +374,8 @@ void AppUi::draw() {
         logLines_.erase(logLines_.begin(),
                         logLines_.begin() + (logLines_.size() - kMaxLogLines));
 
+    applyDumpPick();
+
     // Poll once; detect renderState Running->non-Running to clear stale playback chart data.
     ms_ = monitor_.poll();
     const int curRenderState = (int)ms_.renderState;
@@ -530,7 +532,55 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::EndChild();
 }
 
-void AppUi::drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t) {
+void AppUi::beginDumpPick(DumpPickKind kind, wa::TrackId trackId) {
+    if (dumpPicker_.busy()) return;
+    dumpPickKind_ = kind;
+    dumpPickTrackId_ = trackId;
+    if (!dumpPicker_.start(wa::dump_ui::loadDumpFolder())) {
+        dumpPickKind_ = DumpPickKind::None;
+        dumpPickTrackId_ = 0;
+    }
+}
+
+void AppUi::applyDumpPick() {
+    std::wstring folder;
+    bool accepted = false;
+    if (!dumpPicker_.take(folder, accepted)) return;
+    const DumpPickKind kind = dumpPickKind_;
+    const wa::TrackId tid = dumpPickTrackId_;
+    dumpPickKind_ = DumpPickKind::None;
+    dumpPickTrackId_ = 0;
+    if (!accepted || kind == DumpPickKind::None) return;
+    wa::dump_ui::saveDumpFolder(folder);
+
+    auto logStart = [&](wa::Result r, const std::wstring& path) {
+        logLines_.push_back(r ? ("dump started " + wtou(path))
+                              : ("dump start error: " + r.message));
+    };
+    if (kind == DumpPickKind::Loopback || kind == DumpPickKind::AppLoopback) {
+        wa::CaptureTrackList& list =
+            (kind == DumpPickKind::Loopback) ? loopbackTracks_ : appLoopbackTracks_;
+        wa::Result r = list.startDump(tid, folder);
+        std::wstring path;
+        for (const auto& s : list.poll())
+            if (s.id == tid) path = s.dumpPath;
+        logStart(r, path);
+        return;
+    }
+    if (kind == DumpPickKind::MonitorCap) {
+        wa::Result r = monitor_.startDumpCapture(folder);
+        logStart(r, monitor_.poll().capDumpPath);
+        return;
+    }
+    if (kind == DumpPickKind::MonitorRen) {
+        wa::Result r = monitor_.startDumpRender(folder);
+        logStart(r, monitor_.poll().renderDumpPath);
+    }
+}
+
+void AppUi::drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t,
+                             DumpPickKind kind, const char* destroyedLog) {
+    const bool picking = dumpPicker_.busy();
     if (t.dumping) {
         if (ImGui::Button(wa::ui_text::kDumpStop)) {
             const std::wstring path = t.dumpPath;
@@ -539,28 +589,22 @@ void AppUi::drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackS
                                   : ("dump stop error: " + r.message));
             if (r) wa::dump_ui::revealDumpFile(path);
         }
-        if (!t.dumpFileName.empty()) {
-            ImGui::SameLine();
-            ImGui::TextDisabled("%s", wtou(t.dumpFileName).c_str());
-        }
     } else {
-        ImGui::BeginDisabled(t.state != wa::StreamState::Running);
-        if (ImGui::Button(wa::ui_text::kDump)) {
-            std::wstring folder = wa::dump_ui::loadDumpFolder();
-            if (wa::dump_ui::pickDumpFolder(folder)) {
-                wa::dump_ui::saveDumpFolder(folder);
-                wa::Result r = list.startDump(t.id, folder);
-                if (r) {
-                    std::wstring path;
-                    for (const auto& s : list.poll())
-                        if (s.id == t.id) path = s.dumpPath;
-                    logLines_.push_back("dump started " + wtou(path));
-                } else {
-                    logLines_.push_back("dump start error: " + r.message);
-                }
-            }
-        }
+        ImGui::BeginDisabled(t.state != wa::StreamState::Running || picking);
+        if (ImGui::Button(wa::ui_text::kDump))
+            beginDumpPick(kind, t.id);
         ImGui::EndDisabled();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
+        const std::wstring dumpPath = t.dumping ? t.dumpPath : std::wstring{};
+        list.destroy(t.id);
+        if (!dumpPath.empty()) wa::dump_ui::revealDumpFile(dumpPath);
+        logLines_.push_back(std::string(destroyedLog) + std::to_string(t.id));
+    }
+    if (t.dumping && !t.dumpFileName.empty()) {
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", wtou(t.dumpFileName).c_str());
     }
 }
 
@@ -629,13 +673,8 @@ void AppUi::drawLoopbackLeftPanel() {
                     (unsigned long long)t.id, ss[(int)t.state],
                     t.actualFormat.sampleRate, (unsigned long long)t.overruns);
         ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
-        drawDumpControls(loopbackTracks_, t);
-        if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
-            const std::wstring dumpPath = t.dumping ? t.dumpPath : std::wstring{};
-            loopbackTracks_.destroy(t.id);
-            if (!dumpPath.empty()) wa::dump_ui::revealDumpFile(dumpPath);
-            logLines_.push_back("loopback track destroyed id=" + std::to_string(t.id));
-        }
+        drawDumpControls(loopbackTracks_, t, DumpPickKind::Loopback,
+                         "loopback track destroyed id=");
         ImGui::PopID();
     }
 }
@@ -728,14 +767,8 @@ void AppUi::drawApplicationLoopbackLeftPanel() {
                     wa::processLoopbackModeName(t.source.processLoopbackMode),
                     t.actualFormat.sampleRate, (unsigned long long)t.overruns);
         ImGui::ProgressBar((t.levelL > t.levelR) ? t.levelL : t.levelR, ImVec2(-1, 0), "level");
-        drawDumpControls(appLoopbackTracks_, t);
-        if (ImGui::Button(wa::ui_text::kLoopbackDestroy)) {
-            const std::wstring dumpPath = t.dumping ? t.dumpPath : std::wstring{};
-            appLoopbackTracks_.destroy(t.id);
-            if (!dumpPath.empty()) wa::dump_ui::revealDumpFile(dumpPath);
-            logLines_.push_back("application loopback track destroyed id="
-                                + std::to_string(t.id));
-        }
+        drawDumpControls(appLoopbackTracks_, t, DumpPickKind::AppLoopback,
+                         "application loopback track destroyed id=");
         ImGui::PopID();
     }
 }
@@ -828,6 +861,7 @@ void AppUi::drawLeftPanel() {
         if (monitorStarted_) monitor_.setPlaybackEnabled(playbackEnabled_);
     }
 
+    const bool dumpPicking = dumpPicker_.busy();
     ImGui::BeginDisabled(!monitorStarted_ || ms_.capState != wa::StreamState::Running);
     ImGui::PushID("capDump");
     if (ms_.capDumping) {
@@ -842,14 +876,11 @@ void AppUi::drawLeftPanel() {
             ImGui::SameLine();
             ImGui::TextDisabled("%s", wtou(ms_.capDumpFileName).c_str());
         }
-    } else if (ImGui::Button(wa::ui_text::kDumpCapture)) {
-        std::wstring folder = wa::dump_ui::loadDumpFolder();
-        if (wa::dump_ui::pickDumpFolder(folder)) {
-            wa::dump_ui::saveDumpFolder(folder);
-            wa::Result r = monitor_.startDumpCapture(folder);
-            logLines_.push_back(r ? ("dump started " + wtou(monitor_.poll().capDumpPath))
-                                  : ("dump start error: " + r.message));
-        }
+    } else {
+        ImGui::BeginDisabled(dumpPicking);
+        if (ImGui::Button(wa::ui_text::kDumpCapture))
+            beginDumpPick(DumpPickKind::MonitorCap);
+        ImGui::EndDisabled();
     }
     ImGui::PopID();
     ImGui::EndDisabled();
@@ -869,14 +900,11 @@ void AppUi::drawLeftPanel() {
             ImGui::SameLine();
             ImGui::TextDisabled("%s", wtou(ms_.renderDumpFileName).c_str());
         }
-    } else if (ImGui::Button(wa::ui_text::kDumpRender)) {
-        std::wstring folder = wa::dump_ui::loadDumpFolder();
-        if (wa::dump_ui::pickDumpFolder(folder)) {
-            wa::dump_ui::saveDumpFolder(folder);
-            wa::Result r = monitor_.startDumpRender(folder);
-            logLines_.push_back(r ? ("dump started " + wtou(monitor_.poll().renderDumpPath))
-                                  : ("dump start error: " + r.message));
-        }
+    } else {
+        ImGui::BeginDisabled(dumpPicking);
+        if (ImGui::Button(wa::ui_text::kDumpRender))
+            beginDumpPick(DumpPickKind::MonitorRen);
+        ImGui::EndDisabled();
     }
     ImGui::PopID();
     ImGui::EndDisabled();

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -8,6 +8,7 @@
 #include "CaptureTrackList.h"
 #include "ChartHost.h"
 #include "DeviceEnumerator.h"
+#include "DumpUi.h"
 #include "MonitorEngine.h"
 #include "Spectrogram.h"
 #include "TrackScopeReader.h"
@@ -51,7 +52,11 @@ private:
     void drawApplicationLoopbackPage();
     void drawLoopbackLeftPanel();
     void drawApplicationLoopbackLeftPanel();
-    void drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t);
+    enum class DumpPickKind { None, Loopback, AppLoopback, MonitorCap, MonitorRen };
+    void drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t,
+                          DumpPickKind kind, const char* destroyedLog);
+    void beginDumpPick(DumpPickKind kind, wa::TrackId trackId = 0);
+    void applyDumpPick();
     void drawStackedCaptureTrackHosts(wa::CaptureTrackList& list,
                                       std::vector<std::pair<wa::TrackId, VisualState>>& viz,
                                       const char* emptyHint);
@@ -124,6 +129,10 @@ private:
     int                    fmtBackendShown_ = -1;
     int                    capDevShown_     = -1;
     wa::DeviceCapabilities capsCache_{};
+
+    wa::dump_ui::FolderPicker dumpPicker_;
+    DumpPickKind              dumpPickKind_ = DumpPickKind::None;
+    wa::TrackId               dumpPickTrackId_ = 0;
 
     VisualState monitorViz_;
     std::vector<std::pair<wa::TrackId, VisualState>> loopbackViz_;

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -51,6 +51,7 @@ private:
     void drawApplicationLoopbackPage();
     void drawLoopbackLeftPanel();
     void drawApplicationLoopbackLeftPanel();
+    void drawDumpControls(wa::CaptureTrackList& list, const wa::CaptureTrackStatus& t);
     void drawStackedCaptureTrackHosts(wa::CaptureTrackList& list,
                                       std::vector<std::pair<wa::TrackId, VisualState>>& viz,
                                       const char* emptyHint);
@@ -104,14 +105,12 @@ private:
     int                         delayMs_      = 100;
     bool                        monitorStarted_ = false;
     bool                        loopbackSilentRender_ = true;
-    char                        loopbackWav_[260] = "";
     char                        loopbackFmt_[32] = "";
     bool                        appLoopbackExclude_ = false; // create recipe; false = IncludeTree
     bool                        appLoopbackSessionsLoaded_ = false;
     std::vector<wa::AudioSessionProcess> appLoopbackSessions_;
     int                         appLoopbackSessionIdx_ = -1;
     char                        appLoopbackPid_[32] = "";
-    char                        appLoopbackWav_[260] = "";
     char                        appLoopbackFmt_[32] = "";
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -41,8 +41,11 @@ inline constexpr const char* kLoopbackDestroy = "Destroy";
 inline constexpr const char* kLoopbackDestroyAll = "Destroy all";
 inline constexpr const char* kLoopbackTracks = "Tracks";
 inline constexpr const char* kLoopbackSilentRender = "Silent render keepalive";
-inline constexpr const char* kLoopbackWavOptional = "WAV (optional)";
 inline constexpr const char* kLoopbackFormatOptional = "Format (optional)";
+inline constexpr const char* kDump = "Dump";
+inline constexpr const char* kDumpStop = "Stop dump";
+inline constexpr const char* kDumpCapture = "Dump capture";
+inline constexpr const char* kDumpRender = "Dump render";
 inline constexpr const char* kLoopbackEmptyHint = "Create a Track to capture system audio.";
 inline constexpr const char* kApplicationLoopbackEmptyHint =
     "Create a Track to capture application audio.";

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,11 +1,12 @@
 add_executable(WinAudioGui
     AppUi.cpp
     ChartDataPipeline.cpp
+    DumpUi.cpp
     main.cpp
     Spectrogram.cpp
 )
 target_include_directories(WinAudioGui PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(WinAudioGui PRIVATE WinAudioCore implot d3d11 dxgi d3dcompiler)
+target_link_libraries(WinAudioGui PRIVATE WinAudioCore implot d3d11 dxgi d3dcompiler shell32)
 target_compile_definitions(WinAudioGui PRIVATE NOMINMAX _CRT_SECURE_NO_WARNINGS)
 # Windows-subsystem exe, but the code has main() (not WinMain): keep the CRT main entry.
 set_target_properties(WinAudioGui PROPERTIES WIN32_EXECUTABLE TRUE)

--- a/src/gui/DumpUi.cpp
+++ b/src/gui/DumpUi.cpp
@@ -96,7 +96,8 @@ bool pickDumpFolder(std::wstring& folder) {
                 item->Release();
             }
         }
-        hr = dlg->Show(GetActiveWindow());
+        // No owner: do not disable the GUI window (caller may be a worker thread).
+        hr = dlg->Show(nullptr);
         if (SUCCEEDED(hr)) {
             IShellItem* result = nullptr;
             if (SUCCEEDED(dlg->GetResult(&result)) && result) {
@@ -115,6 +116,47 @@ bool pickDumpFolder(std::wstring& folder) {
     }
     if (uninit) CoUninitialize();
     return ok;
+}
+
+FolderPicker::~FolderPicker() {
+    if (thread_.joinable()) thread_.join();
+}
+
+bool FolderPicker::start(const std::wstring& initialFolder) {
+    if (busy_.load(std::memory_order_acquire)) return false;
+    if (thread_.joinable()) thread_.join();
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        accepted_ = false;
+        folder_.clear();
+    }
+    done_.store(false, std::memory_order_release);
+    busy_.store(true, std::memory_order_release);
+    thread_ = std::thread(&FolderPicker::worker, this, initialFolder);
+    return true;
+}
+
+bool FolderPicker::take(std::wstring& folder, bool& accepted) {
+    if (!done_.load(std::memory_order_acquire)) return false;
+    if (thread_.joinable()) thread_.join();
+    std::lock_guard<std::mutex> lk(mtx_);
+    folder = folder_;
+    accepted = accepted_;
+    done_.store(false, std::memory_order_release);
+    return true;
+}
+
+void FolderPicker::worker(std::wstring initial) {
+    wa::log::setThreadName("dump-ui");
+    std::wstring folder = initial;
+    const bool ok = pickDumpFolder(folder);
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        accepted_ = ok;
+        folder_ = ok ? folder : std::wstring{};
+    }
+    done_.store(true, std::memory_order_release);
+    busy_.store(false, std::memory_order_release);
 }
 
 void revealDumpFile(const std::wstring& path) {

--- a/src/gui/DumpUi.cpp
+++ b/src/gui/DumpUi.cpp
@@ -1,0 +1,129 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include "DumpUi.h"
+#include "Log.h"
+#include <windows.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+#include <shellapi.h>
+
+namespace wa::dump_ui {
+
+namespace {
+constexpr wchar_t kRegKey[]   = L"Software\\WinAudio";
+constexpr wchar_t kRegValue[] = L"DumpFolder";
+
+bool isExistingDirectory(const std::wstring& path) {
+    if (path.empty()) return false;
+    const DWORD a = GetFileAttributesW(path.c_str());
+    return a != INVALID_FILE_ATTRIBUTES && (a & FILE_ATTRIBUTE_DIRECTORY);
+}
+} // namespace
+
+std::wstring downloadsFolder() {
+    PWSTR p = nullptr;
+    std::wstring out;
+    if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Downloads, 0, nullptr, &p)) && p) {
+        out = p;
+        CoTaskMemFree(p);
+    }
+    if (out.empty()) {
+        wchar_t profile[MAX_PATH]{};
+        if (GetEnvironmentVariableW(L"USERPROFILE", profile, MAX_PATH)) {
+            out = std::wstring(profile) + L"\\Downloads";
+        }
+    }
+    return out;
+}
+
+std::wstring storedDumpFolder() {
+    HKEY key = nullptr;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, kRegKey, 0, KEY_QUERY_VALUE, &key) != ERROR_SUCCESS)
+        return {};
+    wchar_t buf[MAX_PATH]{};
+    DWORD bytes = sizeof(buf);
+    DWORD type = 0;
+    const LONG er = RegQueryValueExW(key, kRegValue, nullptr, &type,
+                                     reinterpret_cast<LPBYTE>(buf), &bytes);
+    RegCloseKey(key);
+    if (er != ERROR_SUCCESS || type != REG_SZ || bytes < sizeof(wchar_t)) return {};
+    const size_t chars = bytes / sizeof(wchar_t);
+    if (chars > 0 && buf[chars - 1] == L'\0')
+        return std::wstring(buf, chars - 1);
+    return std::wstring(buf, chars);
+}
+
+std::wstring loadDumpFolder() {
+    const std::wstring stored = storedDumpFolder();
+    if (isExistingDirectory(stored)) return stored;
+    return downloadsFolder();
+}
+
+void saveDumpFolder(const std::wstring& folder) {
+    HKEY key = nullptr;
+    if (RegCreateKeyExW(HKEY_CURRENT_USER, kRegKey, 0, nullptr, 0, KEY_SET_VALUE,
+                        nullptr, &key, nullptr) != ERROR_SUCCESS) {
+        WA_LOG(wa::log::Level::Warn, "DumpUi", "saveDumpFolder", "", "RegCreateKeyEx failed");
+        return;
+    }
+    const DWORD bytes = static_cast<DWORD>((folder.size() + 1) * sizeof(wchar_t));
+    const LONG er = RegSetValueExW(key, kRegValue, 0, REG_SZ,
+                                   reinterpret_cast<const BYTE*>(folder.c_str()), bytes);
+    RegCloseKey(key);
+    if (er != ERROR_SUCCESS)
+        WA_LOG(wa::log::Level::Warn, "DumpUi", "saveDumpFolder", "", "RegSetValueEx failed");
+}
+
+bool pickDumpFolder(std::wstring& folder) {
+    HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool uninit = (hrInit == S_OK || hrInit == S_FALSE);
+
+    IFileOpenDialog* dlg = nullptr;
+    HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_PPV_ARGS(&dlg));
+    bool ok = false;
+    if (SUCCEEDED(hr) && dlg) {
+        DWORD opts = 0;
+        dlg->GetOptions(&opts);
+        dlg->SetOptions(opts | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+        const std::wstring start = folder.empty() ? loadDumpFolder() : folder;
+        if (!start.empty()) {
+            IShellItem* item = nullptr;
+            if (SUCCEEDED(SHCreateItemFromParsingName(start.c_str(), nullptr,
+                                                      IID_PPV_ARGS(&item))) && item) {
+                dlg->SetFolder(item);
+                item->Release();
+            }
+        }
+        hr = dlg->Show(GetActiveWindow());
+        if (SUCCEEDED(hr)) {
+            IShellItem* result = nullptr;
+            if (SUCCEEDED(dlg->GetResult(&result)) && result) {
+                PWSTR path = nullptr;
+                if (SUCCEEDED(result->GetDisplayName(SIGDN_FILESYSPATH, &path)) && path) {
+                    folder = path;
+                    ok = !folder.empty();
+                    CoTaskMemFree(path);
+                }
+                result->Release();
+            }
+        }
+        dlg->Release();
+    } else {
+        WA_LOG(wa::log::Level::Err, "DumpUi", "pickDumpFolder", "", "CoCreateInstance failed");
+    }
+    if (uninit) CoUninitialize();
+    return ok;
+}
+
+void revealDumpFile(const std::wstring& path) {
+    if (path.empty()) return;
+    const std::wstring args = L"/select,\"" + path + L"\"";
+    const INT_PTR r = reinterpret_cast<INT_PTR>(
+        ShellExecuteW(nullptr, L"open", L"explorer.exe", args.c_str(), nullptr, SW_SHOWNORMAL));
+    if (r <= 32)
+        WA_LOG(wa::log::Level::Warn, "DumpUi", "revealDumpFile", "", "ShellExecute failed");
+}
+
+} // namespace wa::dump_ui

--- a/src/gui/DumpUi.h
+++ b/src/gui/DumpUi.h
@@ -1,5 +1,8 @@
 #pragma once
+#include <atomic>
+#include <mutex>
 #include <string>
+#include <thread>
 
 namespace wa::dump_ui {
 
@@ -7,7 +10,32 @@ std::wstring downloadsFolder();
 std::wstring storedDumpFolder();          // raw HKCU value; empty if missing
 std::wstring loadDumpFolder();            // existing dir, else Downloads
 void         saveDumpFolder(const std::wstring& folder);
-bool         pickDumpFolder(std::wstring& folder); // false = cancel
+bool         pickDumpFolder(std::wstring& folder); // blocking; false = cancel
 void         revealDumpFile(const std::wstring& path);
+
+// Native folder dialog on a dedicated STA thread so the GUI frame loop
+// (and capture pumps) keep running. Show() is not given an owner HWND,
+// so the main window is not disabled.
+class FolderPicker {
+public:
+    FolderPicker() = default;
+    ~FolderPicker();
+    FolderPicker(const FolderPicker&)            = delete;
+    FolderPicker& operator=(const FolderPicker&) = delete;
+
+    bool start(const std::wstring& initialFolder); // false if already busy
+    bool busy() const { return busy_.load(std::memory_order_acquire); }
+    bool take(std::wstring& folder, bool& accepted); // true if a pick finished
+
+private:
+    void worker(std::wstring initial);
+
+    std::mutex          mtx_;
+    std::thread         thread_;
+    std::atomic<bool>   busy_{false};
+    std::atomic<bool>   done_{false};
+    bool                accepted_ = false;
+    std::wstring        folder_;
+};
 
 } // namespace wa::dump_ui

--- a/src/gui/DumpUi.h
+++ b/src/gui/DumpUi.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+namespace wa::dump_ui {
+
+std::wstring downloadsFolder();
+std::wstring storedDumpFolder();          // raw HKCU value; empty if missing
+std::wstring loadDumpFolder();            // existing dir, else Downloads
+void         saveDumpFolder(const std::wstring& folder);
+bool         pickDumpFolder(std::wstring& folder); // false = cancel
+void         revealDumpFile(const std::wstring& path);
+
+} // namespace wa::dump_ui

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(WinAudioTests
     test_ringbuffer.cpp
     test_sampleconvert.cpp
     test_wavfile.cpp
+    test_wav_sink.cpp
     test_formatspec.cpp
     test_scopebuffer.cpp
     test_scope_reader.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -26,15 +26,17 @@ add_executable(WinAudioTests
     test_loopback.cpp
     test_audio_session_enumerator.cpp
     test_cli_options.cpp
+    test_dump_ui.cpp
     ${CMAKE_SOURCE_DIR}/src/gui/Spectrogram.cpp   # compiled into tests, as in the current setup
     ${CMAKE_SOURCE_DIR}/src/gui/ChartDataPipeline.cpp
+    ${CMAKE_SOURCE_DIR}/src/gui/DumpUi.cpp
 )
 target_include_directories(WinAudioTests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src/cli
     ${CMAKE_SOURCE_DIR}/src/gui                   # for Spectrogram.h
 )
-target_link_libraries(WinAudioTests PRIVATE WinAudioCore gtest_main)
+target_link_libraries(WinAudioTests PRIVATE WinAudioCore gtest_main shell32)
 wa_set_project_warnings(WinAudioTests)
 
 include(GoogleTest)

--- a/src/tests/test_audio_session_enumerator.cpp
+++ b/src/tests/test_audio_session_enumerator.cpp
@@ -101,8 +101,11 @@ TEST(ChartsTimeZoomUiText, ExposesZoomAndResetLabels) {
     EXPECT_STREQ(wa::ui_text::kLoopbackDestroyAll, "Destroy all");
     EXPECT_STREQ(wa::ui_text::kLoopbackTracks, "Tracks");
     EXPECT_STREQ(wa::ui_text::kLoopbackSilentRender, "Silent render keepalive");
-    EXPECT_STREQ(wa::ui_text::kLoopbackWavOptional, "WAV (optional)");
     EXPECT_STREQ(wa::ui_text::kLoopbackFormatOptional, "Format (optional)");
+    EXPECT_STREQ(wa::ui_text::kDump, "Dump");
+    EXPECT_STREQ(wa::ui_text::kDumpStop, "Stop dump");
+    EXPECT_STREQ(wa::ui_text::kDumpCapture, "Dump capture");
+    EXPECT_STREQ(wa::ui_text::kDumpRender, "Dump render");
     EXPECT_STREQ(wa::ui_text::kLoopbackEmptyHint, "Create a Track to capture system audio.");
 }
 

--- a/src/tests/test_capture_track_list.cpp
+++ b/src/tests/test_capture_track_list.cpp
@@ -12,6 +12,7 @@
 #include "CaptureTrackList.h"
 #include "RingBuffer.h"
 #include "TrackScopeReader.h"
+#include "WavFile.h"
 
 using namespace wa;
 
@@ -308,6 +309,121 @@ TEST(CaptureTrackList, TapsAreIndependent) {
     EXPECT_EQ(list.written(a), 0u);
     EXPECT_GE(list.written(b), 4u);
     list.destroyAll();
+}
+
+TEST(CaptureTrackList, CreateTimeWavWritesPushedPcm) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.wavPath = tempWav(L"pcm");
+    TrackId id = 0;
+    ASSERT_TRUE(list.create(spec, &id));
+    ASSERT_EQ(rig.caps.size(), 1u);
+    const int16_t pcm[8] = {1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000};
+    rig.caps[0]->pushPcm(pcm, sizeof(pcm));
+    ASSERT_TRUE(waitFor([&] { return list.written(id) >= 4; }));
+    list.destroy(id);
+
+    wa::WavReader r;
+    ASSERT_TRUE(r.open(spec.wavPath));
+    std::vector<int16_t> back(8, 0);
+    EXPECT_EQ(r.read(back.data(), sizeof(pcm)), sizeof(pcm));
+    EXPECT_EQ(std::vector<int16_t>(pcm, pcm + 8), back);
+    r.close();
+    DeleteFileW(spec.wavPath.c_str());
+}
+
+TEST(CaptureTrackList, LiveDumpWritesPushedPcm) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    ASSERT_TRUE(list.create({}, &id));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(list.startDump(id, dir));
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_TRUE(st[0].dumping);
+    EXPECT_FALSE(st[0].dumpFileName.empty());
+
+    const int16_t pcm[8] = {11, 22, 33, 44, 55, 66, 77, 88};
+    rig.caps[0]->pushPcm(pcm, sizeof(pcm));
+    ASSERT_TRUE(waitFor([&] { return list.written(id) >= 4; }));
+    ASSERT_TRUE(list.stopDump(id));
+    st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_FALSE(st[0].dumping);
+    EXPECT_EQ(st[0].state, StreamState::Running);
+
+    wa::WavReader r;
+    ASSERT_TRUE(r.open(st[0].dumpPath));
+    std::vector<int16_t> back(8, 0);
+    EXPECT_EQ(r.read(back.data(), sizeof(pcm)), sizeof(pcm));
+    EXPECT_EQ(std::vector<int16_t>(pcm, pcm + 8), back);
+    r.close();
+    DeleteFileW(st[0].dumpPath.c_str());
+    list.destroy(id);
+}
+
+TEST(CaptureTrackList, LiveDumpRejectedWhenAlreadyDumping) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    ASSERT_TRUE(list.create({}, &id));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(list.startDump(id, dir));
+    EXPECT_FALSE(list.startDump(id, dir));
+    list.stopDump(id);
+    DeleteFileW(list.poll()[0].dumpPath.c_str());
+    list.destroy(id);
+}
+
+TEST(CaptureTrackList, LiveDumpRejectedWhenTrackNotRunning) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.wavPath = L"?:\\wa_ctl_not_a_path.wav";
+    TrackId id = 0;
+    ASSERT_TRUE(list.create(spec, &id));
+    ASSERT_EQ(list.poll()[0].state, StreamState::Error);
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    EXPECT_FALSE(list.startDump(id, dir));
+    list.destroy(id);
+}
+
+TEST(CaptureTrackList, LiveDumpOpenFailureLeavesTrackRunning) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    ASSERT_TRUE(list.create({}, &id));
+    EXPECT_FALSE(list.startDump(id, L"?:\\not-a-folder"));
+    auto st = list.poll();
+    ASSERT_EQ(st.size(), 1u);
+    EXPECT_EQ(st[0].state, StreamState::Running);
+    EXPECT_FALSE(st[0].dumping);
+    list.destroy(id);
+}
+
+TEST(CaptureTrackList, DestroyWhileDumpingFinalizesWav) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    TrackId id = 0;
+    ASSERT_TRUE(list.create({}, &id));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(list.startDump(id, dir));
+    const int16_t pcm[4] = {1, 2, 3, 4};
+    rig.caps[0]->pushPcm(pcm, sizeof(pcm));
+    ASSERT_TRUE(waitFor([&] { return list.written(id) >= 2; }));
+    const std::wstring path = list.poll()[0].dumpPath;
+    list.destroy(id);
+    EXPECT_TRUE(list.poll().empty());
+    wa::WavReader r;
+    ASSERT_TRUE(r.open(path));
+    r.close();
+    DeleteFileW(path.c_str());
 }
 
 TEST(CaptureTrackList, OptionalWavStillRuns) {

--- a/src/tests/test_capture_track_list.cpp
+++ b/src/tests/test_capture_track_list.cpp
@@ -365,6 +365,27 @@ TEST(CaptureTrackList, LiveDumpWritesPushedPcm) {
     list.destroy(id);
 }
 
+TEST(CaptureTrackList, AppLoopbackDumpNameIncludesPidAndProcessName) {
+    ListRig rig;
+    CaptureTrackList list(rig.factory());
+    CaptureTrackCreate spec{};
+    spec.source.kind = CaptureSourceKind::ApplicationLoopback;
+    spec.source.processId = 4242;
+    TrackId id = 0;
+    ASSERT_TRUE(list.create(spec, &id));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(list.startDump(id, dir));
+    const std::wstring name = list.poll()[0].dumpFileName;
+    list.stopDump(id);
+    DeleteFileW(list.poll()[0].dumpPath.c_str());
+    list.destroy(id);
+
+    // Name lookup may fail in CI (no such PID) and fall back to "unknown".
+    EXPECT_EQ(name.find(L"app-loopback_"), 0u);
+    EXPECT_NE(name.find(L"4242"), std::wstring::npos);
+}
+
 TEST(CaptureTrackList, LiveDumpRejectedWhenAlreadyDumping) {
     ListRig rig;
     CaptureTrackList list(rig.factory());

--- a/src/tests/test_dump_ui.cpp
+++ b/src/tests/test_dump_ui.cpp
@@ -5,6 +5,14 @@
 #include <windows.h>
 #include "DumpUi.h"
 
+TEST(DumpUi, FolderPickerTakeEmptyWhenIdle) {
+    wa::dump_ui::FolderPicker p;
+    EXPECT_FALSE(p.busy());
+    std::wstring folder;
+    bool accepted = true;
+    EXPECT_FALSE(p.take(folder, accepted));
+}
+
 TEST(DumpUi, DownloadsFolderIsNonEmpty) {
     EXPECT_FALSE(wa::dump_ui::downloadsFolder().empty());
 }

--- a/src/tests/test_dump_ui.cpp
+++ b/src/tests/test_dump_ui.cpp
@@ -1,0 +1,35 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <gtest/gtest.h>
+#include <windows.h>
+#include "DumpUi.h"
+
+TEST(DumpUi, DownloadsFolderIsNonEmpty) {
+    EXPECT_FALSE(wa::dump_ui::downloadsFolder().empty());
+}
+
+TEST(DumpUi, RegistryRoundTripDoesNotRewriteBadPath) {
+    const std::wstring prev = wa::dump_ui::storedDumpFolder();
+    const std::wstring good = L"C:\\Windows";
+    wa::dump_ui::saveDumpFolder(good);
+    EXPECT_EQ(wa::dump_ui::storedDumpFolder(), good);
+    EXPECT_EQ(wa::dump_ui::loadDumpFolder(), good);
+
+    const std::wstring missing = L"Z:\\wa_dump_folder_does_not_exist";
+    wa::dump_ui::saveDumpFolder(missing);
+    EXPECT_EQ(wa::dump_ui::storedDumpFolder(), missing);
+    EXPECT_EQ(wa::dump_ui::loadDumpFolder(), wa::dump_ui::downloadsFolder());
+    EXPECT_EQ(wa::dump_ui::storedDumpFolder(), missing);
+
+    if (prev.empty()) {
+        HKEY key = nullptr;
+        if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\WinAudio", 0, KEY_SET_VALUE, &key)
+            == ERROR_SUCCESS) {
+            RegDeleteValueW(key, L"DumpFolder");
+            RegCloseKey(key);
+        }
+    } else {
+        wa::dump_ui::saveDumpFolder(prev);
+    }
+}

--- a/src/tests/test_monitorengine.cpp
+++ b/src/tests/test_monitorengine.cpp
@@ -17,6 +17,7 @@
 #include "MonitorEngine.h"
 #include "MonitorScopeReader.h"
 #include "RingBuffer.h"
+#include "WavFile.h"
 
 using namespace wa;
 
@@ -979,4 +980,120 @@ TEST(MonitorEngine, RuntimeRenderErrorDoesNotStopCaptureOrFifo) {
     eng.stop();
     EXPECT_TRUE(rig.capStopped.load());
     EXPECT_TRUE(rig.renderStopped.load());
+}
+
+TEST(MonitorEngine, CaptureDumpWritesPcmBeforeDelay) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 50, false)));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(eng.startDumpCapture(dir));
+    EXPECT_TRUE(eng.poll().capDumping);
+
+    std::vector<int16_t> ramp{1, 2, 3, 4, 5, 6, 7, 8};
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    ASSERT_NE(rig.capPtr, nullptr);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.capWritten() >= ramp.size(); }));
+    ASSERT_TRUE(eng.stopDumpCapture());
+    const std::wstring path = eng.poll().capDumpPath;
+    EXPECT_FALSE(eng.poll().capDumping);
+
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    EXPECT_EQ(r.format().sampleRate, 48000u);
+    EXPECT_EQ(r.format().channels, 2);
+    EXPECT_FALSE(r.format().isFloat);
+    std::vector<int16_t> back(ramp.size() * 2, 0);
+    EXPECT_EQ(r.read(back.data(), back.size() * 2), back.size() * 2);
+    EXPECT_EQ(back[0], 1);
+    EXPECT_EQ(back[1], 1);
+    r.close();
+    DeleteFileW(path.c_str());
+    eng.stop();
+}
+
+TEST(MonitorEngine, RenderDumpRejectedWhenPlaybackOff) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 50, false)));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    EXPECT_FALSE(eng.startDumpRender(dir));
+    EXPECT_FALSE(eng.poll().renderDumping);
+    EXPECT_EQ(eng.poll().capState, StreamState::Running);
+    eng.stop();
+}
+
+TEST(MonitorEngine, RenderDumpWritesAfterDelay) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 50, true)));
+    ASSERT_EQ(eng.poll().renderState, StreamState::Running);
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(eng.startDumpRender(dir));
+    EXPECT_TRUE(eng.poll().renderDumping);
+
+    std::vector<int16_t> ramp(5000, 9);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.renderWritten() > 0; }));
+    ASSERT_TRUE(eng.stopDumpRender());
+    const std::wstring path = eng.poll().renderDumpPath;
+
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    EXPECT_EQ(r.format().sampleRate, 48000u);
+    EXPECT_EQ(r.format().channels, 2);
+    EXPECT_FALSE(r.format().isFloat);
+    int16_t sample = 0;
+    EXPECT_GT(r.read(&sample, sizeof(sample)), 0u);
+    r.close();
+    DeleteFileW(path.c_str());
+    eng.stop();
+}
+
+TEST(MonitorEngine, SessionStopFinalizesCaptureDump) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 50, false)));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(eng.startDumpCapture(dir));
+    std::vector<int16_t> ramp(64, 3);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.capWritten() >= ramp.size(); }));
+    const std::wstring path = eng.poll().capDumpPath;
+    eng.stop();
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    r.close();
+    DeleteFileW(path.c_str());
+}
+
+TEST(MonitorEngine, PlaybackOffFinalizesRenderDump) {
+    FakeRig rig;
+    MonitorEngine eng(rig.factory());
+    ASSERT_TRUE(static_cast<bool>(eng.start(BackendKind::WasapiShared, L"", L"", 50, true)));
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    ASSERT_TRUE(eng.startDumpRender(dir));
+    std::vector<int16_t> ramp(5000, 4);
+    auto pcm = makeRampPcm(ramp, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm.data(), pcm.size());
+    ASSERT_TRUE(waitFor([&] { return eng.renderWritten() > 0; }));
+    const std::wstring path = eng.poll().renderDumpPath;
+    eng.setPlaybackEnabled(false);
+    std::vector<int16_t> more(1024, 4);
+    auto pcm2 = makeRampPcm(more, rig.capFmt.channels);
+    rig.capPtr->pushPcm(pcm2.data(), pcm2.size());
+    ASSERT_TRUE(waitFor([&] { return eng.poll().renderState == StreamState::Idle; }));
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    r.close();
+    DeleteFileW(path.c_str());
+    eng.stop();
 }

--- a/src/tests/test_wav_sink.cpp
+++ b/src/tests/test_wav_sink.cpp
@@ -120,6 +120,20 @@ TEST(WavSink, AutoNameUsesPrefixFormatAndTimestamp) {
     DeleteFileW(sink.poll().path.c_str());
 }
 
+TEST(WavSink, AutoNameKeepsCallerPrefixTokens) {
+    AudioFormat fmt{48000, 2, 16, false};
+    const int16_t sample[2] = {1, -1};
+    WavSink sink;
+    ASSERT_TRUE(sink.start(tempDir(), L"app-loopback_chrome.exe_4242", fmt))
+        << sink.poll().message;
+    const std::string nameA = narrow(sink.poll().fileName);
+    ASSERT_EQ(sink.push(sample, sizeof(sample)), sizeof(sample));
+    ASSERT_TRUE(sink.stop());
+    EXPECT_TRUE(std::regex_match(nameA, std::regex(
+        R"(app-loopback_chrome\.exe_4242_48000_2ch_16_\d{8}_\d{6}\.wav)"))) << nameA;
+    DeleteFileW(sink.poll().path.c_str());
+}
+
 TEST(WavSink, AutoNameCollisionGetsNumericSuffix) {
     AudioFormat fmt{44100, 1, 24, false};
     WavSink first;

--- a/src/tests/test_wav_sink.cpp
+++ b/src/tests/test_wav_sink.cpp
@@ -1,0 +1,191 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <gtest/gtest.h>
+#include <windows.h>
+#include <cstdint>
+#include <regex>
+#include <string>
+#include <vector>
+#include "AudioFormat.h"
+#include "WavFile.h"
+#include "WavSink.h"
+
+using wa::AudioFormat;
+using wa::WavReader;
+using wa::WavSink;
+using wa::WavSinkState;
+
+namespace {
+
+std::wstring tempDir() {
+    wchar_t dir[MAX_PATH]{};
+    GetTempPathW(MAX_PATH, dir);
+    return dir;
+}
+
+std::wstring tempWav(const wchar_t* tag) {
+    return tempDir() + L"wa_sink_" + tag + L"_" + std::to_wstring(GetTickCount64()) + L".wav";
+}
+
+std::string narrow(const std::wstring& w) {
+    std::string s;
+    s.reserve(w.size());
+    for (wchar_t c : w) s.push_back(static_cast<char>(c));
+    return s;
+}
+
+} // namespace
+
+TEST(WavSink, ExactPathRoundTrip16BitStereo) {
+    AudioFormat fmt{48000, 2, 16, false};
+    std::vector<int16_t> samples(480 * 2);
+    for (size_t i = 0; i < samples.size(); ++i)
+        samples[i] = static_cast<int16_t>(i - 100);
+    const size_t bytes = samples.size() * sizeof(int16_t);
+    const std::wstring path = tempWav(L"rt16");
+
+    WavSink sink;
+    ASSERT_TRUE(sink.startExact(path, fmt)) << sink.poll().message;
+    EXPECT_EQ(sink.poll().state, WavSinkState::Running);
+    EXPECT_EQ(sink.poll().path, path);
+    ASSERT_EQ(sink.push(samples.data(), bytes), bytes);
+    ASSERT_TRUE(sink.stop());
+    EXPECT_EQ(sink.poll().state, WavSinkState::Idle);
+
+    WavReader r;
+    const wa::Result opened = r.open(path);
+    ASSERT_TRUE(opened) << opened.message;
+    EXPECT_TRUE(r.format() == fmt);
+    std::vector<int16_t> back(samples.size());
+    EXPECT_EQ(r.read(back.data(), bytes), bytes);
+    EXPECT_EQ(samples, back);
+    r.close();
+    DeleteFileW(path.c_str());
+}
+
+TEST(WavSink, ExactPathRoundTripFloat32Stereo) {
+    AudioFormat fmt{48000, 2, 32, true};
+    std::vector<float> samples(240 * 2);
+    for (size_t i = 0; i < samples.size(); ++i)
+        samples[i] = static_cast<float>(i) * 0.001f - 0.1f;
+    const size_t bytes = samples.size() * sizeof(float);
+    const std::wstring path = tempWav(L"rt32f");
+
+    WavSink sink;
+    ASSERT_TRUE(sink.startExact(path, fmt)) << sink.poll().message;
+    ASSERT_EQ(sink.push(samples.data(), bytes), bytes);
+    ASSERT_TRUE(sink.stop());
+
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    EXPECT_TRUE(r.format() == fmt);
+    std::vector<float> back(samples.size());
+    EXPECT_EQ(r.read(back.data(), bytes), bytes);
+    EXPECT_EQ(samples, back);
+    r.close();
+    DeleteFileW(path.c_str());
+}
+
+TEST(WavSink, ExactPathKeepsCallerName) {
+    AudioFormat fmt{48000, 2, 16, false};
+    const std::wstring path = tempWav(L"keepname");
+    WavSink sink;
+    ASSERT_TRUE(sink.startExact(path, fmt));
+    EXPECT_EQ(sink.poll().path, path);
+    EXPECT_EQ(sink.poll().fileName, path.substr(path.find_last_of(L"\\/") + 1));
+    sink.stop();
+    DeleteFileW(path.c_str());
+}
+
+TEST(WavSink, InvalidPathFailsWithoutThrowing) {
+    AudioFormat fmt{48000, 2, 16, false};
+    WavSink sink;
+    EXPECT_FALSE(sink.startExact(L"?:\\wa_sink_not_a_path.wav", fmt));
+    EXPECT_EQ(sink.poll().state, WavSinkState::Error);
+}
+
+TEST(WavSink, AutoNameUsesPrefixFormatAndTimestamp) {
+    AudioFormat fmt{48000, 2, 16, false};
+    const int16_t sample[2] = {1, -1};
+    WavSink sink;
+    ASSERT_TRUE(sink.start(tempDir(), "loopback", fmt)) << sink.poll().message;
+    const std::wstring name = sink.poll().fileName;
+    ASSERT_EQ(sink.push(sample, sizeof(sample)), sizeof(sample));
+    ASSERT_TRUE(sink.stop());
+
+    const std::string nameA = narrow(name);
+    EXPECT_TRUE(std::regex_match(nameA, std::regex(
+        R"(loopback_48000_2ch_16_\d{8}_\d{6}\.wav)"))) << nameA;
+    DeleteFileW(sink.poll().path.c_str());
+}
+
+TEST(WavSink, AutoNameCollisionGetsNumericSuffix) {
+    AudioFormat fmt{44100, 1, 24, false};
+    WavSink first;
+    ASSERT_TRUE(first.start(tempDir(), "loopback", fmt)) << first.poll().message;
+    const std::wstring firstPath = first.poll().path;
+    const std::wstring firstName = first.poll().fileName;
+    ASSERT_TRUE(first.stop());
+
+    WavSink second;
+    ASSERT_TRUE(second.start(tempDir(), "loopback", fmt)) << second.poll().message;
+    const std::wstring secondName = second.poll().fileName;
+    second.stop();
+
+    EXPECT_NE(secondName, firstName);
+    const std::string a = narrow(firstName);
+    const std::string b = narrow(secondName);
+    const std::regex stem(R"(loopback_44100_1ch_24_\d{8}_\d{6}(_\d+)?\.wav)");
+    EXPECT_TRUE(std::regex_match(a, stem)) << a;
+    EXPECT_TRUE(std::regex_match(b, stem)) << b;
+    DeleteFileW(firstPath.c_str());
+    DeleteFileW(second.poll().path.c_str());
+}
+
+TEST(WavSink, OverflowFailsSinkAndPatchesHeader) {
+    AudioFormat fmt{48000, 2, 16, false};
+    const std::wstring path = tempWav(L"ovf");
+    WavSink sink;
+    ASSERT_TRUE(sink.startExact(path, fmt));
+    std::vector<uint8_t> blob(2u * 1024u * 1024u + 64u, 0x11);
+    const size_t n = sink.push(blob.data(), blob.size());
+    EXPECT_LT(n, blob.size());
+    EXPECT_FALSE(sink.stop());
+    EXPECT_EQ(sink.poll().state, WavSinkState::Error);
+
+    WavReader r;
+    ASSERT_TRUE(r.open(path));
+    EXPECT_TRUE(r.format() == fmt);
+    EXPECT_GT(r.format().sampleRate, 0u);
+    r.close();
+    DeleteFileW(path.c_str());
+}
+
+TEST(WavSink, TwoSinksDoNotMixBytes) {
+    AudioFormat fmt{48000, 2, 16, false};
+    std::vector<int16_t> a(64, 1111);
+    std::vector<int16_t> b(64, 2222);
+    const std::wstring pa = tempWav(L"mixA");
+    const std::wstring pb = tempWav(L"mixB");
+    WavSink sa, sb;
+    ASSERT_TRUE(sa.startExact(pa, fmt));
+    ASSERT_TRUE(sb.startExact(pb, fmt));
+    ASSERT_EQ(sa.push(a.data(), a.size() * 2), a.size() * 2);
+    ASSERT_EQ(sb.push(b.data(), b.size() * 2), b.size() * 2);
+    ASSERT_TRUE(sa.stop());
+    ASSERT_TRUE(sb.stop());
+
+    WavReader ra, rb;
+    ASSERT_TRUE(ra.open(pa));
+    ASSERT_TRUE(rb.open(pb));
+    std::vector<int16_t> ba(64), bb(64);
+    EXPECT_EQ(ra.read(ba.data(), ba.size() * 2), ba.size() * 2);
+    EXPECT_EQ(rb.read(bb.data(), bb.size() * 2), bb.size() * 2);
+    EXPECT_EQ(a, ba);
+    EXPECT_EQ(b, bb);
+    ra.close();
+    rb.close();
+    DeleteFileW(pa.c_str());
+    DeleteFileW(pb.c_str());
+}


### PR DESCRIPTION
## What / Why

GUI 把 WAV 落盘从「Create 时手填完整路径」改成每路独立、运行中随时 Dump / Stop dump：选保存文件夹，按固定 prefix + 实际格式 + 本地时间戳生成 `.wav`。Monitor 补上采集 / 播放两路 dump。手填路径既慢又容易写错，也无法在已经在跑的 Track 上只录一段。

Closes #52
Closes #53
Closes #54
Closes #55

## How

- 新增 **WAV sink**：独立写线程 + 约 4 秒 ring + 256 KiB 批量落盘；热路径只往 ring 里拷，ring 满则该路 dump 失败（不默默丢帧，不绑 Track）。
- GUI Start dump 用原生选文件夹对话框（不是另存为）；目录写入 `HKCU\Software\WinAudio\DumpFolder`，第一次默认 Downloads。
- Stop dump / Destroy / 停 Monitor / 关掉同步播放（若正在 dump render）成功收尾后 `explorer /select` 选中该文件。
- Monitor 采集 dump 在 DelayFifo 之前；播放 dump 在转成 render 格式之后。CLI `capture --out` 仍是创建时精确路径，内部改走同一个 sink。

## Testing

- `WinAudioTests.exe` Debug：**237 passed**
- `WinAudioTests.exe` Release：**237 passed**
- 覆盖 WAV sink 命名/撞名/overflow/双 sink、CaptureTrackList live dump、MonitorEngine 采集/播放 dump 接线、DumpFolder 注册表回退；无真音频设备。
- GUI 改动：本会话未附截图，合并前建议本地看一眼 Dump / Stop dump 按钮与文件夹对话框。
- 真设备冒烟：**未做**。合并前建议：两路 loopback 同时 dump、Stop 后资源管理器选中文件、Monitor 采集/播放各一份 wav、写到不可写盘时图仍在跑。

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
