### PR TITLE
feat(gui): probe selected Live session endpoint

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(WinAudioCore STATIC
     PipelineGraph.cpp
     LiveSessionEnumerator.cpp
     EndpointGraphReader.cpp
+    SharedProbe.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi spdlog)

--- a/src/core/ComUtil.h
+++ b/src/core/ComUtil.h
@@ -17,7 +17,7 @@ template <class T> using ComPtr = Microsoft::WRL::ComPtr<T>;
 struct ComInitGuard {
     HRESULT hr;
     ComInitGuard() { hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED); }
-    ~ComInitGuard() { if (SUCCEEDED(hr)) CoUninitialize(); }
+    ~ComInitGuard() { if (hr == S_OK) CoUninitialize(); }
     bool ok() const { return SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE; }
 };
 

--- a/src/core/PipelineGraph.cpp
+++ b/src/core/PipelineGraph.cpp
@@ -26,6 +26,10 @@ void addProbeEffects(PipelineNode& node, const std::vector<ProbeSlice>& probes) 
     if (probes.empty())
         return;
     for (const auto& slice : probes) {
+        if (!slice.error.empty()) {
+            node.params.push_back(param(slice.label, slice.error, ObservationKind::Unknown));
+            continue;
+        }
         if (slice.effects.empty()) {
             node.params.push_back(param(slice.label, "(no advertised effects)", ObservationKind::Probed));
             continue;
@@ -191,11 +195,11 @@ void appendEngine(std::vector<PipelineNode>& out, const EndpointSnapshot& endpoi
     };
 
     if (capture) {
-        out.push_back(efxNode(endpoint, probes, exclusive));
+        out.push_back(efxNode(endpoint, {}, exclusive));
         pushSfxMfxSrc();
     } else {
         pushSfxMfxSrc();
-        out.push_back(efxNode(endpoint, probes, exclusive));
+        out.push_back(efxNode(endpoint, {}, exclusive));
     }
 }
 

--- a/src/core/PipelineGraph.h
+++ b/src/core/PipelineGraph.h
@@ -83,6 +83,7 @@ struct ProbeSlice {
     std::string label;
     bool raw = false;
     std::vector<AdvertisedEffect> effects;
+    std::string error;
 };
 
 const char* observationKindName(ObservationKind kind);

--- a/src/core/SharedProbe.cpp
+++ b/src/core/SharedProbe.cpp
@@ -1,0 +1,227 @@
+#include "SharedProbe.h"
+#include "AudioFormatStr.h"
+#include "ComUtil.h"
+#include "Log.h"
+#include "StreamInit.h"
+#include "WasapiStream.h"
+#include <audioclient.h>
+#include <mmdeviceapi.h>
+#include <ksmedia.h>
+#include <cstring>
+
+namespace wa {
+namespace {
+
+std::string guidToName(const GUID& id) {
+    struct Row { GUID g; const char* name; };
+    static const Row kRows[] = {
+        {AUDIO_EFFECT_TYPE_ACOUSTIC_ECHO_CANCELLATION, "Acoustic Echo Cancellation"},
+        {AUDIO_EFFECT_TYPE_NOISE_SUPPRESSION, "Noise Suppression"},
+        {AUDIO_EFFECT_TYPE_AUTOMATIC_GAIN_CONTROL, "Automatic Gain Control"},
+        {AUDIO_EFFECT_TYPE_BEAMFORMING, "Beam Forming"},
+        {AUDIO_EFFECT_TYPE_CONSTANT_TONE_REMOVAL, "Constant Tone Removal"},
+        {AUDIO_EFFECT_TYPE_EQUALIZER, "Equalizer"},
+        {AUDIO_EFFECT_TYPE_LOUDNESS_EQUALIZER, "Loudness Equalizer"},
+        {AUDIO_EFFECT_TYPE_BASS_BOOST, "Bass Boost"},
+        {AUDIO_EFFECT_TYPE_VIRTUAL_SURROUND, "Virtual Surround"},
+        {AUDIO_EFFECT_TYPE_VIRTUAL_HEADPHONES, "Virtual Headphones"},
+        {AUDIO_EFFECT_TYPE_SPEAKER_FILL, "Speaker Fill"},
+        {AUDIO_EFFECT_TYPE_ROOM_CORRECTION, "Room Correction"},
+        {AUDIO_EFFECT_TYPE_BASS_MANAGEMENT, "Bass Management"},
+        {AUDIO_EFFECT_TYPE_ENVIRONMENTAL_EFFECTS, "Environmental Effects"},
+        {AUDIO_EFFECT_TYPE_SPEAKER_PROTECTION, "Speaker Protection"},
+        {AUDIO_EFFECT_TYPE_SPEAKER_COMPENSATION, "Speaker Compensation"},
+        {AUDIO_EFFECT_TYPE_DYNAMIC_RANGE_COMPRESSION, "Dynamic Range Compression"},
+#ifdef AUDIO_EFFECT_TYPE_DEEP_NOISE_SUPPRESSION
+        {AUDIO_EFFECT_TYPE_DEEP_NOISE_SUPPRESSION, "Deep Noise Suppression"},
+#endif
+    };
+    for (const auto& row : kRows) {
+        if (InlineIsEqualGUID(row.g, id)) return row.name;
+    }
+    wchar_t w[64] = {};
+    const int n = StringFromGUID2(id, w, 64);
+    if (n <= 1) return "Unknown effect";
+    std::string s;
+    s.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n - 1; ++i) s += static_cast<char>(w[i]);
+    return s;
+}
+
+class WasapiSharedProbeHost : public SharedProbeHost {
+public:
+    WasapiSharedProbeHost(DataFlow flow, DeviceId id) : flow_(flow), id_(std::move(id)) {}
+
+    Result open(const StreamParams& params) override {
+        close();
+        WA_LOG(wa::log::Level::Info, "SharedProbe", "open",
+               std::string(flow_ == DataFlow::Capture ? "capture" : "render") +
+                   " id=" + wa::narrowAscii(id_),
+               "start");
+
+        ComPtr<IMMDeviceEnumerator> e;
+        HRESULT hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                                      __uuidof(IMMDeviceEnumerator),
+                                      reinterpret_cast<void**>(e.GetAddressOf()));
+        WA_LOG(wa::log::Level::Debug, "SharedProbe", "CoCreateInstance(MMDeviceEnumerator)", "",
+               wa::log::hrName(hr));
+        if (FAILED(hr)) {
+            WA_LOG(wa::log::Level::Err, "SharedProbe", "CoCreateInstance(MMDeviceEnumerator)", "",
+                   wa::log::hrName(hr));
+            return HrToResult(hr, "SharedProbe: CoCreateInstance");
+        }
+
+        const EDataFlow ef = flow_ == DataFlow::Capture ? eCapture : eRender;
+        hr = id_.empty() ? e->GetDefaultAudioEndpoint(ef, eConsole, device_.GetAddressOf())
+                         : e->GetDevice(id_.c_str(), device_.GetAddressOf());
+        WA_LOG(wa::log::Level::Debug, "SharedProbe",
+               id_.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+               wa::narrowAscii(id_), wa::log::hrName(hr));
+        if (FAILED(hr)) {
+            WA_LOG(wa::log::Level::Err, "SharedProbe",
+                   id_.empty() ? "GetDefaultAudioEndpoint" : "GetDevice",
+                   wa::narrowAscii(id_), wa::log::hrName(hr));
+            return HrToResult(hr, "SharedProbe: GetDevice");
+        }
+
+        hr = device_->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr,
+                               reinterpret_cast<void**>(client_.GetAddressOf()));
+        WA_LOG(wa::log::Level::Debug, "SharedProbe", "Activate(IAudioClient)", "",
+               wa::log::hrName(hr));
+        if (FAILED(hr)) {
+            WA_LOG(wa::log::Level::Err, "SharedProbe", "Activate(IAudioClient)", "",
+                   wa::log::hrName(hr));
+            return HrToResult(hr, "SharedProbe: Activate(IAudioClient)");
+        }
+
+        if (params.anyClientProps()) {
+            AudioClientInitAdapter adapter(client_, device_.Get());
+            AudioClientProperties p{};
+            p.cbSize = sizeof(p);
+            p.bIsOffload = params.clientProperties.offload ? TRUE : FALSE;
+            p.eCategory = mapCategory(params.clientProperties.category);
+            p.Options = mapStreamOption(params.clientProperties.option);
+            hr = adapter.setClientProperties(p);
+            if (FAILED(hr)) {
+                WA_LOG(wa::log::Level::Err, "SharedProbe", "SetClientProperties", "",
+                       wa::log::hrName(hr));
+                return HrToResult(hr, "SharedProbe: SetClientProperties");
+            }
+        }
+
+        AudioClientInitAdapter adapter(client_, device_.Get());
+        StreamInitRequest req;
+        req.params = params;
+        req.direction = flow_ == DataFlow::Capture ? StreamInitDirection::Capture
+                                                   : StreamInitDirection::Render;
+        StreamInitOutcome out;
+        Result r = streamInitShared(adapter, req, out);
+        if (!r) return r;
+        WA_LOG(wa::log::Level::Info, "SharedProbe", "Initialize(shared)",
+               "fmt=" + wa::formatAudio(out.actualFormat) + " no Start", "ok");
+        return Result::Ok();
+    }
+
+    Result readEffects(std::vector<AdvertisedEffect>& out) override {
+        out.clear();
+        if (!client_) return Result::Fail(-1, "SharedProbe: client not open");
+
+        ComPtr<IAudioEffectsManager> fx;
+        HRESULT hr = client_->GetService(__uuidof(IAudioEffectsManager),
+                                         reinterpret_cast<void**>(fx.GetAddressOf()));
+        WA_LOG(wa::log::Level::Debug, "SharedProbe", "GetService(IAudioEffectsManager)", "",
+               wa::log::hrName(hr));
+        if (FAILED(hr) || !fx) {
+            WA_LOG(wa::log::Level::Warn, "SharedProbe", "GetService(IAudioEffectsManager)", "",
+                   wa::log::hrName(FAILED(hr) ? hr : E_NOINTERFACE));
+            return Result::Ok();
+        }
+
+        AUDIO_EFFECT* effects = nullptr;
+        UINT32 n = 0;
+        hr = fx->GetAudioEffects(&effects, &n);
+        WA_LOG(wa::log::Level::Debug, "SharedProbe", "GetAudioEffects",
+               "n=" + std::to_string(n), wa::log::hrName(hr));
+        if (FAILED(hr)) {
+            WA_LOG(wa::log::Level::Warn, "SharedProbe", "GetAudioEffects", "", wa::log::hrName(hr));
+            return Result::Ok();
+        }
+        for (UINT32 i = 0; i < n; ++i) {
+            AdvertisedEffect a;
+            a.typeName = guidToName(effects[i].id);
+            a.on = effects[i].state == AUDIO_EFFECT_STATE_ON;
+            a.canSetState = effects[i].canSetState != FALSE;
+            out.push_back(std::move(a));
+        }
+        CoTaskMemFree(effects);
+        return Result::Ok();
+    }
+
+    void close() override {
+        if (client_) {
+            WA_LOG(wa::log::Level::Info, "SharedProbe", "close", "", "ok");
+        }
+        client_.Reset();
+        device_.Reset();
+    }
+
+private:
+    DataFlow flow_;
+    DeviceId id_;
+    ComPtr<IMMDevice> device_;
+    ComPtr<IAudioClient> client_;
+};
+
+}  // namespace
+
+std::vector<SharedProbeRecipe> sharedProbeRecipes() {
+    SharedProbeRecipe def;
+    def.label = "Default";
+
+    SharedProbeRecipe comm;
+    comm.label = "Communications";
+    comm.params.clientProperties.enabled = true;
+    comm.params.clientProperties.category = AudioCategory::Communications;
+    comm.params.clientProperties.option = StreamOption::None;
+
+    SharedProbeRecipe raw;
+    raw.label = "Raw";
+    raw.raw = true;
+    raw.params.clientProperties.enabled = true;
+    raw.params.clientProperties.category = AudioCategory::Other;
+    raw.params.clientProperties.option = StreamOption::Raw;
+
+    return {def, comm, raw};
+}
+
+Result runSharedProbes(SharedProbeHost& host, bool exclusive, std::vector<ProbeSlice>& out) {
+    if (exclusive) {
+        WA_LOG(wa::log::Level::Warn, "SharedProbe", "runSharedProbes", "", "exclusive refused");
+        return Result::Fail(-1, "exclusive probe refused");
+    }
+    out.clear();
+    for (const auto& recipe : sharedProbeRecipes()) {
+        ProbeSlice slice;
+        slice.label = recipe.label;
+        slice.raw = recipe.raw;
+        Result r = host.open(recipe.params);
+        if (r) {
+            r = host.readEffects(slice.effects);
+            if (!r) slice.error = r.message;
+        } else {
+            slice.error = r.message;
+        }
+        host.close();
+        out.push_back(std::move(slice));
+    }
+    return Result::Ok();
+}
+
+Result probeEndpointShared(DataFlow flow, const DeviceId& id, std::vector<ProbeSlice>& out) {
+    ComInitGuard com;
+    if (!com.ok()) return HrToResult(com.hr, "SharedProbe: CoInitializeEx");
+    WasapiSharedProbeHost host(flow, id);
+    return runSharedProbes(host, false, out);
+}
+
+}  // namespace wa

--- a/src/core/SharedProbe.h
+++ b/src/core/SharedProbe.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "IAudioBackend.h"
+#include "PipelineGraph.h"
+#include "Result.h"
+#include "StreamParams.h"
+
+namespace wa {
+
+struct SharedProbeRecipe {
+    std::string label;
+    bool raw = false;
+    StreamParams params;
+};
+
+std::vector<SharedProbeRecipe> sharedProbeRecipes();
+
+class SharedProbeHost {
+public:
+    virtual ~SharedProbeHost() = default;
+    virtual Result open(const StreamParams& params) = 0;
+    virtual Result readEffects(std::vector<AdvertisedEffect>& out) = 0;
+    virtual void close() = 0;
+};
+
+// exclusive=true fails without calling the host. Recipe open failures still
+// append a slice so the caller can keep the Live session radar.
+Result runSharedProbes(SharedProbeHost& host, bool exclusive, std::vector<ProbeSlice>& out);
+
+Result probeEndpointShared(DataFlow flow, const DeviceId& id, std::vector<ProbeSlice>& out);
+
+}  // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -179,6 +179,8 @@ void AppUi::refreshPipelineSessions() {
             break;
         }
     }
+    if (pipelineSelected_ < 0)
+        pipelineProbes_.clear();
     rebuildPipelineGraph();
 }
 
@@ -194,7 +196,42 @@ void AppUi::rebuildPipelineGraph() {
     wa::Result r = endpointGraphReader_.snapshot(flow, utow(session.deviceId.c_str()), snap);
     if (!r)
         logLines_.push_back("pipeline endpoint snapshot failed: " + r.message);
-    pipelineNodes_ = wa::assemblePipeline(session, snap, {}, {});
+    pipelineNodes_ = wa::assemblePipeline(session, snap, {}, pipelineProbes_);
+}
+
+void AppUi::runPipelineProbe() {
+    if (pipelineProbing_) return;
+    if (pipelineSelected_ < 0 || pipelineSelected_ >= (int)pipelineSessions_.size())
+        return;
+
+    const auto sessionsCopy = pipelineSessions_;
+    const int selected = pipelineSelected_;
+    const wa::LiveSessionView session = pipelineSessions_[(size_t)pipelineSelected_];
+    const wa::DataFlow flow =
+        session.flow == wa::PipelineFlow::Capture ? wa::DataFlow::Capture : wa::DataFlow::Render;
+
+    pipelineProbing_ = true;
+    std::vector<wa::ProbeSlice> slices;
+    wa::Result r = wa::probeEndpointShared(flow, utow(session.deviceId.c_str()), slices);
+    pipelineProbing_ = false;
+
+    if (pipelineSessions_.size() != sessionsCopy.size() || pipelineSelected_ != selected) {
+        logLines_.push_back("pipeline probe ignored: Live session list changed");
+        return;
+    }
+    if (!r) {
+        logLines_.push_back("pipeline probe failed: " + r.message);
+        rebuildPipelineGraph();
+        return;
+    }
+    pipelineProbes_ = std::move(slices);
+    int failed = 0;
+    for (const auto& s : pipelineProbes_)
+        if (!s.error.empty()) ++failed;
+    logLines_.push_back(failed ? ("pipeline probe finished with " + std::to_string(failed) +
+                                  " recipe error(s)")
+                               : "pipeline probe completed");
+    rebuildPipelineGraph();
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -725,6 +762,12 @@ void AppUi::drawPipelinePage() {
     if (ImGui::Button(wa::ui_text::kPipelineRefresh))
         refreshPipelineSessions();
     ImGui::SameLine();
+    const bool canProbe = pipelineSelected_ >= 0 && !pipelineProbing_;
+    if (!canProbe) ImGui::BeginDisabled();
+    if (ImGui::Button(wa::ui_text::kPipelineProbe))
+        runPipelineProbe();
+    if (!canProbe) ImGui::EndDisabled();
+    ImGui::SameLine();
     if (ImGui::Checkbox(wa::ui_text::kPipelineShowSelf, &pipelineShowSelf_))
         refreshPipelineSessions();
 
@@ -750,6 +793,8 @@ void AppUi::drawPipelinePage() {
             std::snprintf(label, sizeof(label), "%s##ps%d",
                           s.flow == wa::PipelineFlow::Capture ? "capture" : "render", i);
             if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns)) {
+                if (pipelineSelected_ != i)
+                    pipelineProbes_.clear();
                 pipelineSelected_ = i;
                 rebuildPipelineGraph();
             }

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -14,6 +14,7 @@
 #include "LiveSessionEnumerator.h"
 #include "MonitorEngine.h"
 #include "PipelineGraph.h"
+#include "SharedProbe.h"
 #include "Spectrogram.h"
 #include "TrackScopeReader.h"
 
@@ -53,6 +54,7 @@ private:
     void refreshApplicationLoopbackSessions();
     void refreshPipelineSessions();
     void rebuildPipelineGraph();
+    void runPipelineProbe();
     void drawMonitorPage();
     void drawPipelinePage();
     void drawLoopbackPage();
@@ -138,6 +140,8 @@ private:
     int  pipelineSelected_ = -1;
     std::vector<wa::LiveSessionView> pipelineSessions_;
     std::vector<wa::PipelineNode> pipelineNodes_;
+    std::vector<wa::ProbeSlice> pipelineProbes_;
+    bool pipelineProbing_ = false;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -62,5 +62,6 @@ inline constexpr const char* kPipelineEmpty =
 inline constexpr const char* kPipelineSelectHint =
     "Select a Live session to see its processing graph.";
 inline constexpr const char* kPipelineGraph = "Processing graph";
+inline constexpr const char* kPipelineProbe = "Probe this device";
 
 } // namespace wa::ui_text

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(WinAudioTests
     test_audio_session_enumerator.cpp
     test_pipeline_graph.cpp
     test_live_session_list.cpp
+    test_shared_probe.cpp
 
     test_cli_options.cpp
     test_dump_ui.cpp

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -81,4 +81,5 @@ TEST(PipelineUiText, ExposesPipelineTabControls) {
     EXPECT_STREQ(wa::ui_text::kPipelineSelectHint,
                  "Select a Live session to see its processing graph.");
     EXPECT_STREQ(wa::ui_text::kPipelineGraph, "Processing graph");
+    EXPECT_STREQ(wa::ui_text::kPipelineProbe, "Probe this device");
 }

--- a/src/tests/test_shared_probe.cpp
+++ b/src/tests/test_shared_probe.cpp
@@ -1,0 +1,125 @@
+#include <gtest/gtest.h>
+#include "SharedProbe.h"
+
+using namespace wa;
+
+namespace {
+
+class RecordingHost : public SharedProbeHost {
+public:
+    int opens = 0;
+    int reads = 0;
+    int closes = 0;
+    std::vector<StreamParams> opened;
+    Result openResult = Result::Ok();
+    std::vector<AdvertisedEffect> effects = {{"Deep Noise Suppression", true, true}};
+
+    Result open(const StreamParams& params) override {
+        ++opens;
+        opened.push_back(params);
+        return openResult;
+    }
+    Result readEffects(std::vector<AdvertisedEffect>& out) override {
+        ++reads;
+        out = effects;
+        return Result::Ok();
+    }
+    void close() override { ++closes; }
+};
+
+}  // namespace
+
+TEST(SharedProbe, RecipesAreDefaultCommunicationsAndRaw) {
+    const auto recipes = sharedProbeRecipes();
+    ASSERT_EQ(recipes.size(), 3u);
+    EXPECT_EQ(recipes[0].label, "Default");
+    EXPECT_FALSE(recipes[0].raw);
+    EXPECT_TRUE(recipes[0].params.isDefault());
+
+    EXPECT_EQ(recipes[1].label, "Communications");
+    EXPECT_FALSE(recipes[1].raw);
+    EXPECT_TRUE(recipes[1].params.clientProperties.enabled);
+    EXPECT_EQ(recipes[1].params.clientProperties.category, AudioCategory::Communications);
+    EXPECT_EQ(recipes[1].params.clientProperties.option, StreamOption::None);
+
+    EXPECT_EQ(recipes[2].label, "Raw");
+    EXPECT_TRUE(recipes[2].raw);
+    EXPECT_TRUE(recipes[2].params.clientProperties.enabled);
+    EXPECT_EQ(recipes[2].params.clientProperties.option, StreamOption::Raw);
+}
+
+TEST(SharedProbe, ExclusiveFailsWithoutOpeningHost) {
+    RecordingHost host;
+    std::vector<ProbeSlice> slices = {{"stale", false, {}}};
+    const Result r = runSharedProbes(host, true, slices);
+    EXPECT_FALSE(r);
+    EXPECT_NE(r.message.find("exclusive"), std::string::npos);
+    EXPECT_EQ(host.opens, 0);
+    EXPECT_EQ(host.reads, 0);
+    EXPECT_EQ(host.closes, 0);
+    ASSERT_EQ(slices.size(), 1u);
+    EXPECT_EQ(slices[0].label, "stale");
+}
+
+TEST(SharedProbe, SharedRunsAllRecipesAndMarksProbedOnJoin) {
+    RecordingHost host;
+    std::vector<ProbeSlice> slices;
+    const Result r = runSharedProbes(host, false, slices);
+    EXPECT_TRUE(r);
+    EXPECT_EQ(host.opens, 3);
+    EXPECT_EQ(host.reads, 3);
+    EXPECT_EQ(host.closes, 3);
+    ASSERT_EQ(slices.size(), 3u);
+    EXPECT_EQ(slices[0].label, "Default");
+    EXPECT_EQ(slices[2].label, "Raw");
+    EXPECT_TRUE(slices[2].raw);
+
+    LiveSessionView session;
+    session.processId = 1;
+    session.processName = "chrome.exe";
+    session.flow = PipelineFlow::Capture;
+    EndpointSnapshot ep;
+    const auto nodes = assemblePipeline(session, ep, {}, slices);
+    bool sawProbed = false;
+    for (const auto& n : nodes) {
+        for (const auto& p : n.params) {
+            if (p.key == "Default" || p.key == "Communications" || p.key == "Raw") {
+                EXPECT_EQ(p.kind, ObservationKind::Probed);
+                EXPECT_NE(p.kind, ObservationKind::Observed);
+                sawProbed = true;
+            }
+        }
+    }
+    EXPECT_TRUE(sawProbed);
+}
+
+TEST(SharedProbe, OpenFailureStillClosesAndKeepsOtherRecipes) {
+    RecordingHost host;
+    host.openResult = Result::Fail(-1, "device in exclusive");
+    std::vector<ProbeSlice> slices;
+    const Result r = runSharedProbes(host, false, slices);
+    EXPECT_TRUE(r);
+    EXPECT_EQ(host.opens, 3);
+    EXPECT_EQ(host.reads, 0);
+    EXPECT_EQ(host.closes, 3);
+    ASSERT_EQ(slices.size(), 3u);
+    EXPECT_TRUE(slices[0].effects.empty());
+    EXPECT_EQ(slices[0].error, "device in exclusive");
+
+    LiveSessionView session;
+    session.processId = 1;
+    session.processName = "chrome.exe";
+    session.flow = PipelineFlow::Capture;
+    const auto nodes = assemblePipeline(session, {}, {}, slices);
+    bool sawUnknown = false;
+    for (const auto& n : nodes) {
+        for (const auto& p : n.params) {
+            if (p.key == "Default") {
+                EXPECT_EQ(p.kind, ObservationKind::Unknown);
+                EXPECT_EQ(p.value, "device in exclusive");
+                sawUnknown = true;
+            }
+        }
+    }
+    EXPECT_TRUE(sawUnknown);
+}


### PR DESCRIPTION
## What / Why

The Pipeline tab could list Live sessions and draw an inferred endpoint graph, but it could not query what Shared-mode effect types WASAPI advertises for that endpoint. This PR adds an on-demand **Shared probe** (Default / Communications / Raw): Initialize without Start, then join advertised effects onto the graph as **Probed**.

Closes #65. Parent: #63. Design: `docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md`.

## How

- `probeEndpointShared` runs three Shared recipes through a `SharedProbeHost` seam (`Activate` + `SetClientProperties` + `streamInitShared` + `GetAudioEffects`). Exclusive is refused without opening a client.
- Recipe errors become `ProbeSlice.error` and assemble as **Unknown**; they never look like Observed APO instances.
- Probe close is always attempted so a failed probe does not take down the Live session radar.
- GUI: **Probe this device** on the Pipeline tab; Exclusive selection never issues a probe.

## Testing

- Local Debug: `ctest -C Debug` **278/278 passed**.
- Targeted: `SharedProbe.*` (recipes, exclusive fail-closed, error to Unknown, empty probes do not invent Probed layers).
- Release ctest was not re-run in this session; CI matrix covers Debug + Release.
- Device-free gtests do not open a real WASAPI stream (host is a fake).
- GUI: no screenshot in this PR. Real-device smoke (Probe on a Live session endpoint) not recorded here.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug ctest passed locally; Release covered by CI
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above