### PR TITLE
feat(gui): add Pipeline tab for live session graph

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -93,3 +93,41 @@ _Avoid_: StreamOption, AUDCLNT_STREAMOPTIONS, extraSharedInitFlags
 **Stream init**:
 The share-mode recipe shared by every Track and by silent-render: mix vs requested conversion, exclusive probe and align-retry, duration, and stream flags. Loopback extras are supplied by the caller; Stream init does not inspect the Capture source. Endpoint or Application Loopback activation sits outside it, as do client properties, ducking, and the pump.
 _Avoid_: Client Init, prepareClient, format negotiation (that is only the format half)
+
+### Pipeline inspector
+
+**Pipeline Inspector**:
+A reconstruction of one capture or render path (hardware mic → app, or app → hardware), from a Live session plus optional Hooked streams, the endpoint graph, Shared probes, and ETW Initialize hints. It intercepts Core Audio COM in the target app process; it does not intercept APO COM in audiodg.
+_Avoid_: APO dumper, API Monitor clone, session APO list
+
+**Live session**:
+A Windows audio session on one endpoint for one process — the mixer row used to discover who is capturing or playing. It is not a Track, not a Monitor, and may contain more than one Hooked stream.
+_Avoid_: session (when meaning a Track or Monitor), process (too coarse), WASAPI stream
+
+**Hooked stream**:
+One `IAudioClient` in a target process whose Core Audio COM calls are intercepted in-process. Control-path methods carry full arguments; buffer pump calls are metadata only. It is not an audiodg APO object.
+_Avoid_: Live session (the mixer row), attach as caller (we do not `GetService` their client from our process)
+
+**Core Audio intercept**:
+The closed COM set captured on a Hooked stream: device activate, `IAudioClient*`, capture/render clients (metadata only), `IAudioEffectsManager`, session control, stream/channel volume, and audio clock. Not XAudio2, DirectSound, or WinRT AudioGraph entry points, and not audiodg APO COM.
+_Avoid_: full Win32 hook table, APO intercept
+
+**On-demand attach**:
+Injection into the process PID of a Live session the user selected, only when GUI and target have the same bitness. Cross-bitness attach fails closed. The GUI stays unelevated; attach that lacks debug rights fails closed and the rest of the Inspector still runs. WinAudio does not inject every audio process and does not launch the target suspended.
+_Avoid_: global inject, monitor-new-process, attach as caller, always-admin GUI, 32-bit helper from x64 GUI
+
+**Call log**:
+The time-ordered list of intercepted Core Audio COM calls on Hooked streams: interface, method, arguments, HRESULT. Control-path calls are kept. Buffer pump metadata is off until enabled; when on, it uses a small ring (recent calls plus xrun counts) and never includes PCM. It sits beside the pipeline graph; it is not the graph.
+_Avoid_: API Monitor dump, PCM capture, ETW etl file, unbounded GetBuffer log
+
+**Observation kind**:
+The confidence label on a pipeline node or parameter: Observed, Probed, Inferred, Skipped, or Unknown. Hooked-stream arguments are Observed. Shared-probe effect types stay Probed and must not be shown as the target's APO instances.
+_Avoid_: guaranteed, actual APO instance, "what Chrome ran"
+
+**Shared probe**:
+A short-lived WASAPI Shared stream this process opens on the same endpoint as a Live session, to query advertised effect types when no Hooked stream is attached. Not Exclusive; not a clone of the target's stream.
+_Avoid_: Exclusive probe, Hooked stream
+
+**AudioClientInitialize (ETW)**:
+Initialize-related events used to fill Initialize fields for a Live session before On-demand attach, or when attach is absent. Match by PID + short time window + device id, or else Unknown. After attach, Hooked-stream calls override these fields.
+_Avoid_: CollectAudioLogs dump, pump/glitch trace

--- a/docs/adr/0002-pipeline-core-audio-intercept.md
+++ b/docs/adr/0002-pipeline-core-audio-intercept.md
@@ -1,0 +1,10 @@
+# Pipeline Inspector intercepts Core Audio COM in the target app, not audiodg
+
+The Inspector must show another process's Initialize arguments, which public session APIs cannot. We intercept Core Audio COM in-process on On-demand attach (same bitness, fail closed without debug rights). We do not hook audiodg APO COM, do not clone system-wide API Monitor, and do not require an always-elevated GUI. Pre-attach Initialize is filled from ETW / endpoint graph / Shared probe; the Call log keeps control-path calls and optional pump metadata in a small ring.
+
+## Considered Options
+
+- **Public APIs only** — rejected. Cannot observe the target's `WAVEFORMATEX`, RAW, or category as Observed.
+- **Inject audiodg for `IAudioProcessingObject`** — rejected for v1. Protected process; still no supported way to dump APO internals safely.
+- **Hook all Win32/COM or XAudio2/DirectSound/WinRT entry points** — rejected. Out of the Core Audio intercept closed set.
+- **Auto-inject every audio process, or launch-suspended monitor** — rejected. On-demand attach only.

--- a/docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md
+++ b/docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md
@@ -1,0 +1,209 @@
+# WinAudio Pipeline Inspector 设计
+
+日期: 2026-08-21 · 状态: 2026-08-25 grill 已锁定（ADR-0002）· 范围: Core + GUI 新 tab；**CLI is unchanged**
+
+## 1. 产品定位
+
+Pipeline Inspector 重建一条捕获或播放路径（hardware mic → app，或 app → hardware）。
+
+- **Live session**（混音器行）用来发现谁在开麦/播放。
+- **On-demand attach** 之后，观察单元细化为该进程里的 **Hooked stream**（一条 `IAudioClient`）。
+- 在目标 **应用进程** 内拦截 **Core Audio intercept** 闭集；**不**拦截 audiodg 里的 APO COM。
+- 呈现：**Pipeline 图 + Call log**。
+
+它 **不是** 从本进程去 `GetService` 对方的 client。  
+它 **不是** 枚举 audiodg 里的 APO 实例，也 **不是** 系统级 API Monitor。
+
+架构取舍见 `docs/adr/0002-pipeline-core-audio-intercept.md`。用词见 `CONTEXT.md`。
+
+每个处理图节点必须带一种 Observation kind：
+
+| Kind | 含义 |
+|---|---|
+| Observed | 公开 API、已对齐 ETW，或 Hooked stream 上拦到的 COM 实参 |
+| Probed | 本工具在同设备上另开 Shared 流测到的（不是对方那条流） |
+| Inferred | 由模式规则推出（例如 RAW ⇒ SFX 不加载） |
+| Skipped | 有证据表明这一段没跑（Exclusive、SysFx 关、RAW 的 SFX） |
+| Unknown | 没有 API / 事件，禁止猜测填值 |
+
+UI 不得把 Probed 画成「Chrome 实际走过的 APO」。**禁止把 Shared probe 的效果类型呈现为被观察 App 的实际 APO 实例。**
+
+## 2.1 能拿到 vs 拿不到
+
+**能拿到（v1）：**
+
+- PID、进程名、data flow、session 音量 / 静音 / 状态（Live session）
+- mix / device / OEM 格式；已注册 SFX / MFX / EFX CLSID；硬件 volume / mute / AGC（拓扑暴露时）
+- Shared probe 广告的效果类型（未 attach 时，Probed）
+- ETW 对得上时的 category / RAW / HRESULT（attach 前）
+- **On-demand attach 之后**：Core Audio intercept 的控制路径实参（`Initialize` 的 format/share/RAW/category、`Start`/`Stop`、session/volume/clock、`IAudioEffectsManager`）为 Observed
+
+**拿不到：**
+
+- audiodg 里的 APO COM 实例、EQ 曲线、NS 强度、`APOProcess` 实参
+- attach 之前的调用栈（只能靠 ETW/探针补洞）
+- 跨位数目标、无调试权限时的挂钩
+- XAudio2 / DirectSound / WinRT 入口（仅当它们在本 PID 落到 WASAPI 时才会出现在日志里）
+- 应用私有 DSP；泵 PCM
+
+## 2.2 v1 规则（硬约束）
+
+- **On-demand attach**：用户选中 Live session 后注入该 PID；同位数；GUI 默认不抬权；缺调试权限 **fails closed**。不自动注入、不挂起启动目标。
+- **Core Audio intercept**：Activate、`IAudioClient*`、capture/render client、`IAudioEffectsManager`、session control、stream/channel volume、clock。不钩 audiodg，不钩 XAudio2/DS/WinRT 入口。
+- **Call log**：控制路径保留；泵默认关；打开后走小环形缓冲 + xrun 计数；永不记 PCM。
+- **Shared probe**：未挂钩时用；Default / Communications / Raw；Initialize then `IAudioEffectsManager`；**no Start**；**never Exclusive probe**。
+- **ETW Initialize**：attach 前补洞；PID + 短时间窗 + device id；对不上 Unknown。无 ETW 权限则该层缺席，其余仍工作。
+- **CLI is unchanged**。
+
+## 3. 非目标（v1）
+
+- 钩 audiodg / `IAudioProcessingObject`；系统级 API Monitor；跨位数注入助手。
+- 枚举 APO 运行实例、内部旋钮；Exclusive 探针；打断并重开对方的流。
+- 热路径逐帧 ETW；CollectAudioLogs；空间音频对象级参数；CLI 子命令。
+
+## 4. 五层数据，合成图 + 日志
+
+缺一层时其余层仍工作：
+
+1. **Live session watch**（capture and render）
+2. **Endpoint graph**（格式、SysFx、SFX/MFX/EFX CLSID、硬件旋钮）
+3. **Shared probe**（未 attach）
+4. **ETW Initialize** hints（attach 前）
+5. **Core Audio intercept**（On-demand attach → Hooked stream + Call log）
+
+`assemblePipeline`（`src/core/PipelineGraph.*`，windows-free）把快照合成带 Observation kind 的节点。Call log 是旁路时间线，不替代图。COM / ETW / 注入适配器只负责填快照。
+
+### 4.1 Live session（Observed）
+
+对 **capture 与 render** 每个 active endpoint 注册 `IAudioSessionNotification`，并枚举已有 session。
+
+每行：
+
+- PID、进程名、device id / friendly name、data flow（capture | render）
+- session 状态、session 音量 / 静音
+- session instance id（关联 ETW 用，能拿到就 Observed）
+
+本仓库现有 `AudioSessionEnumerator` 只服务 Application Loopback（render、按 PID 去重）。Inspector 需要 **按 session 实例、含 capture**，不得改坏 Application Loopback 的去重语义；新类型放在 Pipeline 模块。
+
+### 4.2 Endpoint graph（设备级，与 session 无关）
+
+对选中 session 的 endpoint：
+
+- Mix / Device / OEM 格式（复用 Capabilities 的三来源，不新开采集流）
+- `PKEY_AudioEndpoint_Disable_SysFx`
+- FX store：`PKEY_FX_StreamEffectClsid` / `ModeEffectClsid` / `EndpointEffectClsid` 及支持的 processing modes
+- `IDeviceTopology` 可 QI 到的控制：音量、静音、AGC、bass/treble（有则 Observed 参数；没有则不下发空旋钮）
+
+硬件拓扑参数是该 endpoint 上所有共享流真正经过的，对「别人的麦」也成立。
+
+### 4.3 Shared probe（Probed）
+
+选中一个 session 后，本工具在 **同一 endpoint** 上依次打开短寿命 WASAPI Shared 流（Initialize + `GetService(IAudioEffectsManager)` + 关闭；**不 Start**，避免占缓冲抢时序）：
+
+| 探针标签 | SetClientProperties |
+|---|---|
+| Default | 不启用 client properties |
+| Communications | category = Communications |
+| Raw | option = Raw（设备不支持则该切片失败，节点记 Unknown + 失败原因） |
+
+约束：
+
+- 仅 Shared；Exclusive 请求直接 Fail，禁止降级去抢设备。
+- 探针失败（含对方 Exclusive 占设备）不得拆掉 session 雷达。
+- 探针流必须能从会话列表里识别为自己，UI 默认隐藏本进程，可勾选显示。
+
+得到的是 **效果类型 GUID + ON/OFF + canSetState**，不是 APO CLSID。
+
+### 4.4 ETW Initialize（Observed，失败则整层缺席）
+
+v1 订阅（实时 session，尽量不写 etl 文件）：
+
+1. **Microsoft-Windows-Audio** `{AE4BD3BE-F36F-45B6-8D21-BDD6FB832853}`
+   - PlaybackManager 事件 24/25：`AppId`, `PID`, `Category`
+   - Performance 事件 123 / 125 / 127 文案含 `category=%2, raw=%3, matchformat=%4`（GetMixFormat / IsFormatSupported / Vadserver_CreateStream）
+2. **Microsoft.Windows.Audio.Client** `{6E7B1892-5288-5FE5-8F34-E3B0DC671FD2}` TraceLogging  
+   官方措施文档中的 **AudioClientInitialize**（HRESULT）。字段用 TDH 尽力解码；缺字段保持 Unknown。
+
+关联规则（从严）：
+
+- PID + 时间窗（默认 5 s）+ 能解析到的 device id 对齐到 Live session。
+- 对不上就不贴，节点保持 Unknown。禁止「最近一条 Initialize 套到当前选中行」。
+
+权限：`EnableTraceEx2` 失败（非管理员 / 非 Performance Log Users）→ Inspector 横幅「ETW unavailable」，其余层照常。不得要求用户重启以开这个功能。
+
+### 4.5 Core Audio intercept（On-demand attach）
+
+用户在雷达中选中一行并 Attach：
+
+- 注入该 PID，位数必须与 GUI 相同；否则失败说明，不降级。
+- GUI 默认普通权限；无 SeDebugPrivilege 则 fails closed，图/探针/ETW 仍可用。
+- 闭集见 CONTEXT **Core Audio intercept**。控制路径进 Call log（完整参数）。泵默认不记；勾选后进小环 + xrun，无 PCM。
+- attach 之后的 COM 实参覆盖 ETW 补丁，标 Observed。
+- 不钩 audiodg；不卸载失败时假装已挂钩。
+
+## 5. 图的节点顺序
+
+采集（硬件麦克风 → 软件采集）节点顺序：
+
+`Hardware → Driver/KS → EFX → MFX → SFX → Engine SRC → Session → App`
+
+（mode tee 是 EFX 与 MFX 之间的分路，不单独占一个带参数的节点。）
+
+播放（软件写数据 → 硬件播放）为反向顺序：
+
+`App → Session → Engine SRC → SFX → MFX → EFX → Driver/KS → Hardware`
+
+（mix / mode mix 是引擎混音步骤，合入 SRC/MFX 节点说明，不另开 COM 槽。）
+
+规则：
+
+- Exclusive（仅当 ETW 或其它 Observed 证据说是 Exclusive）：引擎 SFX/MFX/SRC 为 Skipped；硬件节点仍在；EFX 为 Unknown（软件 EFX 通常不在 Exclusive 路径，但不得假装读到了硬件 DSP）。
+- RAW Observed：SFX = Skipped（官方：RAW 不跑 SFX）；MFX 在 Win10+ 仍可能加载 → Unknown，除非探针 Raw 切片有效果类型。
+- SysFx disabled Observed：SFX/MFX = Skipped；EFX 仍画出注册 CLSID，kind Observed（注册表），是否执行标 Unknown。
+- 无 ETW category：MFX/SFX 旁边挂 Default / Communications / Raw 三列探针结果，全部 Probed，标题写明「not this session」。
+
+每个节点的 params 每条也带 kind。禁止把 Mix format 标成「该 App 的流格式」——那是引擎混音格式，除非 ETW 给出了 Initialize 的 WAVEFORMATEX。
+
+## 6. GUI
+
+新 tab：**Pipeline**（文案进 `AppUiText.h`，英文，带文案测试）。
+
+布局：
+
+- 左：Live sessions 表（flow、进程、PID、设备、状态）；Refresh；「Hide this process」默认开；ETW 状态一行。
+- 中：选中行的处理图（垂直节点列表即可，v1 不用独立图形库）。节点颜色区分 kind。
+- 右或节点展开：参数表（key / value / kind）。
+- 「Probe this device」按钮：跑 4.3；运行中禁用该按钮。探针失败写日志，不弹阻塞框。
+- 「Attach」：对选中 Live session 做 On-demand attach（4.5）。失败横幅，不伪装挂钩。
+- 调用日志栏：控制路径；可选泵小环。与图并排，不替代图。
+
+不改 Monitor / Loopback / Application Loopback 的开流行为。切到 Pipeline tab 不停止其它页的 Track。
+
+## 7. 测试（必须无真实声卡）
+
+- `assemblePipeline`：Exclusive / RAW / SysFx off / 无 ETW / 有 ETW 对齐 / 探针对不上 PID 等夹具。
+- ETW 解码：用录好的 `EVENT_RECORD` 字节或字段字典，不 EnableTrace。
+- Session 列表排序与 capture+render 共存（不与 Application Loopback 去重逻辑耦合）。
+- GUI 文案常量测试。
+- 既有测试零回归。COM 适配器可用 fake；CI runner 无音频硬件。
+
+## 8. 日志
+
+凡新增 WASAPI/COM/ETW Win32 调用，按现有 `wa::log` 插桩：EnableTrace / Initialize 探针 / OpenPropertyStore 为 Debug；探针生命周期 Info；热路径不在本功能。core 不 print。
+
+## 9. 分层提交
+
+1. `feat(core): add pipeline graph assembly`（纯模型 + 单测）
+2. `feat(core): watch sessions and snapshot endpoint FX`
+3. `feat(core): shared effects probe and ETW initialize hints`
+4. `feat(gui): add Pipeline inspector tab`
+5. `docs: Pipeline Inspector usage and limits`
+
+## 10. 验收
+
+1. 打开 Pipeline tab，任意 App 开麦或播放后出现对应 session（PID + 设备 + flow）。
+2. 选中后看到有序节点，每节点有 kind；Probed 与 Observed 视觉可分。
+3. Probe 在 Shared 下补出效果类型；对方 Exclusive 时探针失败但雷达仍在。
+4. 有 ETW 权限时，能把 category/RAW/HRESULT 贴到对得上的 session；无权限时横幅说明且不崩溃。
+5. 不声称列出了该 session 的全部 APO 实例或内部 DSP 参数。
+6. `test.bat` Debug + Release 全绿。

--- a/docs/superpowers/specs/2026-08-25-pipeline-inspector-prd.md
+++ b/docs/superpowers/specs/2026-08-25-pipeline-inspector-prd.md
@@ -1,0 +1,94 @@
+## Problem Statement
+
+When another app starts microphone capture or playback, I cannot see what processing the audio went through from the hardware microphone to the app, or from the app writing samples to the hardware renderer — nor the parameters of each stage. Windows does not expose another process's in-process APO objects. Public session APIs also omit that process's stream Initialize arguments (format, share mode, RAW, category).
+
+## Solution
+
+A Pipeline Inspector tab reconstructs one capture or render path for a Live session I select. The graph shows stages with Observation kind (Observed, Probed, Inferred, Skipped, Unknown). I can On-demand attach into that process (same bitness) to intercept Core Audio COM and see a Call log of control-path arguments. Attach-before Initialize holes are filled from ETW, the endpoint graph, and a Shared probe. The Inspector never hooks audiodg APO COM and never claims Shared-probe effect types are the target's APO instances.
+
+## User Stories
+
+1. As an audio tester, I want a Pipeline tab besides Monitor / Loopback / Application Loopback, so that I can inspect other apps without stopping Tracks I already created.
+2. As an audio tester, I want Live sessions on both capture and render endpoints listed, so that I see who is using a microphone and who is playing.
+3. As an audio tester, I want each Live session row to show process name, PID, device, flow, volume, mute, and state, so that I can pick the right mixer row.
+4. As an audio tester, I want the list to update when a process starts or stops a Live session, so that I do not have to guess whether capture has begun.
+5. As an audio tester, I want to refresh the Live session list manually, so that I can recover if a notification was missed.
+6. As an audio tester, I want this process hidden from the list by default, so that WinAudio's own streams do not clutter the radar.
+7. As an audio tester, I want an option to show this process, so that I can verify Inspector behaviour against a Track I control.
+8. As an audio tester, I want selecting a Live session to show an ordered processing graph, so that I can follow hardware mic → app or app → hardware.
+9. As an audio tester, I want capture node order Hardware → Driver/KS → EFX → MFX → SFX → Engine SRC → Session → App, so that the graph matches the shared-mode engine.
+10. As an audio tester, I want render node order to be the reverse of capture, so that playback is not drawn as if it were capture.
+11. As an audio tester, I want every graph node and parameter labelled Observed, Probed, Inferred, Skipped, or Unknown, so that I do not treat guesses as facts.
+12. As an audio tester, I want Observed and Probed visually distinct, so that I never read a Shared probe as the target's APO instances.
+13. As an audio tester, I want mix format labelled as the engine mix, not as the app stream format, so that I do not misread Capabilities as the other process's WAVEFORMATEX.
+14. As an audio tester, I want registered SFX, MFX, and EFX CLSIDs on the endpoint graph, so that I see what the device recipe installed.
+15. As an audio tester, I want readable hardware volume, mute, and AGC when the topology exposes them, so that I see controls every shared stream actually passes.
+16. As an audio tester, I want SysFx-disabled endpoints to show SFX and MFX as Skipped, so that I do not draw enhancements that are off.
+17. As an audio tester, I want Exclusive (only with Observed evidence) to skip the shared engine nodes, so that I do not draw SFX/MFX/SRC on a path that bypassed them.
+18. As an audio tester, I want RAW Observed to skip SFX, so that the graph matches the engine rule that RAW streams do not use SFX.
+19. As an audio tester, I want to run a Shared probe on the same endpoint (Default, Communications, Raw) without Start and never Exclusive, so that I can see advertised effect types when I have not attached.
+20. As an audio tester, I want a failed Shared probe (including when the target holds Exclusive) to leave the Live session radar intact, so that discovery does not die with the probe.
+21. As an audio tester, I want probe results stored as Probed, so that I cannot confuse them with Hooked-stream Observed arguments.
+22. As an audio tester, I want ETW Initialize hints matched by PID, a short time window, and device id, so that pre-attach category/RAW/HRESULT can be Observed when they actually belong to this Live session.
+23. As an audio tester, I want unmatched ETW to stay Unknown rather than applying the latest Initialize on the machine, so that I do not glue the wrong stream onto this row.
+24. As an audio tester, I want the Inspector to keep working when ETW cannot be enabled, with a clear unavailable status, so that I can still use radar, graph, probe, and attach.
+25. As an audio tester, I want On-demand attach on the selected Live session PID, so that I intercept that process's Core Audio COM without injecting every audio process.
+26. As an audio tester, I want attach to require the same bitness as the GUI, so that a 64-bit GUI does not pretend to hook a 32-bit target.
+27. As an audio tester, I want the GUI to stay unelevated, so that Monitor and Loopback keep working without Administrator.
+28. As an audio tester, I want attach without debug rights to fail closed with a banner, so that the Inspector does not look attached when it is not.
+29. As an audio tester, I want attach not to launch the target suspended and not to restart the target's stream, so that I do not interrupt a call to obtain Initialize.
+30. As an audio tester, I want Hooked-stream control-path arguments (Activate, Initialize, SetClientProperties, Start/Stop, GetService, session control, volume, clock, IAudioEffectsManager) in the Call log, so that I can read the real parameters.
+31. As an audio tester, I want Initialize fields from a Hooked stream to override ETW patches on the graph and be Observed, so that attach-after facts win.
+32. As an audio tester, I want pump GetBuffer/ReleaseBuffer omitted from the Call log by default, so that Initialize is not drowned in 10 ms noise.
+33. As an audio tester, I want an option to record pump metadata into a small ring with xrun counts and never PCM, so that I can prove the stream is pumping without a disk flood.
+34. As an audio tester, I want a Call log pane beside the graph, so that time-ordered COM detail and the path narrative stay separate.
+35. As an audio tester, I want one Live session to show multiple Hooked streams if the process Initialized more than once, so that session and stream stay distinct.
+36. As an audio tester, I want Core Audio intercept limited to the closed COM set (no XAudio2, DirectSound, or WinRT AudioGraph entry points), so that the product is not an API Monitor clone.
+37. As an audio tester, I want no intercept of audiodg APO COM, so that I do not destabilize protected audio or fake APO internals.
+38. As an audio tester, I want switching away from the Pipeline tab not to stop Monitor or Loopback Tracks, so that inspection is side-by-side with my own streams.
+39. As an audio tester, I want CLI behaviour unchanged, so that scripts and `list`/`caps`/`capture`/`play`/`monitor` keep working.
+40. As an audio tester, I want Unknown rather than invented APO knobs (EQ curves, NS strength), so that the tool stays honest.
+41. As an audio tester, I want attach after Initialize to still show future calls immediately, so that Stop/Start and the next Initialize are Observed even if the first Initialize was missed.
+42. As an audio tester, I want a 32-bit WinAudio GUI to attach to 32-bit targets the same way, so that same-bitness attach works on both official binaries.
+43. As an audio tester, I want failed attach to keep using Shared probe and ETW on that Live session, so that I still have a reconstruction.
+44. As a reviewer, I want Observation kind names stable in UI copy tests, so that labels cannot drift from the glossary.
+
+## Implementation Decisions
+
+- Respect ADR-0002: in-process Core Audio intercept on On-demand attach; no audiodg APO intercept; no system-wide API Monitor; GUI not always elevated.
+- Add a Pipeline Inspector surface on the GUI. It does not own Tracks, Monitor, or WAV dumps.
+- Keep Live session enumeration separate from Application Loopback's PID-deduped render list so that Inspector can show capture and render session instances.
+- Join all reconstruction inputs through one snapshot → graph function. The landed join already takes Live session view, endpoint snapshot, ETW Initialize hint, and probe slices. Extend that snapshot with optional hooked-call records so attach overrides ETW without a second graph builder.
+- Type shape from the landed join (prototype, not a demo): `ObservationKind { Observed, Probed, Inferred, Skipped, Unknown }`; `assemblePipeline(session, endpoint, etw, probes) → nodes`; hooked control-path fields, when present, are Observed and replace matching ETW fields.
+- Call log is a separate view of the same hooked-call records: control-path retained; pump metadata off until enabled, then a small ring plus xrun counts, never PCM.
+- Shared probe: three Shared-only recipes (Default, Communications, Raw); Initialize then query advertised effects; no Start; Exclusive probe fails closed.
+- ETW Initialize: Microsoft-Windows-Audio PlaybackManager/Performance and Microsoft.Windows.Audio.Client AudioClientInitialize; match PID + short window + device id; no match → Unknown; enable failure → layer absent.
+- On-demand attach: selected Live session PID only; same bitness; fail closed without debug rights; no auto-inject; no launch-suspended; no cross-bitness helper from the 64-bit GUI.
+- Core Audio intercept closed set: device activate, IAudioClient*, capture/render clients, IAudioEffectsManager, session control, stream/channel volume, audio clock.
+- Adapters (session watch, endpoint FX/topology, probe, ETW enable, inject) sit below the snapshot join. They must not become the test seam.
+- CLI is unchanged.
+
+## Testing Decisions
+
+- Good tests assert external behaviour of the snapshot join and the Call log retention rules: node order, kind labels, RAW skips SFX, Exclusive skips engine, SysFx skips SFX/MFX, probe stays Probed, unmatched ETW does not invent HRESULT, hooked Initialize overrides ETW, pump default-off, pump ring drops oldest metadata, no PCM in log records. Tests do not inject into live processes, do not EnableTrace, and do not open real WASAPI devices.
+- Primary seam (one): Pipeline Inspector snapshot in → graph nodes + Call log view out. Prefer extending the existing assemblePipeline join over adding parallel graph code. Feed canned Live session, endpoint, ETW, probe, and hooked-call records.
+- Secondary only if the join cannot express it: Call log ring behaviour with canned intercept records (still no inject).
+- Modules under test: pipeline join, Call log retention, Live session list shaping (sort/filter/hide-self) with fake rows — same style as existing session-list tests.
+- Prior art: pipeline graph tests (capture/render order, RAW, Exclusive, Probed vs Observed); audio session enumerator tests (sort/dedupe without devices); stream params tests (Windows-free predicates). GUI copy constants follow existing UI text tests.
+- CI must remain device-free. Real attach, real ETW, and real Shared probe are manual smoke, not gating.
+
+## Out of Scope
+
+- Hooking audiodg or IAudioProcessingObject; APO instance lists; EQ/NS internal knobs.
+- Auto-inject; launch-suspended monitor; 32-bit helper spawned from the 64-bit GUI; always-admin GUI.
+- XAudio2, DirectSound, and WinRT AudioGraph entry-point hooks.
+- Exclusive Shared probe; forcing the target to re-Initialize; recording PCM from GetBuffer.
+- CLI flags for Inspector; CollectAudioLogs-scale tracing; spatial object parameters; Time Travel Tracing.
+- Changing Monitor, System Loopback, or Application Loopback stream behaviour.
+
+## Further Notes
+
+- Glossary: Live session, Hooked stream, Core Audio intercept, On-demand attach, Call log, Observation kind, Shared probe, AudioClientInitialize (ETW). Avoid calling a Live session a Track or a Monitor.
+- Application Loopback session picker remains a different list (render, unique PID). Do not reuse it as the Inspector radar.
+- Chromium and similar hosts may open WASAPI in a child PID; attach uses the Live session's process id, which is the WASAPI opener when the enumerator reports it.
+- Design narrative also lives in the Pipeline Inspector design document and ADR-0002; this spec is the implementation contract.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,6 +17,9 @@ add_library(WinAudioCore STATIC
     CaptureTrackList.cpp
     Capabilities.cpp
     Log.cpp
+    PipelineGraph.cpp
+    LiveSessionEnumerator.cpp
+    EndpointGraphReader.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi spdlog)

--- a/src/core/EndpointGraphReader.cpp
+++ b/src/core/EndpointGraphReader.cpp
@@ -1,0 +1,245 @@
+#include "EndpointGraphReader.h"
+#include <cstdio>
+#include <initguid.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <devicetopology.h>
+#include <functiondiscoverykeys_devpkey.h>
+#include "AudioFormatStr.h"
+#include "ComUtil.h"
+#include "DeviceEnumerator.h"
+#include "Log.h"
+
+DEFINE_PROPERTYKEY(PKEY_FX_StreamEffectClsid,
+                   0xd04e05a6, 0x594b, 0x4fb6, 0xa8, 0x0d, 0x01, 0xaf, 0x5e, 0xed, 0x7d, 0x1d, 5);
+DEFINE_PROPERTYKEY(PKEY_FX_ModeEffectClsid,
+                   0xd04e05a6, 0x594b, 0x4fb6, 0xa8, 0x0d, 0x01, 0xaf, 0x5e, 0xed, 0x7d, 0x1d, 6);
+DEFINE_PROPERTYKEY(PKEY_FX_EndpointEffectClsid,
+                   0xd04e05a6, 0x594b, 0x4fb6, 0xa8, 0x0d, 0x01, 0xaf, 0x5e, 0xed, 0x7d, 0x1d, 7);
+
+namespace wa {
+namespace {
+
+std::string wideToUtf8(const wchar_t* w) {
+    if (!w || !*w) return {};
+    int n = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0, nullptr, nullptr);
+    if (n <= 1) return {};
+    std::string s(static_cast<size_t>(n - 1), 0);
+    WideCharToMultiByte(CP_UTF8, 0, w, -1, s.data(), n, nullptr, nullptr);
+    return s;
+}
+
+void readClsid(IPropertyStore* props, const PROPERTYKEY& key, const char* role,
+               EndpointSnapshot& out) {
+    PROPVARIANT pv;
+    PropVariantInit(&pv);
+    HRESULT hr = props->GetValue(key, &pv);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetValue(FX CLSID)", role, wa::log::hrName(hr));
+    if (SUCCEEDED(hr) && pv.vt == VT_LPWSTR && pv.pwszVal && pv.pwszVal[0]) {
+        ApoSlot slot;
+        slot.role = role;
+        slot.clsid = wideToUtf8(pv.pwszVal);
+        out.apos.push_back(std::move(slot));
+    }
+    PropVariantClear(&pv);
+}
+
+void readFxStore(IMMDevice* dev, EndpointSnapshot& out) {
+    ComPtr<IPropertyStore> props;
+    HRESULT hr = dev->OpenPropertyStore(STGM_READ, props.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "OpenPropertyStore", "STGM_READ",
+           wa::log::hrName(hr));
+    if (FAILED(hr) || !props) return;
+
+    PROPVARIANT sysfx;
+    PropVariantInit(&sysfx);
+    hr = props->GetValue(PKEY_AudioEndpoint_Disable_SysFx, &sysfx);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetValue(Disable_SysFx)", "",
+           wa::log::hrName(hr));
+    if (SUCCEEDED(hr) && (sysfx.vt == VT_UI4 || sysfx.vt == VT_BOOL || sysfx.vt == VT_I4)) {
+        if (sysfx.vt == VT_BOOL)
+            out.sysFxDisabled = sysfx.boolVal != VARIANT_FALSE;
+        else
+            out.sysFxDisabled = sysfx.ulVal != 0;
+    }
+    PropVariantClear(&sysfx);
+
+    readClsid(props.Get(), PKEY_FX_StreamEffectClsid, "SFX", out);
+    readClsid(props.Get(), PKEY_FX_ModeEffectClsid, "MFX", out);
+    readClsid(props.Get(), PKEY_FX_EndpointEffectClsid, "EFX", out);
+}
+
+void addHardware(IPart* part, EndpointSnapshot& out) {
+    LPWSTR name = nullptr;
+    HRESULT hr = part->GetName(&name);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "IPart::GetName", "", wa::log::hrName(hr));
+    const std::string partName = SUCCEEDED(hr) && name ? wideToUtf8(name) : "part";
+    if (name) CoTaskMemFree(name);
+
+    ComPtr<IAudioMute> mute;
+    hr = part->Activate(CLSCTX_ALL, __uuidof(IAudioMute), reinterpret_cast<void**>(mute.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "Activate(IAudioMute)", partName,
+           wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        WA_LOG(wa::log::Level::Warn, "EndpointGraph", "Activate(IAudioMute)", partName,
+               wa::log::hrName(hr));
+    } else if (mute) {
+        BOOL on = FALSE;
+        hr = mute->GetMute(&on);
+        WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetMute", partName, wa::log::hrName(hr));
+        if (SUCCEEDED(hr))
+            out.hardware.push_back(HardwareControl{"mute", on ? "true" : "false"});
+    }
+
+    ComPtr<IAudioVolumeLevel> vol;
+    hr = part->Activate(CLSCTX_ALL, __uuidof(IAudioVolumeLevel),
+                        reinterpret_cast<void**>(vol.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "Activate(IAudioVolumeLevel)", partName,
+           wa::log::hrName(hr));
+    if (SUCCEEDED(hr) && vol) {
+        UINT nch = 0;
+        hr = vol->GetChannelCount(&nch);
+        WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetChannelCount", partName,
+               wa::log::hrName(hr));
+        if (SUCCEEDED(hr) && nch > 0) {
+            float db = 0.f;
+            hr = vol->GetLevel(0, &db);
+            WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetLevel", partName,
+                   wa::log::hrName(hr));
+            if (SUCCEEDED(hr)) {
+                char buf[32];
+                std::snprintf(buf, sizeof(buf), "%.1f dB", static_cast<double>(db));
+                out.hardware.push_back(HardwareControl{"volume", buf});
+            }
+        }
+    }
+
+    ComPtr<IAudioAutoGainControl> agc;
+    hr = part->Activate(CLSCTX_ALL, __uuidof(IAudioAutoGainControl),
+                        reinterpret_cast<void**>(agc.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "Activate(IAudioAutoGainControl)", partName,
+           wa::log::hrName(hr));
+    if (SUCCEEDED(hr) && agc) {
+        BOOL on = FALSE;
+        hr = agc->GetEnabled(&on);
+        WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetEnabled(AGC)", partName,
+               wa::log::hrName(hr));
+        if (SUCCEEDED(hr))
+            out.hardware.push_back(HardwareControl{"AGC", on ? "on" : "off"});
+    }
+}
+
+void walkTopology(IDeviceTopology* topo, EndpointSnapshot& out) {
+    UINT n = 0;
+    HRESULT hr = topo->GetSubunitCount(&n);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetSubunitCount",
+           "n=" + std::to_string(n), wa::log::hrName(hr));
+    if (FAILED(hr)) return;
+    for (UINT i = 0; i < n; ++i) {
+        ComPtr<ISubunit> sub;
+        hr = topo->GetSubunit(i, sub.GetAddressOf());
+        WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetSubunit",
+               "i=" + std::to_string(i), wa::log::hrName(hr));
+        if (FAILED(hr) || !sub) continue;
+        ComPtr<IPart> part;
+        hr = sub.As(&part);
+        WA_LOG(wa::log::Level::Debug, "EndpointGraph", "QueryInterface(IPart)",
+               "i=" + std::to_string(i), wa::log::hrName(hr));
+        if (SUCCEEDED(hr) && part) addHardware(part.Get(), out);
+    }
+}
+
+void readTopology(IMMDevice* dev, EndpointSnapshot& out) {
+    ComPtr<IDeviceTopology> epTopo;
+    HRESULT hr = dev->Activate(__uuidof(IDeviceTopology), CLSCTX_ALL, nullptr,
+                               reinterpret_cast<void**>(epTopo.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "Activate(IDeviceTopology)", "",
+           wa::log::hrName(hr));
+    if (FAILED(hr) || !epTopo) return;
+
+    walkTopology(epTopo.Get(), out);
+
+    UINT connectors = 0;
+    hr = epTopo->GetConnectorCount(&connectors);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetConnectorCount",
+           "n=" + std::to_string(connectors), wa::log::hrName(hr));
+    if (FAILED(hr) || connectors == 0) return;
+
+    ComPtr<IConnector> conn;
+    hr = epTopo->GetConnector(0, conn.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetConnector", "0", wa::log::hrName(hr));
+    if (FAILED(hr) || !conn) return;
+
+    ComPtr<IConnector> other;
+    hr = conn->GetConnectedTo(other.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetConnectedTo", "", wa::log::hrName(hr));
+    if (FAILED(hr) || !other) return;
+
+    ComPtr<IPart> part;
+    hr = other.As(&part);
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "QueryInterface(IPart)", "",
+           wa::log::hrName(hr));
+    if (FAILED(hr) || !part) {
+        if (FAILED(hr))
+            WA_LOG(wa::log::Level::Warn, "EndpointGraph", "QueryInterface(IPart)", "",
+                   wa::log::hrName(hr));
+        return;
+    }
+
+    ComPtr<IDeviceTopology> adapter;
+    hr = part->GetTopologyObject(adapter.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "GetTopologyObject", "", wa::log::hrName(hr));
+    if (SUCCEEDED(hr) && adapter) walkTopology(adapter.Get(), out);
+}
+
+}  // namespace
+
+Result EndpointGraphReader::snapshot(DataFlow flow, const DeviceId& id, EndpointSnapshot& out) {
+    out = EndpointSnapshot{};
+    WA_LOG(wa::log::Level::Info, "EndpointGraph", "snapshot",
+           "flow=" + std::string(flow == DataFlow::Capture ? "capture" : "render") +
+               " id=" + wa::narrowAscii(id),
+           "start");
+
+    ComInitGuard com;
+    if (!com.ok()) return HrToResult(com.hr, "EndpointGraphReader: CoInitializeEx");
+
+    DeviceEnumerator devices;
+    AudioFormat mix{};
+    Result r = devices.mixFormat(id, mix);
+    if (r) out.mixFormat = formatAudio(mix);
+    AudioFormat devFmt{};
+    r = devices.deviceFormat(id, devFmt);
+    if (r) out.deviceFormat = formatAudio(devFmt);
+    AudioFormat oem{};
+    r = devices.oemFormat(id, oem);
+    if (r) out.oemFormat = formatAudio(oem);
+
+    ComPtr<IMMDeviceEnumerator> e;
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                  __uuidof(IMMDeviceEnumerator),
+                                  reinterpret_cast<void**>(e.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph", "CoCreateInstance(MMDeviceEnumerator)", "",
+           wa::log::hrName(hr));
+    if (FAILED(hr)) return HrToResult(hr, "EndpointGraphReader: CoCreateInstance");
+
+    ComPtr<IMMDevice> dev;
+    const EDataFlow ef = flow == DataFlow::Capture ? eCapture : eRender;
+    hr = id.empty() ? e->GetDefaultAudioEndpoint(ef, eConsole, dev.GetAddressOf())
+                    : e->GetDevice(id.c_str(), dev.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "EndpointGraph",
+           id.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+           wa::narrowAscii(id), wa::log::hrName(hr));
+    if (FAILED(hr)) return HrToResult(hr, "EndpointGraphReader: GetDevice");
+
+    readFxStore(dev.Get(), out);
+    readTopology(dev.Get(), out);
+    WA_LOG(wa::log::Level::Info, "EndpointGraph", "snapshot",
+           "apos=" + std::to_string(out.apos.size()) +
+               " hw=" + std::to_string(out.hardware.size()) +
+               " sysfx=" + std::string(out.sysFxDisabled ? "off" : "on"),
+           "ok");
+    return Result::Ok();
+}
+
+}  // namespace wa

--- a/src/core/EndpointGraphReader.h
+++ b/src/core/EndpointGraphReader.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "IAudioBackend.h"
+#include "PipelineGraph.h"
+#include "Result.h"
+
+namespace wa {
+
+class EndpointGraphReader {
+public:
+    Result snapshot(DataFlow flow, const DeviceId& id, EndpointSnapshot& out);
+};
+
+}  // namespace wa

--- a/src/core/LiveSessionEnumerator.cpp
+++ b/src/core/LiveSessionEnumerator.cpp
@@ -1,0 +1,206 @@
+#include "LiveSessionEnumerator.h"
+#include <cwchar>
+#include <mmdeviceapi.h>
+#include <audiopolicy.h>
+#include "AudioFormatStr.h"
+#include "ComUtil.h"
+#include "DeviceEnumerator.h"
+#include "Log.h"
+
+namespace wa {
+namespace {
+
+std::string wideToUtf8(const std::wstring& w) {
+    if (w.empty()) return {};
+    int n = WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()),
+                                nullptr, 0, nullptr, nullptr);
+    if (n <= 0) return {};
+    std::string s(static_cast<size_t>(n), 0);
+    WideCharToMultiByte(CP_UTF8, 0, w.c_str(), static_cast<int>(w.size()),
+                        s.data(), n, nullptr, nullptr);
+    return s;
+}
+
+std::wstring basenameOfPath(const std::wstring& path) {
+    const size_t pos = path.find_last_of(L"\\/");
+    return (pos == std::wstring::npos) ? path : path.substr(pos + 1);
+}
+
+std::string processNameFromPid(uint32_t pid) {
+    HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    if (!h) return "pid-" + std::to_string(pid);
+
+    wchar_t path[MAX_PATH] = {};
+    DWORD n = static_cast<DWORD>(std::size(path));
+    std::wstring name;
+    if (QueryFullProcessImageNameW(h, 0, path, &n) && n > 0) {
+        name = basenameOfPath(std::wstring(path, n));
+    }
+    CloseHandle(h);
+    if (name.empty()) return "pid-" + std::to_string(pid);
+    return wideToUtf8(name);
+}
+
+const char* sessionStateName(AudioSessionState st) {
+    switch (st) {
+        case AudioSessionStateInactive: return "Inactive";
+        case AudioSessionStateActive:   return "Active";
+        case AudioSessionStateExpired:  return "Expired";
+    }
+    return "Unknown";
+}
+
+void fillVolumeMute(IAudioSessionControl* control, LiveSessionView& row) {
+    ComPtr<ISimpleAudioVolume> vol;
+    HRESULT hr = control->QueryInterface(__uuidof(ISimpleAudioVolume),
+                                         reinterpret_cast<void**>(vol.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "QueryInterface(ISimpleAudioVolume)", "",
+           wa::log::hrName(hr));
+    if (FAILED(hr) || !vol) return;
+
+    float level = 1.f;
+    hr = vol->GetMasterVolume(&level);
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "GetMasterVolume", "", wa::log::hrName(hr));
+    if (SUCCEEDED(hr)) row.sessionVolume = level;
+
+    BOOL mute = FALSE;
+    hr = vol->GetMute(&mute);
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "GetMute", "", wa::log::hrName(hr));
+    if (SUCCEEDED(hr)) row.sessionMute = mute != FALSE;
+}
+
+Result appendDeviceSessions(const DeviceInfo& info, std::vector<LiveSessionView>& out,
+                            Result& lastFailure, bool& sawCount) {
+    ComPtr<IMMDeviceEnumerator> e;
+    HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                  __uuidof(IMMDeviceEnumerator),
+                                  reinterpret_cast<void**>(e.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "CoCreateInstance(MMDeviceEnumerator)", "",
+           wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        lastFailure = HrToResult(hr, "LiveSessionEnumerator: CoCreateInstance(MMDeviceEnumerator)");
+        return lastFailure;
+    }
+
+    ComPtr<IMMDevice> dev;
+    hr = e->GetDevice(info.id.c_str(), dev.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "GetDevice",
+           "id=" + wa::narrowAscii(info.id), wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        lastFailure = HrToResult(hr, "LiveSessionEnumerator: GetDevice");
+        return Result::Ok();
+    }
+
+    ComPtr<IAudioSessionManager2> manager;
+    hr = dev->Activate(__uuidof(IAudioSessionManager2), CLSCTX_ALL, nullptr,
+                       reinterpret_cast<void**>(manager.GetAddressOf()));
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "Activate(IAudioSessionManager2)",
+           "id=" + wa::narrowAscii(info.id), wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        lastFailure = HrToResult(hr, "LiveSessionEnumerator: Activate(IAudioSessionManager2)");
+        return Result::Ok();
+    }
+
+    ComPtr<IAudioSessionEnumerator> sessions;
+    hr = manager->GetSessionEnumerator(sessions.GetAddressOf());
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "GetSessionEnumerator", "", wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        lastFailure = HrToResult(hr, "LiveSessionEnumerator: GetSessionEnumerator");
+        return Result::Ok();
+    }
+
+    int count = 0;
+    hr = sessions->GetCount(&count);
+    WA_LOG(wa::log::Level::Debug, "LiveSession", "GetCount",
+           "n=" + std::to_string(count), wa::log::hrName(hr));
+    if (FAILED(hr)) {
+        lastFailure = HrToResult(hr, "LiveSessionEnumerator: GetCount");
+        return Result::Ok();
+    }
+    sawCount = true;
+
+    const PipelineFlow flow =
+        info.flow == DataFlow::Capture ? PipelineFlow::Capture : PipelineFlow::Render;
+    const std::string deviceId = wideToUtf8(info.id);
+    const std::string deviceName = wideToUtf8(info.name);
+
+    for (int i = 0; i < count; ++i) {
+        ComPtr<IAudioSessionControl> control;
+        hr = sessions->GetSession(i, control.GetAddressOf());
+        WA_LOG(wa::log::Level::Debug, "LiveSession", "GetSession",
+               "i=" + std::to_string(i), wa::log::hrName(hr));
+        if (FAILED(hr) || !control) {
+            if (FAILED(hr))
+                WA_LOG(wa::log::Level::Warn, "LiveSession", "GetSession",
+                       "i=" + std::to_string(i), wa::log::hrName(hr));
+            continue;
+        }
+
+        ComPtr<IAudioSessionControl2> control2;
+        hr = control.As(&control2);
+        WA_LOG(wa::log::Level::Debug, "LiveSession", "QueryInterface(IAudioSessionControl2)",
+               "i=" + std::to_string(i), wa::log::hrName(hr));
+        if (FAILED(hr) || !control2) {
+            if (FAILED(hr))
+                WA_LOG(wa::log::Level::Warn, "LiveSession", "QueryInterface(IAudioSessionControl2)",
+                       "i=" + std::to_string(i), wa::log::hrName(hr));
+            continue;
+        }
+
+        DWORD pid = 0;
+        hr = control2->GetProcessId(&pid);
+        WA_LOG(wa::log::Level::Debug, "LiveSession", "GetProcessId", "", wa::log::hrName(hr));
+        if (FAILED(hr) || pid == 0) continue;
+
+        AudioSessionState st = AudioSessionStateExpired;
+        hr = control->GetState(&st);
+        WA_LOG(wa::log::Level::Debug, "LiveSession", "GetState", "", wa::log::hrName(hr));
+
+        LiveSessionView row;
+        row.processId = static_cast<uint32_t>(pid);
+        row.processName = processNameFromPid(row.processId);
+        row.deviceId = deviceId;
+        row.deviceName = deviceName;
+        row.flow = flow;
+        row.state = sessionStateName(st);
+        fillVolumeMute(control.Get(), row);
+        out.push_back(std::move(row));
+    }
+    return Result::Ok();
+}
+
+}  // namespace
+
+Result LiveSessionEnumerator::enumerate(std::vector<LiveSessionView>& out) {
+    out.clear();
+    WA_LOG(wa::log::Level::Info, "LiveSession", "enumerate", "", "start");
+
+    ComInitGuard com;
+    if (!com.ok()) return HrToResult(com.hr, "LiveSessionEnumerator: CoInitializeEx");
+
+    DeviceEnumerator devices;
+    std::vector<DeviceInfo> caps;
+    std::vector<DeviceInfo> rens;
+    Result r = devices.enumerate(DataFlow::Capture, caps);
+    if (!r) return r;
+    r = devices.enumerate(DataFlow::Render, rens);
+    if (!r) return r;
+
+    Result lastFailure = Result::Ok();
+    bool sawCount = false;
+    for (const auto& info : caps) {
+        appendDeviceSessions(info, out, lastFailure, sawCount);
+    }
+    for (const auto& info : rens) {
+        appendDeviceSessions(info, out, lastFailure, sawCount);
+    }
+
+    shapeLiveSessionList(out, 0);
+    if (!sawCount && (!caps.empty() || !rens.empty()) && !lastFailure)
+        return lastFailure;
+    WA_LOG(wa::log::Level::Info, "LiveSession", "enumerate",
+           "n=" + std::to_string(out.size()), "ok");
+    return Result::Ok();
+}
+
+}  // namespace wa

--- a/src/core/LiveSessionEnumerator.h
+++ b/src/core/LiveSessionEnumerator.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <vector>
+#include "PipelineGraph.h"
+#include "Result.h"
+
+namespace wa {
+
+class LiveSessionEnumerator {
+public:
+    Result enumerate(std::vector<LiveSessionView>& out);
+};
+
+}  // namespace wa

--- a/src/core/PipelineGraph.cpp
+++ b/src/core/PipelineGraph.cpp
@@ -1,0 +1,268 @@
+#include "PipelineGraph.h"
+#include <algorithm>
+#include <cstring>
+
+namespace wa {
+namespace {
+
+PipelineParam param(std::string key, std::string value, ObservationKind kind) {
+    return PipelineParam{std::move(key), std::move(value), kind};
+}
+
+void addAposForRole(PipelineNode& node, const EndpointSnapshot& endpoint, const char* role) {
+    int n = 0;
+    for (const auto& apo : endpoint.apos) {
+        if (apo.role != role) continue;
+        ++n;
+        const std::string label = apo.friendlyName.empty() ? apo.clsid : apo.friendlyName;
+        node.params.push_back(param(role, label + " (" + apo.clsid + ")", ObservationKind::Observed));
+    }
+    if (n == 0) {
+        node.params.push_back(param(role, "(none registered)", ObservationKind::Observed));
+    }
+}
+
+void addProbeEffects(PipelineNode& node, const std::vector<ProbeSlice>& probes) {
+    if (probes.empty())
+        return;
+    for (const auto& slice : probes) {
+        if (slice.effects.empty()) {
+            node.params.push_back(param(slice.label, "(no advertised effects)", ObservationKind::Probed));
+            continue;
+        }
+        for (const auto& fx : slice.effects) {
+            std::string v = fx.typeName;
+            v += fx.on ? " ON" : " OFF";
+            if (fx.canSetState) v += " (settable)";
+            node.params.push_back(param(slice.label, std::move(v), ObservationKind::Probed));
+        }
+    }
+}
+
+PipelineNode hardwareNode(const EndpointSnapshot& endpoint) {
+    PipelineNode n{"hardware", "Hardware", ObservationKind::Inferred, {}};
+    if (!endpoint.deviceFormat.empty()) {
+        n.params.push_back(param("device format", endpoint.deviceFormat, ObservationKind::Observed));
+        n.kind = ObservationKind::Observed;
+    }
+    if (!endpoint.oemFormat.empty()) {
+        n.params.push_back(param("OEM format", endpoint.oemFormat, ObservationKind::Observed));
+        n.kind = ObservationKind::Observed;
+    }
+    for (const auto& c : endpoint.hardware) {
+        n.params.push_back(param(c.name.c_str(), c.value, ObservationKind::Observed));
+        n.kind = ObservationKind::Observed;
+    }
+    if (n.params.empty()) {
+        n.params.push_back(param("topology", "no readable controls", ObservationKind::Unknown));
+    }
+    return n;
+}
+
+PipelineNode driverNode() {
+    return {"driver", "Driver / KS", ObservationKind::Inferred,
+            {param("note", "kernel path not dumped in v1", ObservationKind::Inferred)}};
+}
+
+PipelineNode efxNode(const EndpointSnapshot& endpoint, const std::vector<ProbeSlice>& probes,
+                     bool exclusive) {
+    PipelineNode n{"efx", "EFX (endpoint)", ObservationKind::Observed, {}};
+    addAposForRole(n, endpoint, "EFX");
+    if (exclusive) {
+        n.kind = ObservationKind::Unknown;
+        n.params.push_back(param("exclusive", "software EFX usually not on this path",
+                                 ObservationKind::Inferred));
+    }
+    addProbeEffects(n, probes);
+    return n;
+}
+
+PipelineNode mfxNode(const EndpointSnapshot& endpoint, const EtwInitializeHint& etw,
+                     const std::vector<ProbeSlice>& probes, bool skipSysFx) {
+    PipelineNode n{"mfx", "MFX (mode)", ObservationKind::Observed, {}};
+    if (skipSysFx) {
+        n.kind = ObservationKind::Skipped;
+        addAposForRole(n, endpoint, "MFX");
+        n.params.push_back(param("SysFx", "disabled", ObservationKind::Observed));
+        return n;
+    }
+    addAposForRole(n, endpoint, "MFX");
+    if (etw.present && etw.category) {
+        n.params.push_back(param("category", *etw.category, ObservationKind::Observed));
+    } else {
+        n.params.push_back(param("category", "unknown", ObservationKind::Unknown));
+    }
+    if (etw.present && etw.raw && *etw.raw) {
+        n.params.push_back(param("RAW", "SFX skipped; MFX may still load", ObservationKind::Inferred));
+        n.kind = ObservationKind::Unknown;
+    }
+    addProbeEffects(n, probes);
+    return n;
+}
+
+PipelineNode sfxNode(const EndpointSnapshot& endpoint, const EtwInitializeHint& etw,
+                     const std::vector<ProbeSlice>& probes, bool skipSysFx) {
+    PipelineNode n{"sfx", "SFX (stream)", ObservationKind::Observed, {}};
+    if (skipSysFx) {
+        n.kind = ObservationKind::Skipped;
+        addAposForRole(n, endpoint, "SFX");
+        n.params.push_back(param("SysFx", "disabled", ObservationKind::Observed));
+        return n;
+    }
+    if (etw.present && etw.raw && *etw.raw) {
+        n.kind = ObservationKind::Skipped;
+        n.params.push_back(param("RAW", "SFX not used", ObservationKind::Observed));
+        addAposForRole(n, endpoint, "SFX");
+        return n;
+    }
+    addAposForRole(n, endpoint, "SFX");
+    if (!etw.present || !etw.category) {
+        n.params.push_back(param("instance", "per-stream; not the watched session",
+                                 ObservationKind::Unknown));
+    }
+    addProbeEffects(n, probes);
+    return n;
+}
+
+PipelineNode srcNode(const EndpointSnapshot& endpoint, const EtwInitializeHint& etw) {
+    PipelineNode n{"src", "Engine SRC / mix format", ObservationKind::Observed, {}};
+    if (!endpoint.mixFormat.empty()) {
+        n.params.push_back(param("mix format", endpoint.mixFormat, ObservationKind::Observed));
+    } else {
+        n.params.push_back(param("mix format", "unavailable", ObservationKind::Unknown));
+        n.kind = ObservationKind::Unknown;
+    }
+    n.params.push_back(param("note", "mix format is the engine, not the app stream format",
+                             ObservationKind::Inferred));
+    if (etw.present && etw.matchFormat) {
+        n.params.push_back(param("MATCH_FORMAT", *etw.matchFormat ? "requested" : "not requested",
+                                 ObservationKind::Observed));
+    }
+    return n;
+}
+
+PipelineNode sessionNode(const LiveSessionView& session) {
+    PipelineNode n{"session", "Session", ObservationKind::Observed, {}};
+    n.params.push_back(param("pid", std::to_string(session.processId), ObservationKind::Observed));
+    n.params.push_back(param("volume", std::to_string(session.sessionVolume), ObservationKind::Observed));
+    n.params.push_back(param("mute", session.sessionMute ? "true" : "false", ObservationKind::Observed));
+    n.params.push_back(param("device", session.deviceName.empty() ? session.deviceId : session.deviceName,
+                             ObservationKind::Observed));
+    return n;
+}
+
+PipelineNode appNode(const LiveSessionView& session) {
+    PipelineNode n{"app", "App", ObservationKind::Observed, {}};
+    const std::string name = session.processName.empty()
+                                 ? ("pid-" + std::to_string(session.processId))
+                                 : session.processName;
+    n.params.push_back(param("process", name, ObservationKind::Observed));
+    n.params.push_back(param("flow", session.flow == PipelineFlow::Capture ? "capture" : "render",
+                             ObservationKind::Observed));
+    return n;
+}
+
+void appendEngine(std::vector<PipelineNode>& out, const EndpointSnapshot& endpoint,
+                  const EtwInitializeHint& etw, const std::vector<ProbeSlice>& probes,
+                  bool capture) {
+    const bool exclusive = etw.present && etw.exclusive && *etw.exclusive;
+    const bool skipSysFx = endpoint.sysFxDisabled || exclusive;
+
+    auto pushSfxMfxSrc = [&]() {
+        if (exclusive) {
+            PipelineNode skipped{"engine", "Audio engine (Shared)", ObservationKind::Skipped,
+                                 {param("exclusive", "bypassed", ObservationKind::Observed)}};
+            if (etw.hresult) {
+                skipped.params.push_back(param("Initialize HRESULT", std::to_string(*etw.hresult),
+                                               ObservationKind::Observed));
+            }
+            out.push_back(std::move(skipped));
+            return;
+        }
+        if (capture) {
+            out.push_back(mfxNode(endpoint, etw, probes, skipSysFx));
+            out.push_back(sfxNode(endpoint, etw, probes, skipSysFx));
+            out.push_back(srcNode(endpoint, etw));
+        } else {
+            out.push_back(srcNode(endpoint, etw));
+            out.push_back(sfxNode(endpoint, etw, probes, skipSysFx));
+            out.push_back(mfxNode(endpoint, etw, probes, skipSysFx));
+        }
+    };
+
+    if (capture) {
+        out.push_back(efxNode(endpoint, probes, exclusive));
+        pushSfxMfxSrc();
+    } else {
+        pushSfxMfxSrc();
+        out.push_back(efxNode(endpoint, probes, exclusive));
+    }
+}
+
+}  // namespace
+
+const char* observationKindName(ObservationKind kind) {
+    switch (kind) {
+        case ObservationKind::Observed: return "Observed";
+        case ObservationKind::Probed:   return "Probed";
+        case ObservationKind::Inferred: return "Inferred";
+        case ObservationKind::Skipped:  return "Skipped";
+        case ObservationKind::Unknown:  return "Unknown";
+    }
+    return "Unknown";
+}
+
+std::vector<PipelineNode> assemblePipeline(
+    const LiveSessionView& session,
+    const EndpointSnapshot& endpoint,
+    const EtwInitializeHint& etw,
+    const std::vector<ProbeSlice>& probes) {
+    std::vector<PipelineNode> out;
+    const bool capture = session.flow == PipelineFlow::Capture;
+
+    if (capture) {
+        out.push_back(hardwareNode(endpoint));
+        out.push_back(driverNode());
+        appendEngine(out, endpoint, etw, probes, true);
+        out.push_back(sessionNode(session));
+        out.push_back(appNode(session));
+    } else {
+        out.push_back(appNode(session));
+        out.push_back(sessionNode(session));
+        appendEngine(out, endpoint, etw, probes, false);
+        out.push_back(driverNode());
+        out.push_back(hardwareNode(endpoint));
+    }
+
+    if (etw.present && etw.hresult) {
+        // Attach HRESULT to the session node so Initialize result is visible even on Exclusive.
+        for (auto& n : out) {
+            if (n.id == "session") {
+                n.params.push_back(param("Initialize HRESULT", std::to_string(*etw.hresult),
+                                         ObservationKind::Observed));
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+void shapeLiveSessionList(std::vector<LiveSessionView>& rows, uint32_t hidePid) {
+    rows.erase(std::remove_if(rows.begin(), rows.end(),
+                              [hidePid](const LiveSessionView& row) {
+                                  if (row.processId == 0) return true;
+                                  return hidePid != 0 && row.processId == hidePid;
+                              }),
+               rows.end());
+    std::sort(rows.begin(), rows.end(), [](const LiveSessionView& a, const LiveSessionView& b) {
+        const int nameCmp = _stricmp(a.processName.c_str(), b.processName.c_str());
+        if (nameCmp != 0) return nameCmp < 0;
+        if (a.processId != b.processId) return a.processId < b.processId;
+        if (a.flow != b.flow) return static_cast<uint8_t>(a.flow) < static_cast<uint8_t>(b.flow);
+        const int devCmp = _stricmp(a.deviceName.c_str(), b.deviceName.c_str());
+        if (devCmp != 0) return devCmp < 0;
+        return a.deviceId < b.deviceId;
+    });
+}
+
+}  // namespace wa

--- a/src/core/PipelineGraph.h
+++ b/src/core/PipelineGraph.h
@@ -1,0 +1,97 @@
+#pragma once
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace wa {
+
+enum class ObservationKind : uint8_t {
+    Observed,
+    Probed,
+    Inferred,
+    Skipped,
+    Unknown,
+};
+
+enum class PipelineFlow : uint8_t { Capture, Render };
+
+struct PipelineParam {
+    std::string key;
+    std::string value;
+    ObservationKind kind = ObservationKind::Unknown;
+};
+
+struct PipelineNode {
+    std::string id;
+    std::string title;
+    ObservationKind kind = ObservationKind::Unknown;
+    std::vector<PipelineParam> params;
+};
+
+struct LiveSessionView {
+    uint32_t processId = 0;
+    std::string processName;
+    std::string deviceId;
+    std::string deviceName;
+    PipelineFlow flow = PipelineFlow::Capture;
+    float sessionVolume = 1.f;
+    bool sessionMute = false;
+    std::string state;
+};
+
+// Drop pid 0; drop hidePid when non-zero; keep one row per session instance (do not
+// collapse the same PID on two devices). Sort by name, pid, flow, device.
+void shapeLiveSessionList(std::vector<LiveSessionView>& rows, uint32_t hidePid);
+
+struct ApoSlot {
+    std::string role;  // "SFX" | "MFX" | "EFX"
+    std::string clsid;
+    std::string friendlyName;
+};
+
+struct HardwareControl {
+    std::string name;
+    std::string value;
+};
+
+struct EndpointSnapshot {
+    bool sysFxDisabled = false;
+    std::string mixFormat;
+    std::string deviceFormat;
+    std::string oemFormat;
+    std::vector<ApoSlot> apos;
+    std::vector<HardwareControl> hardware;
+};
+
+struct EtwInitializeHint {
+    bool present = false;
+    std::optional<std::string> category;
+    std::optional<bool> raw;
+    std::optional<bool> matchFormat;
+    std::optional<bool> exclusive;
+    std::optional<int32_t> hresult;
+};
+
+struct AdvertisedEffect {
+    std::string typeName;
+    bool on = true;
+    bool canSetState = false;
+};
+
+struct ProbeSlice {
+    std::string label;
+    bool raw = false;
+    std::vector<AdvertisedEffect> effects;
+};
+
+const char* observationKindName(ObservationKind kind);
+
+// Pure join of session + endpoint + optional ETW + probes. No COM, no devices.
+std::vector<PipelineNode> assemblePipeline(
+    const LiveSessionView& session,
+    const EndpointSnapshot& endpoint,
+    const EtwInitializeHint& etw,
+    const std::vector<ProbeSlice>& probes);
+
+}  // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <string>
 
 static std::string wtou(const std::wstring& w) {
@@ -148,6 +149,52 @@ void AppUi::refreshApplicationLoopbackSessions() {
                                             appLoopbackSessionsLoaded_,
                                             appLoopbackSessionIdx_,
                                             std::move(rows));
+}
+
+void AppUi::refreshPipelineSessions() {
+    wa::LiveSessionView prev;
+    if (pipelineSelected_ >= 0 && pipelineSelected_ < (int)pipelineSessions_.size())
+        prev = pipelineSessions_[(size_t)pipelineSelected_];
+
+    std::vector<wa::LiveSessionView> rows;
+    wa::Result r = liveSessionEnumerator_.enumerate(rows);
+    pipelineSessionsLoaded_ = true;
+    if (!r) {
+        pipelineSessions_.clear();
+        pipelineSelected_ = -1;
+        pipelineNodes_.clear();
+        logLines_.push_back("pipeline refresh failed: " + r.message);
+        return;
+    }
+
+    const uint32_t hidePid = pipelineShowSelf_ ? 0u : static_cast<uint32_t>(GetCurrentProcessId());
+    wa::shapeLiveSessionList(rows, hidePid);
+    pipelineSessions_ = std::move(rows);
+
+    pipelineSelected_ = -1;
+    for (int i = 0; i < (int)pipelineSessions_.size(); ++i) {
+        const auto& s = pipelineSessions_[(size_t)i];
+        if (s.processId == prev.processId && s.deviceId == prev.deviceId && s.flow == prev.flow) {
+            pipelineSelected_ = i;
+            break;
+        }
+    }
+    rebuildPipelineGraph();
+}
+
+void AppUi::rebuildPipelineGraph() {
+    pipelineNodes_.clear();
+    if (pipelineSelected_ < 0 || pipelineSelected_ >= (int)pipelineSessions_.size())
+        return;
+
+    const wa::LiveSessionView& session = pipelineSessions_[(size_t)pipelineSelected_];
+    wa::EndpointSnapshot snap;
+    const wa::DataFlow flow =
+        session.flow == wa::PipelineFlow::Capture ? wa::DataFlow::Capture : wa::DataFlow::Render;
+    wa::Result r = endpointGraphReader_.snapshot(flow, utow(session.deviceId.c_str()), snap);
+    if (!r)
+        logLines_.push_back("pipeline endpoint snapshot failed: " + r.message);
+    pipelineNodes_ = wa::assemblePipeline(session, snap, {}, {});
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -527,6 +574,10 @@ void AppUi::draw() {
             drawApplicationLoopbackPage();
             ImGui::EndTabItem();
         }
+        if (ImGui::BeginTabItem(wa::ui_text::kPipelineTab)) {
+            drawPipelinePage();
+            ImGui::EndTabItem();
+        }
         ImGui::EndTabBar();
     }
 
@@ -644,6 +695,106 @@ void AppUi::drawApplicationLoopbackPage() {
     ImGui::BeginChild("appLoopbackLogRegion", ImVec2(0, kLogHeight), true);
     ImGui::SeparatorText("Log");
     drawLogPanel("appLoopbackLog", false);
+    ImGui::EndChild();
+}
+
+namespace {
+ImVec4 kindColor(wa::ObservationKind kind) {
+    switch (kind) {
+        case wa::ObservationKind::Observed: return ImVec4(0.45f, 0.90f, 0.55f, 1.f);
+        case wa::ObservationKind::Probed:   return ImVec4(0.95f, 0.85f, 0.35f, 1.f);
+        case wa::ObservationKind::Inferred: return ImVec4(0.50f, 0.75f, 0.95f, 1.f);
+        case wa::ObservationKind::Skipped:  return ImVec4(0.62f, 0.62f, 0.62f, 1.f);
+        case wa::ObservationKind::Unknown:  return ImVec4(0.90f, 0.55f, 0.55f, 1.f);
+    }
+    return ImVec4(1.f, 1.f, 1.f, 1.f);
+}
+}  // namespace
+
+void AppUi::drawPipelinePage() {
+    if (!pipelineSessionsLoaded_)
+        refreshPipelineSessions();
+
+    constexpr float kLogHeight = 200.0f;
+    const float availY = ImGui::GetContentRegionAvail().y;
+    const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
+
+    ImGui::BeginChild("pipelineTop", ImVec2(0, topHeight), false);
+    ImGui::BeginChild("pipelineLeft", ImVec2(420, 0), true);
+    ImGui::SeparatorText(wa::ui_text::kPipelineSessions);
+    if (ImGui::Button(wa::ui_text::kPipelineRefresh))
+        refreshPipelineSessions();
+    ImGui::SameLine();
+    if (ImGui::Checkbox(wa::ui_text::kPipelineShowSelf, &pipelineShowSelf_))
+        refreshPipelineSessions();
+
+    if (pipelineSessions_.empty()) {
+        ImGui::TextWrapped("%s", wa::ui_text::kPipelineEmpty);
+    } else if (ImGui::BeginTable("pipelineSessions", 7,
+                                 ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                     ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp)) {
+        ImGui::TableSetupColumn("Flow", ImGuiTableColumnFlags_WidthFixed, 70.f);
+        ImGui::TableSetupColumn("Process");
+        ImGui::TableSetupColumn("PID", ImGuiTableColumnFlags_WidthFixed, 60.f);
+        ImGui::TableSetupColumn("Device");
+        ImGui::TableSetupColumn("Vol", ImGuiTableColumnFlags_WidthFixed, 40.f);
+        ImGui::TableSetupColumn("Mute", ImGuiTableColumnFlags_WidthFixed, 40.f);
+        ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 70.f);
+        ImGui::TableHeadersRow();
+        for (int i = 0; i < (int)pipelineSessions_.size(); ++i) {
+            const auto& s = pipelineSessions_[(size_t)i];
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            const bool selected = (i == pipelineSelected_);
+            char label[64];
+            std::snprintf(label, sizeof(label), "%s##ps%d",
+                          s.flow == wa::PipelineFlow::Capture ? "capture" : "render", i);
+            if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns)) {
+                pipelineSelected_ = i;
+                rebuildPipelineGraph();
+            }
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TextUnformatted(s.processName.c_str());
+            ImGui::TableSetColumnIndex(2);
+            ImGui::Text("%u", s.processId);
+            ImGui::TableSetColumnIndex(3);
+            ImGui::TextUnformatted(s.deviceName.c_str());
+            ImGui::TableSetColumnIndex(4);
+            ImGui::Text("%.2f", static_cast<double>(s.sessionVolume));
+            ImGui::TableSetColumnIndex(5);
+            ImGui::TextUnformatted(s.sessionMute ? "yes" : "no");
+            ImGui::TableSetColumnIndex(6);
+            ImGui::TextUnformatted(s.state.c_str());
+        }
+        ImGui::EndTable();
+    }
+    ImGui::EndChild();
+
+    ImGui::SameLine();
+    ImGui::BeginChild("pipelineGraph", ImVec2(0, 0), true);
+    ImGui::SeparatorText(wa::ui_text::kPipelineGraph);
+    if (pipelineSelected_ < 0) {
+        ImGui::TextWrapped("%s", wa::ui_text::kPipelineSelectHint);
+    } else {
+        for (const auto& n : pipelineNodes_) {
+            ImGui::PushStyleColor(ImGuiCol_Text, kindColor(n.kind));
+            ImGui::Text("%s [%s]", n.title.c_str(), wa::observationKindName(n.kind));
+            ImGui::PopStyleColor();
+            for (const auto& p : n.params) {
+                ImGui::PushStyleColor(ImGuiCol_Text, kindColor(p.kind));
+                ImGui::BulletText("%s: %s [%s]", p.key.c_str(), p.value.c_str(),
+                                  wa::observationKindName(p.kind));
+                ImGui::PopStyleColor();
+            }
+            ImGui::Spacing();
+        }
+    }
+    ImGui::EndChild();
+    ImGui::EndChild();
+
+    ImGui::BeginChild("pipelineLogRegion", ImVec2(0, kLogHeight), true);
+    ImGui::SeparatorText("Log");
+    drawLogPanel("pipelineLog", false);
     ImGui::EndChild();
 }
 

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -10,7 +10,10 @@
 #include "CreateRecipe.h"
 #include "DeviceEnumerator.h"
 #include "DumpUi.h"
+#include "EndpointGraphReader.h"
+#include "LiveSessionEnumerator.h"
 #include "MonitorEngine.h"
+#include "PipelineGraph.h"
 #include "Spectrogram.h"
 #include "TrackScopeReader.h"
 
@@ -48,7 +51,10 @@ private:
 
     void refreshMonitorDevices();
     void refreshApplicationLoopbackSessions();
+    void refreshPipelineSessions();
+    void rebuildPipelineGraph();
     void drawMonitorPage();
+    void drawPipelinePage();
     void drawLoopbackPage();
     void drawApplicationLoopbackPage();
     void drawLoopbackLeftPanel();
@@ -96,6 +102,8 @@ private:
     wa::CaptureTrackList appLoopbackTracks_;
     wa::DeviceEnumerator enumerator_;
     wa::AudioSessionEnumerator sessionEnumerator_;
+    wa::LiveSessionEnumerator liveSessionEnumerator_;
+    wa::EndpointGraphReader endpointGraphReader_;
     wa::MonitorStatus    ms_;   // polled once per frame in draw(); shared by helper methods
 
     int  backendIdx_      = 0;
@@ -124,6 +132,12 @@ private:
     int                         appLoopbackSessionIdx_ = -1;
     char                        appLoopbackPid_[32] = "";
     wa::create_recipe::CreateRecipe appLoopbackRecipe_{};
+
+    bool pipelineSessionsLoaded_ = false;
+    bool pipelineShowSelf_ = false;
+    int  pipelineSelected_ = -1;
+    std::vector<wa::LiveSessionView> pipelineSessions_;
+    std::vector<wa::PipelineNode> pipelineNodes_;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -53,4 +53,14 @@ inline constexpr const char* kLoopbackEmptyHint = "Create a Track to capture sys
 inline constexpr const char* kApplicationLoopbackEmptyHint =
     "Create a Track to capture application audio.";
 
+inline constexpr const char* kPipelineTab = "Pipeline";
+inline constexpr const char* kPipelineRefresh = "Refresh";
+inline constexpr const char* kPipelineSessions = "Live sessions";
+inline constexpr const char* kPipelineShowSelf = "Show this process";
+inline constexpr const char* kPipelineEmpty =
+    "No Live sessions. Start capture or playback in another app, then Refresh.";
+inline constexpr const char* kPipelineSelectHint =
+    "Select a Live session to see its processing graph.";
+inline constexpr const char* kPipelineGraph = "Processing graph";
+
 } // namespace wa::ui_text

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,6 +25,9 @@ add_executable(WinAudioTests
     test_log.cpp
     test_loopback.cpp
     test_audio_session_enumerator.cpp
+    test_pipeline_graph.cpp
+    test_live_session_list.cpp
+
     test_cli_options.cpp
     test_dump_ui.cpp
     test_create_recipe.cpp

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include "AppUiText.h"
+#include "PipelineGraph.h"
+
+using namespace wa;
+
+namespace {
+
+LiveSessionView row(uint32_t pid, const char* name, const char* device, PipelineFlow flow) {
+    LiveSessionView s;
+    s.processId = pid;
+    s.processName = name;
+    s.deviceId = device;
+    s.deviceName = device;
+    s.flow = flow;
+    s.sessionVolume = 1.f;
+    s.state = "Active";
+    return s;
+}
+
+}  // namespace
+
+TEST(LiveSessionList, DropsPidZero) {
+    std::vector<LiveSessionView> rows = {
+        row(0, "system", "mic", PipelineFlow::Capture),
+        row(10, "chrome.exe", "mic", PipelineFlow::Capture),
+    };
+    shapeLiveSessionList(rows, 0);
+    ASSERT_EQ(rows.size(), 1u);
+    EXPECT_EQ(rows[0].processId, 10u);
+}
+
+TEST(LiveSessionList, HidesSelfPid) {
+    std::vector<LiveSessionView> rows = {
+        row(42, "WinAudioGui.exe", "speakers", PipelineFlow::Render),
+        row(10, "chrome.exe", "mic", PipelineFlow::Capture),
+    };
+    shapeLiveSessionList(rows, 42);
+    ASSERT_EQ(rows.size(), 1u);
+    EXPECT_EQ(rows[0].processId, 10u);
+}
+
+TEST(LiveSessionList, HidePidZeroKeepsOthers) {
+    std::vector<LiveSessionView> rows = {row(10, "chrome.exe", "mic", PipelineFlow::Capture)};
+    shapeLiveSessionList(rows, 0);
+    ASSERT_EQ(rows.size(), 1u);
+}
+
+TEST(LiveSessionList, KeepsSamePidOnDifferentDevices) {
+    std::vector<LiveSessionView> rows = {
+        row(10, "chrome.exe", "headset", PipelineFlow::Render),
+        row(10, "chrome.exe", "mic", PipelineFlow::Capture),
+    };
+    shapeLiveSessionList(rows, 0);
+    ASSERT_EQ(rows.size(), 2u);
+}
+
+TEST(LiveSessionList, SortsByNameThenPidThenFlowThenDevice) {
+    std::vector<LiveSessionView> rows = {
+        row(20, "zoom.exe", "mic", PipelineFlow::Capture),
+        row(10, "chrome.exe", "speakers", PipelineFlow::Render),
+        row(10, "chrome.exe", "headset", PipelineFlow::Render),
+        row(10, "chrome.exe", "mic", PipelineFlow::Capture),
+    };
+    shapeLiveSessionList(rows, 0);
+    ASSERT_EQ(rows.size(), 4u);
+    EXPECT_EQ(rows[0].processName, "chrome.exe");
+    EXPECT_EQ(rows[0].flow, PipelineFlow::Capture);
+    EXPECT_EQ(rows[1].deviceName, "headset");
+    EXPECT_EQ(rows[2].deviceName, "speakers");
+    EXPECT_EQ(rows[3].processName, "zoom.exe");
+}
+
+TEST(PipelineUiText, ExposesPipelineTabControls) {
+    EXPECT_STREQ(wa::ui_text::kPipelineTab, "Pipeline");
+    EXPECT_STREQ(wa::ui_text::kPipelineRefresh, "Refresh");
+    EXPECT_STREQ(wa::ui_text::kPipelineSessions, "Live sessions");
+    EXPECT_STREQ(wa::ui_text::kPipelineShowSelf, "Show this process");
+    EXPECT_STREQ(wa::ui_text::kPipelineEmpty,
+                 "No Live sessions. Start capture or playback in another app, then Refresh.");
+    EXPECT_STREQ(wa::ui_text::kPipelineSelectHint,
+                 "Select a Live session to see its processing graph.");
+    EXPECT_STREQ(wa::ui_text::kPipelineGraph, "Processing graph");
+}

--- a/src/tests/test_pipeline_graph.cpp
+++ b/src/tests/test_pipeline_graph.cpp
@@ -1,0 +1,194 @@
+#include <gtest/gtest.h>
+#include "PipelineGraph.h"
+
+using namespace wa;
+
+namespace {
+
+LiveSessionView chromeCap() {
+    LiveSessionView s;
+    s.processId = 4242;
+    s.processName = "chrome.exe";
+    s.deviceId = "{cap}";
+    s.deviceName = "Headset Mic";
+    s.flow = PipelineFlow::Capture;
+    s.sessionVolume = 0.75f;
+    s.sessionMute = false;
+    return s;
+}
+
+LiveSessionView chromeRen() {
+    auto s = chromeCap();
+    s.flow = PipelineFlow::Render;
+    s.deviceId = "{ren}";
+    s.deviceName = "Speakers";
+    return s;
+}
+
+EndpointSnapshot endpointWithApos() {
+    EndpointSnapshot e;
+    e.mixFormat = "48000/32f/2";
+    e.deviceFormat = "48000/24/2";
+    e.apos = {
+        {"SFX", "{sfx-guid}", "OEM EQ"},
+        {"MFX", "{mfx-guid}", "OEM NS"},
+        {"EFX", "{efx-guid}", "Speaker protect"},
+    };
+    e.hardware = {{"mute", "false"}, {"volume", "-6 dB"}};
+    return e;
+}
+
+const PipelineNode* findNode(const std::vector<PipelineNode>& nodes, const char* id) {
+    for (const auto& n : nodes) {
+        if (n.id == id) return &n;
+    }
+    return nullptr;
+}
+
+std::vector<std::string> ids(const std::vector<PipelineNode>& nodes) {
+    std::vector<std::string> out;
+    out.reserve(nodes.size());
+    for (const auto& n : nodes) out.push_back(n.id);
+    return out;
+}
+
+bool hasParam(const PipelineNode& n, const char* key, const char* value, ObservationKind kind) {
+    for (const auto& p : n.params) {
+        if (p.key == key && p.value == value && p.kind == kind) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(ObservationKind, Names) {
+    EXPECT_STREQ(observationKindName(ObservationKind::Observed), "Observed");
+    EXPECT_STREQ(observationKindName(ObservationKind::Probed), "Probed");
+    EXPECT_STREQ(observationKindName(ObservationKind::Inferred), "Inferred");
+    EXPECT_STREQ(observationKindName(ObservationKind::Skipped), "Skipped");
+    EXPECT_STREQ(observationKindName(ObservationKind::Unknown), "Unknown");
+}
+
+TEST(PipelineGraph, CaptureOrderHardwareToApp) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    EXPECT_EQ(ids(nodes), (std::vector<std::string>{
+        "hardware", "driver", "efx", "mfx", "sfx", "src", "session", "app"}));
+}
+
+TEST(PipelineGraph, RenderOrderAppToHardware) {
+    const auto nodes = assemblePipeline(chromeRen(), endpointWithApos(), {}, {});
+    EXPECT_EQ(ids(nodes), (std::vector<std::string>{
+        "app", "session", "src", "sfx", "mfx", "efx", "driver", "hardware"}));
+}
+
+TEST(PipelineGraph, SessionFieldsAreObserved) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    const auto* session = findNode(nodes, "session");
+    ASSERT_NE(session, nullptr);
+    EXPECT_EQ(session->kind, ObservationKind::Observed);
+    EXPECT_TRUE(hasParam(*session, "pid", "4242", ObservationKind::Observed));
+    EXPECT_TRUE(hasParam(*session, "mute", "false", ObservationKind::Observed));
+    const auto* app = findNode(nodes, "app");
+    ASSERT_NE(app, nullptr);
+    EXPECT_TRUE(hasParam(*app, "flow", "capture", ObservationKind::Observed));
+}
+
+TEST(PipelineGraph, MixFormatIsNotClaimedAsAppFormat) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    const auto* src = findNode(nodes, "src");
+    ASSERT_NE(src, nullptr);
+    EXPECT_TRUE(hasParam(*src, "mix format", "48000/32f/2", ObservationKind::Observed));
+    EXPECT_TRUE(hasParam(*src, "note", "mix format is the engine, not the app stream format",
+                         ObservationKind::Inferred));
+}
+
+TEST(PipelineGraph, RegisteredAposAreObservedOnSlots) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_TRUE(hasParam(*sfx, "SFX", "OEM EQ ({sfx-guid})", ObservationKind::Observed));
+    const auto* efx = findNode(nodes, "efx");
+    ASSERT_NE(efx, nullptr);
+    EXPECT_TRUE(hasParam(*efx, "EFX", "Speaker protect ({efx-guid})", ObservationKind::Observed));
+}
+
+TEST(PipelineGraph, SysFxOffSkipsSfxAndMfx) {
+    auto ep = endpointWithApos();
+    ep.sysFxDisabled = true;
+    const auto nodes = assemblePipeline(chromeCap(), ep, {}, {});
+    const auto* sfx = findNode(nodes, "sfx");
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(sfx, nullptr);
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_EQ(sfx->kind, ObservationKind::Skipped);
+    EXPECT_EQ(mfx->kind, ObservationKind::Skipped);
+    const auto* efx = findNode(nodes, "efx");
+    ASSERT_NE(efx, nullptr);
+    EXPECT_EQ(efx->kind, ObservationKind::Observed);
+}
+
+TEST(PipelineGraph, RawEtwSkipsSfx) {
+    EtwInitializeHint etw;
+    etw.present = true;
+    etw.raw = true;
+    etw.category = std::string("Communications");
+    etw.hresult = 0;
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), etw, {});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_EQ(sfx->kind, ObservationKind::Skipped);
+    EXPECT_TRUE(hasParam(*sfx, "RAW", "SFX not used", ObservationKind::Observed));
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "Communications", ObservationKind::Observed));
+}
+
+TEST(PipelineGraph, ExclusiveSkipsEngine) {
+    EtwInitializeHint etw;
+    etw.present = true;
+    etw.exclusive = true;
+    etw.hresult = 0;
+    const auto nodes = assemblePipeline(chromeRen(), endpointWithApos(), etw, {});
+    EXPECT_NE(findNode(nodes, "engine"), nullptr);
+    EXPECT_EQ(findNode(nodes, "sfx"), nullptr);
+    EXPECT_EQ(findNode(nodes, "mfx"), nullptr);
+    EXPECT_EQ(findNode(nodes, "src"), nullptr);
+    const auto* engine = findNode(nodes, "engine");
+    ASSERT_NE(engine, nullptr);
+    EXPECT_EQ(engine->kind, ObservationKind::Skipped);
+    const auto* efx = findNode(nodes, "efx");
+    ASSERT_NE(efx, nullptr);
+    EXPECT_EQ(efx->kind, ObservationKind::Unknown);
+}
+
+TEST(PipelineGraph, WithoutEtwCategoryStaysUnknownOnMfx) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "unknown", ObservationKind::Unknown));
+}
+
+TEST(PipelineGraph, ProbeSlicesAreProbedNotObserved) {
+    ProbeSlice comm;
+    comm.label = "Communications";
+    comm.effects = {{"Deep Noise Suppression", true, true}};
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {comm});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_TRUE(hasParam(*sfx, "Communications", "Deep Noise Suppression ON (settable)",
+                         ObservationKind::Probed));
+    for (const auto& p : sfx->params) {
+        if (p.key == "Communications") {
+            EXPECT_NE(p.kind, ObservationKind::Observed);
+        }
+    }
+}
+
+TEST(PipelineGraph, UnmatchedEtwAbsentDoesNotInventHresult) {
+    const auto nodes = assemblePipeline(chromeCap(), endpointWithApos(), {}, {});
+    const auto* session = findNode(nodes, "session");
+    ASSERT_NE(session, nullptr);
+    for (const auto& p : session->params) {
+        EXPECT_NE(p.key, "Initialize HRESULT");
+    }
+}


### PR DESCRIPTION
## What / Why

WinAudio had no way to see which other processes were capturing or playing, or what processing chain the selected endpoint would apply. This PR adds a **Pipeline** tab that lists **Live sessions** (capture and render) and draws a processing graph with Observation kinds.

Closes #64. Design: `docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md`. ADR-0002 records why later slices intercept Core Audio in the app process, not audiodg.

## How

- Join Live session + endpoint snapshot (formats, SysFx, registered SFX/MFX/EFX, readable hardware controls) in `assemblePipeline`. Empty probe/ETW inputs do not invent those layers.
- Enumerate sessions on capture and render endpoints without collapsing the same PID across devices.
- GUI lists sessions (hide this process by default) and draws the graph; switching tabs does not stop Monitor / Loopback Tracks.
- Shared probe, ETW Initialize, and On-demand attach stay out of this PR (#65–#67).

## Testing

- Local Debug: `ctest -C Debug` **274/274 passed** (8.24s).
- Targeted: `LiveSessionList.*`, `PipelineGraph.*`, `ObservationKind.*`, `PipelineUiText.*` all passed.
- Release ctest was not re-run in this session; CI matrix covers Debug + Release.
- Device-free gtest covers list shaping (hide-self, keep same PID on two devices) and graph join (order, SysFx skip, mix format not claimed as app format).
- GUI: no screenshot in this PR. Real-device smoke: open Pipeline tab, Refresh, select a session — not recorded here.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug ctest passed locally; Release covered by CI
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
