### PR TITLE
feat(gui): overlay ETW hints on selected Live session

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,7 +21,8 @@ add_library(WinAudioCore STATIC
     LiveSessionEnumerator.cpp
     EndpointGraphReader.cpp
     SharedProbe.cpp
+    EtwInitialize.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi spdlog)
+target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi tdh advapi32 spdlog)
 wa_set_project_warnings(WinAudioCore)

--- a/src/core/EtwInitialize.cpp
+++ b/src/core/EtwInitialize.cpp
@@ -1,0 +1,536 @@
+#include "EtwInitialize.h"
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <tdh.h>
+#include <objbase.h>
+
+#include "AudioFormatStr.h"
+#include "ComUtil.h"
+#include "Log.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace wa {
+namespace {
+
+std::string lowerCopy(std::string s) {
+    for (char& c : s)
+        c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+    return s;
+}
+
+bool containsI(const std::string& hay, const std::string& needle) {
+    if (needle.empty()) return true;
+    if (hay.size() < needle.size()) return false;
+    for (size_t i = 0; i + needle.size() <= hay.size(); ++i) {
+        if (_strnicmp(hay.c_str() + i, needle.c_str(), needle.size()) == 0)
+            return true;
+    }
+    return false;
+}
+
+bool deviceIdsAlign(const std::string& eventId, const std::string& sessionId) {
+    if (eventId.empty() || sessionId.empty()) return false;
+    return _stricmp(eventId.c_str(), sessionId.c_str()) == 0;
+}
+
+std::optional<int32_t> parseI32(const std::string& s) {
+    if (s.empty()) return std::nullopt;
+    char* end = nullptr;
+    const long v = strtol(s.c_str(), &end, 0);
+    if (end == s.c_str() || *end != '\0') return std::nullopt;
+    return static_cast<int32_t>(v);
+}
+
+std::optional<bool> parseBool(const std::string& s) {
+    const std::string l = lowerCopy(s);
+    if (l == "1" || l == "true" || l == "yes") return true;
+    if (l == "0" || l == "false" || l == "no") return false;
+    if (const auto n = parseI32(s)) return *n != 0;
+    return std::nullopt;
+}
+
+const char* categoryNameFromValue(int v) {
+    switch (v) {
+        case 0:  return "Other";
+        case 1:  return "ForegroundOnlyMedia";
+        case 2:  return "BackgroundCapableMedia";
+        case 3:  return "Communications";
+        case 4:  return "Alerts";
+        case 5:  return "SoundEffects";
+        case 6:  return "GameEffects";
+        case 7:  return "GameMedia";
+        case 8:  return "GameChat";
+        case 9:  return "Speech";
+        case 10: return "Movie";
+        case 11: return "Media";
+        case 12: return "FarFieldSpeech";
+        case 13: return "UniformSpeech";
+        case 14: return "VoiceTyping";
+        default: return nullptr;
+    }
+}
+
+std::string mapCategory(const std::string& raw) {
+    if (const auto n = parseI32(raw)) {
+        if (const char* name = categoryNameFromValue(*n)) return name;
+        return std::to_string(*n);
+    }
+    return raw;
+}
+
+int64_t fileTimeToUnixMs(const FILETIME& ft) {
+    ULARGE_INTEGER u;
+    u.LowPart = ft.dwLowDateTime;
+    u.HighPart = ft.dwHighDateTime;
+    return static_cast<int64_t>(u.QuadPart / 10000ULL) - 11644473600000LL;
+}
+
+void mergeFields(EtwInitializeHint& hint, const EtwEventFields& e) {
+    hint.present = true;
+    if (e.category) hint.category = e.category;
+    if (e.raw) hint.raw = e.raw;
+    if (e.matchFormat) hint.matchFormat = e.matchFormat;
+    if (e.exclusive) hint.exclusive = e.exclusive;
+    if (e.hresult) hint.hresult = e.hresult;
+}
+
+Result win32Result(ULONG err, const char* where) {
+    if (err == ERROR_SUCCESS) return Result::Ok();
+    return HrToResult(HRESULT_FROM_WIN32(err), where);
+}
+
+const GUID kMicrosoftWindowsAudio = {
+    0xAE4BD3BE, 0xF36F, 0x45B6, {0x8D, 0x21, 0xBD, 0xD6, 0xFB, 0x83, 0x28, 0x53}};
+const GUID kMicrosoftWindowsAudioClient = {
+    0x6E7B1892, 0x5288, 0x5FE5, {0x8F, 0x34, 0xE3, 0xB0, 0xDC, 0x67, 0x1F, 0xD2}};
+
+bool interestingAudioEvent(USHORT id) {
+    return id == 24 || id == 25 || id == 123 || id == 125 || id == 127;
+}
+
+std::string wideToUtf8(const wchar_t* w, int nchars = -1) {
+    if (!w || !*w) return {};
+    const int n = WideCharToMultiByte(CP_UTF8, 0, w, nchars, nullptr, 0, nullptr, nullptr);
+    if (n <= 0) return {};
+    std::string s(static_cast<size_t>(n), 0);
+    WideCharToMultiByte(CP_UTF8, 0, w, nchars, s.data(), n, nullptr, nullptr);
+    if (!s.empty() && s.back() == '\0') s.pop_back();
+    return s;
+}
+
+std::string guidString(const GUID& g) {
+    wchar_t w[64] = {};
+    const int n = StringFromGUID2(g, w, 64);
+    if (n <= 1) return {};
+    return wa::narrowAscii(std::wstring(w, static_cast<size_t>(n - 1)));
+}
+
+std::string tdhPropertyString(PEVENT_RECORD rec, PTRACE_EVENT_INFO info, USHORT index) {
+    const EVENT_PROPERTY_INFO& epi = info->EventPropertyInfoArray[index];
+    if ((epi.Flags & PropertyParamCount) != 0 || (epi.Flags & PropertyStruct) != 0)
+        return {};
+    const wchar_t* name = reinterpret_cast<const wchar_t*>(
+        reinterpret_cast<const BYTE*>(info) + epi.NameOffset);
+    PROPERTY_DATA_DESCRIPTOR desc{};
+    desc.PropertyName = reinterpret_cast<ULONGLONG>(name);
+    desc.ArrayIndex = ULONG_MAX;
+    ULONG sz = 0;
+    ULONG st = TdhGetPropertySize(rec, 0, nullptr, 1, &desc, &sz);
+    if (st != ERROR_SUCCESS || sz == 0) return {};
+    std::vector<BYTE> buf(sz);
+    st = TdhGetProperty(rec, 0, nullptr, 1, &desc, sz, buf.data());
+    if (st != ERROR_SUCCESS) return {};
+
+    const USHORT inType = epi.nonStructType.InType;
+    switch (inType) {
+        case TDH_INTYPE_INT8:
+            return std::to_string(static_cast<int>(static_cast<int8_t>(buf[0])));
+        case TDH_INTYPE_UINT8:
+            return std::to_string(static_cast<unsigned>(buf[0]));
+        case TDH_INTYPE_INT16:
+            return std::to_string(*reinterpret_cast<int16_t*>(buf.data()));
+        case TDH_INTYPE_UINT16:
+            return std::to_string(*reinterpret_cast<uint16_t*>(buf.data()));
+        case TDH_INTYPE_INT32:
+            return std::to_string(*reinterpret_cast<int32_t*>(buf.data()));
+        case TDH_INTYPE_UINT32:
+            return std::to_string(*reinterpret_cast<uint32_t*>(buf.data()));
+        case TDH_INTYPE_INT64:
+            return std::to_string(*reinterpret_cast<int64_t*>(buf.data()));
+        case TDH_INTYPE_UINT64:
+            return std::to_string(*reinterpret_cast<uint64_t*>(buf.data()));
+        case TDH_INTYPE_FLOAT:
+            return std::to_string(*reinterpret_cast<float*>(buf.data()));
+        case TDH_INTYPE_BOOLEAN:
+            return (*reinterpret_cast<uint32_t*>(buf.data()) != 0) ? "1" : "0";
+        case TDH_INTYPE_UNICODESTRING:
+            return wideToUtf8(reinterpret_cast<const wchar_t*>(buf.data()));
+        case TDH_INTYPE_ANSISTRING:
+            return reinterpret_cast<const char*>(buf.data());
+        case TDH_INTYPE_GUID:
+            if (sz >= sizeof(GUID))
+                return guidString(*reinterpret_cast<const GUID*>(buf.data()));
+            return {};
+        default:
+            break;
+    }
+    return {};
+}
+
+bool decodeRecord(PEVENT_RECORD rec, EtwEventFields& out) {
+    ULONG bufSize = 0;
+    ULONG st = TdhGetEventInformation(rec, 0, nullptr, nullptr, &bufSize);
+    if (st != ERROR_INSUFFICIENT_BUFFER) return false;
+    std::vector<BYTE> raw(bufSize);
+    auto* info = reinterpret_cast<PTRACE_EVENT_INFO>(raw.data());
+    st = TdhGetEventInformation(rec, 0, nullptr, info, &bufSize);
+    if (st != ERROR_SUCCESS) {
+        WA_LOG(wa::log::Level::Warn, "EtwInit", "TdhGetEventInformation",
+               "id=" + std::to_string(rec->EventHeader.EventDescriptor.Id),
+               wa::log::hrName(HRESULT_FROM_WIN32(st)));
+        return false;
+    }
+
+    const bool audioProv = InlineIsEqualGUID(rec->EventHeader.ProviderId, kMicrosoftWindowsAudio);
+    const bool clientProv =
+        InlineIsEqualGUID(rec->EventHeader.ProviderId, kMicrosoftWindowsAudioClient);
+    if (!audioProv && !clientProv) return false;
+    if (audioProv && !interestingAudioEvent(rec->EventHeader.EventDescriptor.Id))
+        return false;
+
+    std::wstring eventName;
+    if (info->EventNameOffset) {
+        eventName = reinterpret_cast<const wchar_t*>(
+            reinterpret_cast<const BYTE*>(info) + info->EventNameOffset);
+    }
+    if (clientProv && !eventName.empty() &&
+        _wcsicmp(eventName.c_str(), L"AudioClientInitialize") != 0) {
+        return false;
+    }
+
+    std::vector<std::pair<std::string, std::string>> props;
+    props.reserve(info->TopLevelPropertyCount);
+    for (USHORT i = 0; i < info->TopLevelPropertyCount; ++i) {
+        const EVENT_PROPERTY_INFO& epi = info->EventPropertyInfoArray[i];
+        const wchar_t* wname = reinterpret_cast<const wchar_t*>(
+            reinterpret_cast<const BYTE*>(info) + epi.NameOffset);
+        const std::string name = wideToUtf8(wname);
+        const std::string value = tdhPropertyString(rec, info, i);
+        if (!name.empty() && !value.empty())
+            props.emplace_back(name, value);
+    }
+
+    FILETIME ft{};
+    ft.dwLowDateTime = rec->EventHeader.TimeStamp.LowPart;
+    ft.dwHighDateTime = rec->EventHeader.TimeStamp.HighPart;
+    out = etwFieldsFromProperties(rec->EventHeader.ProcessId, fileTimeToUnixMs(ft), props);
+    return out.processId != 0 || out.category || out.raw || out.matchFormat || out.exclusive ||
+           out.hresult;
+}
+
+struct SessionProps {
+    EVENT_TRACE_PROPERTIES props;
+    wchar_t loggerName[128];
+};
+
+void fillSessionProps(SessionProps& p, const wchar_t* name) {
+    ZeroMemory(&p, sizeof(p));
+    p.props.Wnode.BufferSize = sizeof(SessionProps);
+    p.props.Wnode.Flags = WNODE_FLAG_TRACED_GUID;
+    p.props.Wnode.ClientContext = 2;  // system time (FILETIME)
+    p.props.LogFileMode = EVENT_TRACE_REAL_TIME_MODE;
+    p.props.LoggerNameOffset = static_cast<ULONG>(offsetof(SessionProps, loggerName));
+    p.props.BufferSize = 64;
+    p.props.MinimumBuffers = 2;
+    p.props.MaximumBuffers = 8;
+    p.props.FlushTimer = 1;
+    wcsncpy_s(p.loggerName, name, _TRUNCATE);
+}
+
+}  // namespace
+
+const char* etwWatchStatusText(EtwWatchStatus status) {
+    switch (status) {
+        case EtwWatchStatus::Listening:   return "ETW listening";
+        case EtwWatchStatus::Unavailable: return "ETW unavailable";
+        case EtwWatchStatus::Stopped:     return "ETW stopped";
+    }
+    return "ETW unavailable";
+}
+
+int64_t etwNowMs() {
+    FILETIME ft{};
+    GetSystemTimeAsFileTime(&ft);
+    return fileTimeToUnixMs(ft);
+}
+
+EtwEventFields etwFieldsFromProperties(
+    uint32_t headerPid,
+    int64_t timeMs,
+    const std::vector<std::pair<std::string, std::string>>& props) {
+    EtwEventFields f;
+    f.processId = headerPid;
+    f.timeMs = timeMs;
+    for (const auto& kv : props) {
+        const std::string key = lowerCopy(kv.first);
+        const std::string& val = kv.second;
+        if (key == "pid" || key == "processid") {
+            if (const auto n = parseI32(val)) {
+                if (*n > 0) f.processId = static_cast<uint32_t>(*n);
+            }
+        } else if (key == "deviceid" || key == "endpointid" || key == "endpoint" ||
+                   key == "device" || key == "endpointidstring") {
+            if (f.deviceId.empty()) f.deviceId = val;
+        } else if (key == "category" || key == "audiocategory") {
+            f.category = mapCategory(val);
+        } else if (key == "raw") {
+            f.raw = parseBool(val);
+        } else if (key == "matchformat" || key == "match_format") {
+            f.matchFormat = parseBool(val);
+        } else if (key == "hresult" || key == "hr" || key == "result") {
+            f.hresult = parseI32(val);
+        } else if (key == "sharemode" || key == "exclusive") {
+            const std::string l = lowerCopy(val);
+            if (containsI(l, "excl")) {
+                f.exclusive = true;
+            } else if (const auto n = parseI32(val)) {
+                f.exclusive = (*n != 0);
+            } else {
+                const auto b = parseBool(val);
+                if (b) f.exclusive = b;
+            }
+        }
+    }
+    return f;
+}
+
+EtwInitializeHint matchEtwInitialize(
+    const LiveSessionView& session,
+    const std::vector<EtwEventFields>& events,
+    int64_t nowMs,
+    int64_t windowMs) {
+    EtwInitializeHint hint;
+    if (session.processId == 0 || windowMs < 0) return hint;
+
+    std::vector<const EtwEventFields*> hits;
+    hits.reserve(events.size());
+    for (const auto& e : events) {
+        if (e.timeMs > nowMs + 1000) continue;
+        if (nowMs - e.timeMs > windowMs) continue;
+        const bool pidHit = e.processId != 0 && e.processId == session.processId;
+        const bool deviceParsed = !e.deviceId.empty();
+        const bool deviceHit = deviceParsed && deviceIdsAlign(e.deviceId, session.deviceId);
+        // PlaybackManager / AudioClientInitialize: PID (+ device when parsed).
+        // Performance 123/125/127 often run in the audio engine: no app PID,
+        // match by parsed endpoint id + time so RAW is not dropped.
+        if (pidHit) {
+            if (deviceParsed && !deviceHit) continue;
+        } else if (!deviceHit) {
+            continue;
+        }
+        hits.push_back(&e);
+    }
+    if (hits.empty()) return hint;
+
+    std::sort(hits.begin(), hits.end(),
+              [](const EtwEventFields* a, const EtwEventFields* b) {
+                  return a->timeMs < b->timeMs;
+              });
+    for (const auto* e : hits)
+        mergeFields(hint, *e);
+    return hint;
+}
+
+struct EtwInitializeWatch::Impl {
+    mutable std::mutex mu;
+    std::vector<EtwEventFields> events;
+    std::atomic<EtwWatchStatus> status{EtwWatchStatus::Stopped};
+    TRACEHANDLE session = 0;
+    TRACEHANDLE consumer = INVALID_PROCESSTRACE_HANDLE;
+    std::thread worker;
+    wchar_t name[128] = {};
+
+    void push(EtwEventFields e) {
+        const int64_t now = etwNowMs();
+        std::lock_guard<std::mutex> lock(mu);
+        events.push_back(std::move(e));
+        constexpr int64_t kRetainMs = 30000;
+        constexpr size_t kMaxEvents = 256;
+        const auto isOld = [&](const EtwEventFields& x) {
+            return now - x.timeMs > kRetainMs;
+        };
+        events.erase(std::remove_if(events.begin(), events.end(), isOld), events.end());
+        if (events.size() > kMaxEvents)
+            events.erase(events.begin(),
+                         events.begin() + static_cast<std::ptrdiff_t>(events.size() - kMaxEvents));
+    }
+
+    static VOID WINAPI onRecord(PEVENT_RECORD rec) {
+        if (!rec || !rec->UserContext) return;
+        auto* self = static_cast<Impl*>(rec->UserContext);
+        EtwEventFields f;
+        if (!decodeRecord(rec, f)) return;
+        self->push(std::move(f));
+    }
+
+    Result enableProviders() {
+        ULONG err = EnableTraceEx2(session, &kMicrosoftWindowsAudio, EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+                                   TRACE_LEVEL_INFORMATION, 0, 0, 0, nullptr);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "EnableTraceEx2(Microsoft-Windows-Audio)",
+               "", wa::log::hrName(HRESULT_FROM_WIN32(err)));
+        if (err != ERROR_SUCCESS) return win32Result(err, "EtwInit: EnableTraceEx2(Audio)");
+
+        err = EnableTraceEx2(session, &kMicrosoftWindowsAudioClient, EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+                             TRACE_LEVEL_VERBOSE, 0, 0, 0, nullptr);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "EnableTraceEx2(Microsoft.Windows.Audio.Client)",
+               "", wa::log::hrName(HRESULT_FROM_WIN32(err)));
+        if (err != ERROR_SUCCESS)
+            return win32Result(err, "EtwInit: EnableTraceEx2(Audio.Client)");
+        return Result::Ok();
+    }
+
+    void disableProviders() {
+        if (session == 0) return;
+        ULONG err = EnableTraceEx2(session, &kMicrosoftWindowsAudio,
+                                   EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, nullptr);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "EnableTraceEx2(disable Audio)", "",
+               wa::log::hrName(HRESULT_FROM_WIN32(err)));
+        err = EnableTraceEx2(session, &kMicrosoftWindowsAudioClient,
+                             EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, nullptr);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "EnableTraceEx2(disable Audio.Client)", "",
+               wa::log::hrName(HRESULT_FROM_WIN32(err)));
+    }
+
+    void stopSession() {
+        disableProviders();
+        if (consumer != INVALID_PROCESSTRACE_HANDLE) {
+            const ULONG err = CloseTrace(consumer);
+            WA_LOG(wa::log::Level::Debug, "EtwInit", "CloseTrace", "",
+                   wa::log::hrName(HRESULT_FROM_WIN32(err)));
+            consumer = INVALID_PROCESSTRACE_HANDLE;
+        }
+        if (worker.joinable()) worker.join();
+        if (name[0]) {
+            SessionProps p{};
+            fillSessionProps(p, name);
+            const ULONG err = ControlTraceW(session, name, &p.props, EVENT_TRACE_CONTROL_STOP);
+            if (err == ERROR_SUCCESS || err == ERROR_WMI_INSTANCE_NOT_FOUND) {
+                WA_LOG(wa::log::Level::Debug, "EtwInit", "ControlTrace(STOP)",
+                       wa::narrowAscii(name), wa::log::hrName(HRESULT_FROM_WIN32(err)));
+            } else {
+                WA_LOG(wa::log::Level::Warn, "EtwInit", "ControlTrace(STOP)",
+                       wa::narrowAscii(name), wa::log::hrName(HRESULT_FROM_WIN32(err)));
+            }
+        }
+        session = 0;
+    }
+};
+
+EtwInitializeWatch::EtwInitializeWatch() : impl_(std::make_unique<Impl>()) {}
+
+EtwInitializeWatch::~EtwInitializeWatch() { stop(); }
+
+Result EtwInitializeWatch::start() {
+    if (impl_->status.load() == EtwWatchStatus::Listening) return Result::Ok();
+    stop();
+
+    swprintf_s(impl_->name, L"WinAudioPplInit-%lu", GetCurrentProcessId());
+    SessionProps props{};
+    fillSessionProps(props, impl_->name);
+
+    ULONG err = StartTraceW(&impl_->session, impl_->name, &props.props);
+    WA_LOG(wa::log::Level::Debug, "EtwInit", "StartTrace", wa::narrowAscii(impl_->name),
+           wa::log::hrName(HRESULT_FROM_WIN32(err)));
+    if (err == ERROR_ALREADY_EXISTS) {
+        const ULONG stopErr = ControlTraceW(0, impl_->name, &props.props, EVENT_TRACE_CONTROL_STOP);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "ControlTrace(STOP leftover)",
+               wa::narrowAscii(impl_->name), wa::log::hrName(HRESULT_FROM_WIN32(stopErr)));
+        fillSessionProps(props, impl_->name);
+        err = StartTraceW(&impl_->session, impl_->name, &props.props);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "StartTrace(retry)", wa::narrowAscii(impl_->name),
+               wa::log::hrName(HRESULT_FROM_WIN32(err)));
+    }
+    if (err != ERROR_SUCCESS) {
+        impl_->status = EtwWatchStatus::Unavailable;
+        impl_->session = 0;
+        WA_LOG(wa::log::Level::Info, "EtwInit", "start", wa::narrowAscii(impl_->name),
+               "unavailable");
+        return win32Result(err, "EtwInit: StartTrace");
+    }
+
+    Result enabled = impl_->enableProviders();
+    if (!enabled) {
+        impl_->stopSession();
+        impl_->status = EtwWatchStatus::Unavailable;
+        WA_LOG(wa::log::Level::Info, "EtwInit", "start", enabled.message, "unavailable");
+        return enabled;
+    }
+
+    EVENT_TRACE_LOGFILEW log{};
+    log.LoggerName = impl_->name;
+    log.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD;
+    log.EventRecordCallback = &Impl::onRecord;
+    log.Context = impl_.get();
+    impl_->consumer = OpenTraceW(&log);
+    WA_LOG(wa::log::Level::Debug, "EtwInit", "OpenTrace", wa::narrowAscii(impl_->name),
+           impl_->consumer == INVALID_PROCESSTRACE_HANDLE ? "INVALID_PROCESSTRACE_HANDLE" : "ok");
+    if (impl_->consumer == INVALID_PROCESSTRACE_HANDLE) {
+        const DWORD oe = GetLastError();
+        impl_->stopSession();
+        impl_->status = EtwWatchStatus::Unavailable;
+        WA_LOG(wa::log::Level::Info, "EtwInit", "OpenTrace", wa::narrowAscii(impl_->name),
+               wa::log::hrName(HRESULT_FROM_WIN32(oe)));
+        return win32Result(oe, "EtwInit: OpenTrace");
+    }
+
+    const TRACEHANDLE consumer = impl_->consumer;
+    impl_->worker = std::thread([consumer]() {
+        wa::log::setThreadName("etw");
+        TRACEHANDLE h = consumer;
+        ULONG pr = ProcessTrace(&h, 1, nullptr, nullptr);
+        WA_LOG(wa::log::Level::Debug, "EtwInit", "ProcessTrace", "",
+               wa::log::hrName(HRESULT_FROM_WIN32(pr)));
+    });
+    impl_->status = EtwWatchStatus::Listening;
+    WA_LOG(wa::log::Level::Info, "EtwInit", "start", wa::narrowAscii(impl_->name), "listening");
+    return Result::Ok();
+}
+
+void EtwInitializeWatch::stop() {
+    if (!impl_) return;
+    if (impl_->session == 0 && !impl_->worker.joinable())
+        return;
+    impl_->stopSession();
+    if (impl_->status.load() != EtwWatchStatus::Unavailable)
+        impl_->status = EtwWatchStatus::Stopped;
+    WA_LOG(wa::log::Level::Info, "EtwInit", "stop", wa::narrowAscii(impl_->name), "ok");
+}
+
+EtwWatchStatus EtwInitializeWatch::status() const {
+    return impl_ ? impl_->status.load() : EtwWatchStatus::Stopped;
+}
+
+std::vector<EtwEventFields> EtwInitializeWatch::snapshot() const {
+    if (!impl_) return {};
+    std::lock_guard<std::mutex> lock(impl_->mu);
+    return impl_->events;
+}
+
+}  // namespace wa

--- a/src/core/EtwInitialize.h
+++ b/src/core/EtwInitialize.h
@@ -1,0 +1,66 @@
+#pragma once
+#include "PipelineGraph.h"
+#include "Result.h"
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace wa {
+
+struct EtwEventFields {
+    uint32_t processId = 0;
+    int64_t timeMs = 0;
+    std::string deviceId;
+    std::optional<std::string> category;
+    std::optional<bool> raw;
+    std::optional<bool> matchFormat;
+    std::optional<bool> exclusive;
+    std::optional<int32_t> hresult;
+};
+
+inline constexpr int64_t kEtwMatchWindowMs = 5000;
+
+enum class EtwWatchStatus : uint8_t { Stopped, Listening, Unavailable };
+
+const char* etwWatchStatusText(EtwWatchStatus status);
+
+int64_t etwNowMs();
+
+// Map a TDH / canned property dictionary onto fields. headerPid is used when
+// no PID property is present. Does not EnableTrace.
+EtwEventFields etwFieldsFromProperties(
+    uint32_t headerPid,
+    int64_t timeMs,
+    const std::vector<std::pair<std::string, std::string>>& props);
+
+// Join canned events onto one Live session. Match is PID + time window +
+// parsed device id. No match leaves present=false (do not glue the latest
+// Initialize on the machine).
+EtwInitializeHint matchEtwInitialize(
+    const LiveSessionView& session,
+    const std::vector<EtwEventFields>& events,
+    int64_t nowMs,
+    int64_t windowMs = kEtwMatchWindowMs);
+
+// Real-time ETW adapter. Enable failure is Unavailable; snapshot stays empty.
+class EtwInitializeWatch {
+public:
+    EtwInitializeWatch();
+    ~EtwInitializeWatch();
+    EtwInitializeWatch(const EtwInitializeWatch&) = delete;
+    EtwInitializeWatch& operator=(const EtwInitializeWatch&) = delete;
+
+    Result start();
+    void stop();
+    EtwWatchStatus status() const;
+    std::vector<EtwEventFields> snapshot() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -133,6 +133,7 @@ void AppUi::stopAll() {
     monitor_.stop();
     loopbackTracks_.destroyAll();
     appLoopbackTracks_.destroyAll();
+    pipelineEtw_.stop();
 }
 
 void AppUi::refreshApplicationLoopbackSessions() {
@@ -196,7 +197,20 @@ void AppUi::rebuildPipelineGraph() {
     wa::Result r = endpointGraphReader_.snapshot(flow, utow(session.deviceId.c_str()), snap);
     if (!r)
         logLines_.push_back("pipeline endpoint snapshot failed: " + r.message);
-    pipelineNodes_ = wa::assemblePipeline(session, snap, {}, pipelineProbes_);
+    pipelineEndpoint_ = std::move(snap);
+    applyPipelineJoin();
+}
+
+void AppUi::applyPipelineJoin() {
+    pipelineNodes_.clear();
+    if (pipelineSelected_ < 0 || pipelineSelected_ >= (int)pipelineSessions_.size())
+        return;
+    const wa::LiveSessionView& session = pipelineSessions_[(size_t)pipelineSelected_];
+    wa::EtwInitializeHint etw;
+    if (pipelineEtw_.status() == wa::EtwWatchStatus::Listening)
+        etw = wa::matchEtwInitialize(session, pipelineEtw_.snapshot(), wa::etwNowMs());
+    pipelineEtwHint_ = etw;
+    pipelineNodes_ = wa::assemblePipeline(session, pipelineEndpoint_, etw, pipelineProbes_);
 }
 
 void AppUi::runPipelineProbe() {
@@ -736,6 +750,12 @@ void AppUi::drawApplicationLoopbackPage() {
 }
 
 namespace {
+bool etwHintEqual(const wa::EtwInitializeHint& a, const wa::EtwInitializeHint& b) {
+    return a.present == b.present && a.category == b.category && a.raw == b.raw &&
+           a.matchFormat == b.matchFormat && a.exclusive == b.exclusive &&
+           a.hresult == b.hresult;
+}
+
 ImVec4 kindColor(wa::ObservationKind kind) {
     switch (kind) {
         case wa::ObservationKind::Observed: return ImVec4(0.45f, 0.90f, 0.55f, 1.f);
@@ -749,8 +769,21 @@ ImVec4 kindColor(wa::ObservationKind kind) {
 }  // namespace
 
 void AppUi::drawPipelinePage() {
+    if (!pipelineEtwStarted_) {
+        pipelineEtwStarted_ = true;
+        wa::Result etw = pipelineEtw_.start();
+        if (!etw)
+            logLines_.push_back("pipeline ETW unavailable: " + etw.message);
+    }
     if (!pipelineSessionsLoaded_)
         refreshPipelineSessions();
+    if (pipelineSelected_ >= 0 && pipelineEtw_.status() == wa::EtwWatchStatus::Listening) {
+        const wa::LiveSessionView& session = pipelineSessions_[(size_t)pipelineSelected_];
+        const wa::EtwInitializeHint hint =
+            wa::matchEtwInitialize(session, pipelineEtw_.snapshot(), wa::etwNowMs());
+        if (!etwHintEqual(hint, pipelineEtwHint_))
+            applyPipelineJoin();
+    }
 
     constexpr float kLogHeight = 200.0f;
     const float availY = ImGui::GetContentRegionAvail().y;
@@ -770,6 +803,14 @@ void AppUi::drawPipelinePage() {
     ImGui::SameLine();
     if (ImGui::Checkbox(wa::ui_text::kPipelineShowSelf, &pipelineShowSelf_))
         refreshPipelineSessions();
+    const wa::EtwWatchStatus etwStatus = pipelineEtw_.status();
+    if (etwStatus == wa::EtwWatchStatus::Unavailable) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.90f, 0.55f, 0.55f, 1.f));
+        ImGui::TextUnformatted(wa::ui_text::kPipelineEtwUnavailable);
+        ImGui::PopStyleColor();
+    } else if (etwStatus == wa::EtwWatchStatus::Listening) {
+        ImGui::TextUnformatted(wa::ui_text::kPipelineEtwListening);
+    }
 
     if (pipelineSessions_.empty()) {
         ImGui::TextWrapped("%s", wa::ui_text::kPipelineEmpty);

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -11,6 +11,7 @@
 #include "DeviceEnumerator.h"
 #include "DumpUi.h"
 #include "EndpointGraphReader.h"
+#include "EtwInitialize.h"
 #include "LiveSessionEnumerator.h"
 #include "MonitorEngine.h"
 #include "PipelineGraph.h"
@@ -54,6 +55,7 @@ private:
     void refreshApplicationLoopbackSessions();
     void refreshPipelineSessions();
     void rebuildPipelineGraph();
+    void applyPipelineJoin();
     void runPipelineProbe();
     void drawMonitorPage();
     void drawPipelinePage();
@@ -142,6 +144,10 @@ private:
     std::vector<wa::PipelineNode> pipelineNodes_;
     std::vector<wa::ProbeSlice> pipelineProbes_;
     bool pipelineProbing_ = false;
+    wa::EtwInitializeWatch pipelineEtw_;
+    bool pipelineEtwStarted_ = false;
+    wa::EndpointSnapshot pipelineEndpoint_;
+    wa::EtwInitializeHint pipelineEtwHint_{};
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -63,5 +63,7 @@ inline constexpr const char* kPipelineSelectHint =
     "Select a Live session to see its processing graph.";
 inline constexpr const char* kPipelineGraph = "Processing graph";
 inline constexpr const char* kPipelineProbe = "Probe this device";
+inline constexpr const char* kPipelineEtwUnavailable = "ETW unavailable";
+inline constexpr const char* kPipelineEtwListening = "ETW listening";
 
 } // namespace wa::ui_text

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(WinAudioTests
     test_pipeline_graph.cpp
     test_live_session_list.cpp
     test_shared_probe.cpp
+    test_etw_initialize.cpp
 
     test_cli_options.cpp
     test_dump_ui.cpp

--- a/src/tests/test_etw_initialize.cpp
+++ b/src/tests/test_etw_initialize.cpp
@@ -1,0 +1,213 @@
+#include <gtest/gtest.h>
+#include "EtwInitialize.h"
+#include "PipelineGraph.h"
+
+using namespace wa;
+
+namespace {
+
+LiveSessionView chromeCap() {
+    LiveSessionView s;
+    s.processId = 4242;
+    s.processName = "chrome.exe";
+    s.deviceId = "{0.0.1.00000000}.{cap}";
+    s.deviceName = "Headset Mic";
+    s.flow = PipelineFlow::Capture;
+    return s;
+}
+
+EtwEventFields ev(uint32_t pid, int64_t timeMs, std::string device = {}) {
+    EtwEventFields e;
+    e.processId = pid;
+    e.timeMs = timeMs;
+    e.deviceId = std::move(device);
+    return e;
+}
+
+const PipelineNode* findNode(const std::vector<PipelineNode>& nodes, const char* id) {
+    for (const auto& n : nodes) {
+        if (n.id == id) return &n;
+    }
+    return nullptr;
+}
+
+bool hasParam(const PipelineNode& n, const char* key, const char* value, ObservationKind kind) {
+    for (const auto& p : n.params) {
+        if (p.key == key && p.value == value && p.kind == kind) return true;
+    }
+    return false;
+}
+
+}  // namespace
+
+TEST(EtwInitializeMatch, DifferentPidDoesNotApplyLatestOnMachine) {
+    auto latest = ev(1, 10000, "{speakers}");
+    latest.hresult = 0;
+    latest.category = std::string("Media");
+    const auto hint = matchEtwInitialize(chromeCap(), {latest}, 10000);
+    EXPECT_FALSE(hint.present);
+    EXPECT_FALSE(hint.hresult.has_value());
+    EXPECT_FALSE(hint.category.has_value());
+}
+
+TEST(EtwInitializeMatch, WrongDeviceSamePidStaysUnknown) {
+    auto other = ev(4242, 9000, "{0.0.0.00000000}.{speakers}");
+    other.hresult = 0;
+    other.raw = true;
+    const auto hint = matchEtwInitialize(chromeCap(), {other}, 10000);
+    EXPECT_FALSE(hint.present);
+    EXPECT_FALSE(hint.hresult.has_value());
+}
+
+TEST(EtwInitializeMatch, OutsideTimeWindowIsUnmatched) {
+    auto old = ev(4242, 1000, "{0.0.1.00000000}.{cap}");
+    old.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {old}, 10000);
+    EXPECT_FALSE(hint.present);
+    EXPECT_FALSE(hint.hresult.has_value());
+}
+
+TEST(EtwInitializeMatch, PidTimeAndDeviceApplyDecodedFields) {
+    auto hit = ev(4242, 9000, "{0.0.1.00000000}.{cap}");
+    hit.category = std::string("Communications");
+    hit.raw = true;
+    hit.matchFormat = false;
+    hit.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    ASSERT_TRUE(hint.present);
+    ASSERT_TRUE(hint.category.has_value());
+    EXPECT_EQ(*hint.category, "Communications");
+    ASSERT_TRUE(hint.raw.has_value());
+    EXPECT_TRUE(*hint.raw);
+    ASSERT_TRUE(hint.matchFormat.has_value());
+    EXPECT_FALSE(*hint.matchFormat);
+    ASSERT_TRUE(hint.hresult.has_value());
+    EXPECT_EQ(*hint.hresult, 0);
+}
+
+TEST(EtwInitializeMatch, MissingDeviceIdStillMatchesPidAndTime) {
+    auto hit = ev(4242, 9200);
+    hit.category = std::string("Media");
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    ASSERT_TRUE(hint.present);
+    ASSERT_TRUE(hint.category.has_value());
+    EXPECT_EQ(*hint.category, "Media");
+}
+
+TEST(EtwInitializeMatch, MergesMatchingEventsByTime) {
+    auto cat = ev(4242, 8000);
+    cat.category = std::string("Communications");
+    auto raw = ev(4242, 8500, "{0.0.1.00000000}.{cap}");
+    raw.raw = true;
+    auto hr = ev(4242, 8600, "{0.0.1.00000000}.{cap}");
+    hr.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {hr, cat, raw}, 10000);
+    ASSERT_TRUE(hint.present);
+    EXPECT_EQ(*hint.category, "Communications");
+    EXPECT_TRUE(*hint.raw);
+    EXPECT_EQ(*hint.hresult, 0);
+}
+
+TEST(EtwInitializeMatch, FragmentDeviceIdDoesNotMatch) {
+    auto hit = ev(4242, 9000, "{cap}");
+    hit.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    EXPECT_FALSE(hint.present);
+}
+
+TEST(EtwInitializeMatch, EngineEventMatchesByDeviceWithoutAppPid) {
+    auto hit = ev(4, 9000, "{0.0.1.00000000}.{cap}");
+    hit.raw = true;
+    hit.matchFormat = false;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    ASSERT_TRUE(hint.present);
+    ASSERT_TRUE(hint.raw.has_value());
+    EXPECT_TRUE(*hint.raw);
+    ASSERT_TRUE(hint.matchFormat.has_value());
+    EXPECT_FALSE(*hint.matchFormat);
+}
+
+TEST(EtwInitializeMatch, EngineEventOnOtherDeviceDoesNotApply) {
+    auto hit = ev(4, 9000, "{0.0.0.00000000}.{speakers}");
+    hit.raw = true;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    EXPECT_FALSE(hint.present);
+}
+
+TEST(EtwInitializeJoin, MatchedRawSkipsSfxAsObserved) {
+    auto hit = ev(4242, 9000, "{0.0.1.00000000}.{cap}");
+    hit.raw = true;
+    hit.category = std::string("Communications");
+    hit.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    const auto nodes = assemblePipeline(chromeCap(), {}, hint, {});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_EQ(sfx->kind, ObservationKind::Skipped);
+    EXPECT_TRUE(hasParam(*sfx, "RAW", "SFX not used", ObservationKind::Observed));
+    const auto* session = findNode(nodes, "session");
+    ASSERT_NE(session, nullptr);
+    EXPECT_TRUE(hasParam(*session, "Initialize HRESULT", "0", ObservationKind::Observed));
+}
+
+TEST(EtwInitializeJoin, MatchedExclusiveSkipsSharedEngine) {
+    auto hit = ev(4242, 9000, "{0.0.1.00000000}.{cap}");
+    hit.exclusive = true;
+    hit.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {hit}, 10000);
+    const auto nodes = assemblePipeline(chromeCap(), {}, hint, {});
+    EXPECT_NE(findNode(nodes, "engine"), nullptr);
+    EXPECT_EQ(findNode(nodes, "sfx"), nullptr);
+    EXPECT_EQ(findNode(nodes, "src"), nullptr);
+}
+
+TEST(EtwInitializeJoin, UnmatchedLeavesCategoryUnknown) {
+    auto noise = ev(7, 9999, "{speakers}");
+    noise.category = std::string("Media");
+    noise.hresult = 0;
+    const auto hint = matchEtwInitialize(chromeCap(), {noise}, 10000);
+    const auto nodes = assemblePipeline(chromeCap(), {}, hint, {});
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "unknown", ObservationKind::Unknown));
+    const auto* session = findNode(nodes, "session");
+    ASSERT_NE(session, nullptr);
+    for (const auto& p : session->params) {
+        EXPECT_NE(p.key, "Initialize HRESULT");
+    }
+}
+
+TEST(EtwInitializeFields, DictionaryMapsPlaybackAndPerformance) {
+    const std::vector<std::pair<std::string, std::string>> props = {
+        {"PID", "4242"},
+        {"Category", "3"},
+        {"raw", "1"},
+        {"matchformat", "0"},
+        {"Endpoint", "{0.0.1.00000000}.{cap}"},
+        {"HRESULT", "0"},
+    };
+    const auto f = etwFieldsFromProperties(0, 9000, props);
+    EXPECT_EQ(f.processId, 4242u);
+    EXPECT_EQ(f.timeMs, 9000);
+    EXPECT_EQ(f.deviceId, "{0.0.1.00000000}.{cap}");
+    ASSERT_TRUE(f.category.has_value());
+    EXPECT_EQ(*f.category, "Communications");
+    ASSERT_TRUE(f.raw.has_value());
+    EXPECT_TRUE(*f.raw);
+    ASSERT_TRUE(f.matchFormat.has_value());
+    EXPECT_FALSE(*f.matchFormat);
+    ASSERT_TRUE(f.hresult.has_value());
+    EXPECT_EQ(*f.hresult, 0);
+}
+
+TEST(EtwInitializeFields, ShareModeMarksExclusive) {
+    const auto f = etwFieldsFromProperties(11, 1, {{"ShareMode", "1"}});
+    EXPECT_EQ(f.processId, 11u);
+    ASSERT_TRUE(f.exclusive.has_value());
+    EXPECT_TRUE(*f.exclusive);
+}
+
+TEST(EtwWatchStatus, EnableFailureTextIsUnavailable) {
+    EXPECT_STREQ(etwWatchStatusText(EtwWatchStatus::Unavailable), "ETW unavailable");
+    EXPECT_STREQ(etwWatchStatusText(EtwWatchStatus::Listening), "ETW listening");
+}

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "AppUiText.h"
+#include "EtwInitialize.h"
 #include "PipelineGraph.h"
 
 using namespace wa;
@@ -82,4 +83,10 @@ TEST(PipelineUiText, ExposesPipelineTabControls) {
                  "Select a Live session to see its processing graph.");
     EXPECT_STREQ(wa::ui_text::kPipelineGraph, "Processing graph");
     EXPECT_STREQ(wa::ui_text::kPipelineProbe, "Probe this device");
+    EXPECT_STREQ(wa::ui_text::kPipelineEtwUnavailable, "ETW unavailable");
+    EXPECT_STREQ(wa::ui_text::kPipelineEtwListening, "ETW listening");
+    EXPECT_STREQ(wa::etwWatchStatusText(wa::EtwWatchStatus::Unavailable),
+                 wa::ui_text::kPipelineEtwUnavailable);
+    EXPECT_STREQ(wa::etwWatchStatusText(wa::EtwWatchStatus::Listening),
+                 wa::ui_text::kPipelineEtwListening);
 }


### PR DESCRIPTION
## What / Why

The Pipeline tab could list Live sessions and probe advertised effects, but pre-attach Initialize fields (category, RAW, HRESULT) stayed Unknown. This PR overlays **ETW Initialize** hints on the selected Live session when events match PID + a short time window + device id.

Closes #66. Parent: #63. Design: `docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md` section 4.4.

## How

- `matchEtwInitialize` joins canned PlaybackManager / Performance / AudioClientInitialize fields. Match is PID + 5s window + exact device id. Performance events that run in the audio engine (no app PID) still match by endpoint so RAW is not dropped. Unmatched events never apply the latest Initialize on the machine.
- `EtwInitializeWatch` starts a real-time session (`Microsoft-Windows-Audio` and `Microsoft.Windows.Audio.Client`). `EnableTraceEx2` failure is Unavailable; radar, graph, and probe keep working.
- GUI: ETW status line on the Pipeline tab; matched fields join as Observed (RAW skips SFX, Exclusive skips the shared engine). Tests use field dictionaries, not a live trace.

## Testing

- Local Debug: `WinAudioTests` **293/293 passed**.
- Targeted: `EtwInitializeMatch.*`, `EtwInitializeJoin.*`, `EtwInitializeFields.*`, `EtwWatchStatus.*` (match vs no-match, engine-by-device, RAW/Exclusive overlay, unavailable copy).
- Release ctest was not re-run in this session; CI matrix covers Debug + Release.
- Device-free tests do not call `EnableTrace`.
- GUI: no screenshot in this PR. Real-device smoke (ETW permission + overlay on a Live session) not recorded here.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug ctest passed locally; Release covered by CI
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
