### PR TITLE
feat(gui): add Attach button and Call log pane

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ enable_testing()
 
 add_subdirectory(third_party)
 add_subdirectory(src/core)
+add_subdirectory(src/hook)
 add_subdirectory(src/cli)
 add_subdirectory(src/gui)
 add_subdirectory(src/tests)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(WinAudioCore STATIC
     EndpointGraphReader.cpp
     SharedProbe.cpp
     EtwInitialize.cpp
+    HookedCall.cpp
+    OnDemandAttach.cpp
 )
 target_include_directories(WinAudioCore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(WinAudioCore PUBLIC ole32 oleaut32 mmdevapi tdh advapi32 spdlog)

--- a/src/core/HookedCall.cpp
+++ b/src/core/HookedCall.cpp
@@ -1,0 +1,64 @@
+#include "HookedCall.h"
+#include <algorithm>
+#include <cstring>
+
+namespace wa {
+
+bool isPumpMethod(const std::string& method) {
+    return method == "GetBuffer" || method == "ReleaseBuffer";
+}
+
+std::string sanitizeHookedArgs(std::string args) {
+    const auto pos = args.find("pcm=");
+    if (pos != std::string::npos) {
+        args.resize(pos);
+        while (!args.empty() && (args.back() == ' ' || args.back() == ','))
+            args.pop_back();
+    }
+    return args;
+}
+
+std::vector<HookedCall> shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled) {
+    std::vector<HookedCall> out;
+    out.reserve(in.size());
+    for (HookedCall c : in) {
+        const bool pump = c.pump || isPumpMethod(c.method);
+        c.pump = pump;
+        if (pump && !pumpEnabled) continue;
+        c.args = sanitizeHookedArgs(std::move(c.args));
+        out.push_back(std::move(c));
+    }
+    return out;
+}
+
+EtwInitializeHint extractHookedInitialize(const std::vector<HookedCall>& calls) {
+    EtwInitializeHint h;
+    for (const auto& c : calls) {
+        if (c.pump || isPumpMethod(c.method)) continue;
+        if (c.method != "Initialize" && c.method != "SetClientProperties") continue;
+        h.present = true;
+        if (c.category) h.category = c.category;
+        if (c.raw) h.raw = c.raw;
+        if (c.matchFormat) h.matchFormat = c.matchFormat;
+        if (c.exclusive) h.exclusive = c.exclusive;
+        if (c.method == "Initialize") h.hresult = c.hresult;
+        if (c.format) h.format = c.format;
+    }
+    return h;
+}
+
+EtwInitializeHint mergeInitializeHint(const EtwInitializeHint& etw,
+                                      const EtwInitializeHint& hooked) {
+    if (!hooked.present) return etw;
+    EtwInitializeHint out = etw;
+    out.present = true;
+    if (hooked.category) out.category = hooked.category;
+    if (hooked.raw) out.raw = hooked.raw;
+    if (hooked.matchFormat) out.matchFormat = hooked.matchFormat;
+    if (hooked.exclusive) out.exclusive = hooked.exclusive;
+    if (hooked.hresult) out.hresult = hooked.hresult;
+    if (hooked.format) out.format = hooked.format;
+    return out;
+}
+
+}  // namespace wa

--- a/src/core/HookedCall.h
+++ b/src/core/HookedCall.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "PipelineGraph.h"
+#include <string>
+#include <vector>
+
+namespace wa {
+
+bool isPumpMethod(const std::string& method);
+
+std::string sanitizeHookedArgs(std::string args);
+
+// Control-path records are kept. Pump GetBuffer/ReleaseBuffer are omitted
+// unless pumpEnabled (later ticket). Args never keep a pcm= payload.
+std::vector<HookedCall> shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled);
+
+EtwInitializeHint extractHookedInitialize(const std::vector<HookedCall>& calls);
+
+// Hooked fields replace matching ETW fields when present.
+EtwInitializeHint mergeInitializeHint(const EtwInitializeHint& etw,
+                                      const EtwInitializeHint& hooked);
+
+}  // namespace wa

--- a/src/core/HookedCallPod.h
+++ b/src/core/HookedCallPod.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <cstdint>
+#include <cstdio>
+
+namespace wa {
+namespace hook_ipc {
+
+constexpr uint32_t kMagic = 0x5741484Bu;
+constexpr uint32_t kCap = 2048;
+
+struct CallPod {
+    uint32_t streamId;
+    int64_t timeMs;
+    char iface[40];
+    char method[40];
+    char args[192];
+    int32_t hresult;
+    uint8_t pump;
+    uint8_t hasCategory;
+    uint8_t hasRaw;
+    uint8_t hasMatchFormat;
+    uint8_t hasExclusive;
+    uint8_t hasFormat;
+    uint8_t raw;
+    uint8_t matchFormat;
+    uint8_t exclusive;
+    char category[32];
+    char format[64];
+};
+
+struct Ring {
+    uint32_t magic;
+    uint32_t writeIndex;
+    uint32_t cap;
+    uint32_t dropped;
+    CallPod slots[kCap];
+};
+
+inline void mapName(uint32_t pid, wchar_t* out, size_t n) {
+    swprintf_s(out, n, L"Local\\WinAudioHook-%u", pid);
+}
+
+}  // namespace hook_ipc
+}  // namespace wa

--- a/src/core/OnDemandAttach.cpp
+++ b/src/core/OnDemandAttach.cpp
@@ -1,0 +1,289 @@
+#include "OnDemandAttach.h"
+#include "AudioFormatStr.h"
+#include "ComUtil.h"
+#include "HookedCallPod.h"
+#include "Log.h"
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <cstring>
+#include <string>
+
+namespace wa {
+namespace {
+
+std::string basenameUtf8(const wchar_t* path) {
+    const wchar_t* slash = path;
+    for (const wchar_t* p = path; *p; ++p) {
+        if (*p == L'\\' || *p == L'/') slash = p + 1;
+    }
+    std::string s;
+    for (const wchar_t* p = slash; *p; ++p)
+        s += static_cast<char>(*p);
+    return s;
+}
+
+std::string processName(HANDLE proc) {
+    wchar_t path[MAX_PATH] = {};
+    DWORD n = MAX_PATH;
+    if (!QueryFullProcessImageNameW(proc, 0, path, &n) || n == 0)
+        return {};
+    return basenameUtf8(path);
+}
+
+bool sameBitness(HANDLE proc) {
+    BOOL selfWow = FALSE;
+    BOOL targetWow = FALSE;
+    IsWow64Process(GetCurrentProcess(), &selfWow);
+    IsWow64Process(proc, &targetWow);
+    return selfWow == targetWow;
+}
+
+std::wstring hookDllPath() {
+    wchar_t path[MAX_PATH] = {};
+    GetModuleFileNameW(nullptr, path, MAX_PATH);
+    wchar_t* slash = path;
+    for (wchar_t* p = path; *p; ++p) {
+        if (*p == L'\\' || *p == L'/') slash = p;
+    }
+    if (*slash) {
+        slash[1] = 0;
+        wcscat_s(path, L"WinAudioHook.dll");
+    }
+    return path;
+}
+
+HookedCall fromPod(const hook_ipc::CallPod& p) {
+    HookedCall c;
+    c.streamId = p.streamId;
+    c.timeMs = p.timeMs;
+    c.iface = p.iface;
+    c.method = p.method;
+    c.args = p.args;
+    c.hresult = p.hresult;
+    c.pump = p.pump != 0;
+    if (p.hasCategory) c.category = std::string(p.category);
+    if (p.hasRaw) c.raw = p.raw != 0;
+    if (p.hasMatchFormat) c.matchFormat = p.matchFormat != 0;
+    if (p.hasExclusive) c.exclusive = p.exclusive != 0;
+    if (p.hasFormat) c.format = std::string(p.format);
+    return c;
+}
+
+Result win32Result(DWORD err, const char* where) {
+    if (err == ERROR_SUCCESS) return Result::Ok();
+    return HrToResult(HRESULT_FROM_WIN32(err), where);
+}
+
+Result injectDll(HANDLE proc, const std::wstring& dll) {
+    const size_t bytes = (dll.size() + 1) * sizeof(wchar_t);
+    void* remote = VirtualAllocEx(proc, nullptr, bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    const DWORD allocErr = remote ? ERROR_SUCCESS : GetLastError();
+    WA_LOG(wa::log::Level::Debug, "Attach", "VirtualAllocEx", wa::narrowAscii(dll),
+           wa::log::hrName(HRESULT_FROM_WIN32(allocErr)));
+    if (!remote) return win32Result(allocErr, "Attach: VirtualAllocEx");
+
+    SIZE_T written = 0;
+    if (!WriteProcessMemory(proc, remote, dll.c_str(), bytes, &written)) {
+        const DWORD err = GetLastError();
+        WA_LOG(wa::log::Level::Debug, "Attach", "WriteProcessMemory", wa::narrowAscii(dll),
+               wa::log::hrName(HRESULT_FROM_WIN32(err)));
+        VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+        return win32Result(err, "Attach: WriteProcessMemory");
+    }
+    WA_LOG(wa::log::Level::Debug, "Attach", "WriteProcessMemory", wa::narrowAscii(dll), "S_OK");
+
+    HMODULE k32 = GetModuleHandleW(L"kernel32.dll");
+    auto load = k32 ? GetProcAddress(k32, "LoadLibraryW") : nullptr;
+    WA_LOG(wa::log::Level::Debug, "Attach", "GetProcAddress(LoadLibraryW)", "",
+           load ? "S_OK" : "null");
+    if (!load) {
+        VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+        return Result::Fail(static_cast<long>(E_FAIL), "Attach: LoadLibraryW not found");
+    }
+
+    HANDLE thread = CreateRemoteThread(proc, nullptr, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(load),
+                                       remote, 0, nullptr);
+    const DWORD thrErr = thread ? ERROR_SUCCESS : GetLastError();
+    WA_LOG(wa::log::Level::Debug, "Attach", "CreateRemoteThread(LoadLibraryW)",
+           wa::narrowAscii(dll), wa::log::hrName(HRESULT_FROM_WIN32(thrErr)));
+    if (!thread) {
+        VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+        return win32Result(thrErr, "Attach: CreateRemoteThread");
+    }
+    const DWORD wait = WaitForSingleObject(thread, 10000);
+    WA_LOG(wait == WAIT_OBJECT_0 ? wa::log::Level::Debug : wa::log::Level::Warn, "Attach",
+           "WaitForSingleObject(inject)", "",
+           wait == WAIT_OBJECT_0 ? "S_OK" : wa::log::hrName(HRESULT_FROM_WIN32(wait)));
+    CloseHandle(thread);
+    VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+    if (wait != WAIT_OBJECT_0)
+        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(ERROR_TIMEOUT)),
+                            "Attach: inject timed out");
+    return Result::Ok();
+}
+
+}  // namespace
+
+const char* attachBlockText(AttachBlock block) {
+    switch (block) {
+        case AttachBlock::None:          return "Attached";
+        case AttachBlock::PidZero:       return "Attach failed: invalid PID";
+        case AttachBlock::SelfProcess:   return "Attach failed: cannot attach to this process";
+        case AttachBlock::Audiodg:       return "Attach failed: refusing audiodg";
+        case AttachBlock::CrossBitness:  return "Attach failed: cross-bitness";
+        case AttachBlock::NoDebugRights: return "Attach failed: missing debug rights";
+    }
+    return "Attach failed";
+}
+
+AttachBlock evaluateAttach(uint32_t pid, uint32_t ourPid, bool sameBitnessFlag, bool hasDebugRights,
+                           const std::string& processName) {
+    if (pid == 0) return AttachBlock::PidZero;
+    if (pid == ourPid) return AttachBlock::SelfProcess;
+    if (_stricmp(processName.c_str(), "audiodg.exe") == 0) return AttachBlock::Audiodg;
+    if (!sameBitnessFlag) return AttachBlock::CrossBitness;
+    if (!hasDebugRights) return AttachBlock::NoDebugRights;
+    return AttachBlock::None;
+}
+
+struct OnDemandAttach::Impl {
+    uint32_t pid = 0;
+    AttachBlock block = AttachBlock::None;
+    HANDLE map = nullptr;
+    hook_ipc::Ring* ring = nullptr;
+    uint32_t readIndex = 0;
+};
+
+OnDemandAttach::OnDemandAttach() : impl_(std::make_unique<Impl>()) {}
+OnDemandAttach::~OnDemandAttach() { stop(); }
+
+void OnDemandAttach::stop() {
+    if (!impl_) return;
+    if (impl_->ring) {
+        UnmapViewOfFile(impl_->ring);
+        impl_->ring = nullptr;
+    }
+    if (impl_->map) {
+        CloseHandle(impl_->map);
+        impl_->map = nullptr;
+    }
+    if (impl_->pid) {
+        WA_LOG(wa::log::Level::Info, "Attach", "stop", "pid=" + std::to_string(impl_->pid), "ok");
+    }
+    impl_->pid = 0;
+    impl_->readIndex = 0;
+}
+
+bool OnDemandAttach::attached() const {
+    return impl_ && impl_->ring && impl_->pid != 0 && impl_->block == AttachBlock::None;
+}
+
+uint32_t OnDemandAttach::pid() const { return impl_ ? impl_->pid : 0; }
+
+AttachBlock OnDemandAttach::lastBlock() const {
+    return impl_ ? impl_->block : AttachBlock::PidZero;
+}
+
+Result OnDemandAttach::start(uint32_t pid) {
+    stop();
+    impl_->block = AttachBlock::PidZero;
+    const uint32_t ourPid = GetCurrentProcessId();
+
+    HANDLE query = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+    const DWORD queryErr = query ? ERROR_SUCCESS : GetLastError();
+    WA_LOG(wa::log::Level::Debug, "Attach", "OpenProcess(QUERY)", "pid=" + std::to_string(pid),
+           wa::log::hrName(HRESULT_FROM_WIN32(queryErr)));
+    if (!query) {
+        impl_->block = AttachBlock::NoDebugRights;
+        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(queryErr)),
+                            attachBlockText(impl_->block));
+    }
+    const std::string name = processName(query);
+    const bool bit = sameBitness(query);
+    WA_LOG(wa::log::Level::Debug, "Attach", "IsWow64Process", name, bit ? "same-bitness" : "cross-bitness");
+    CloseHandle(query);
+
+    HANDLE inject = OpenProcess(PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION |
+                                    PROCESS_VM_OPERATION | PROCESS_VM_WRITE | PROCESS_VM_READ,
+                                FALSE, pid);
+    const DWORD injOpenErr = inject ? ERROR_SUCCESS : GetLastError();
+    const bool hasDebug = inject != nullptr;
+    WA_LOG(wa::log::Level::Debug, "Attach", "OpenProcess(inject)", "pid=" + std::to_string(pid),
+           wa::log::hrName(HRESULT_FROM_WIN32(injOpenErr)));
+
+    impl_->block = evaluateAttach(pid, ourPid, bit, hasDebug, name);
+    if (impl_->block != AttachBlock::None) {
+        if (inject) CloseHandle(inject);
+        WA_LOG(wa::log::Level::Info, "Attach", "start", "pid=" + std::to_string(pid) + " " + name,
+               attachBlockText(impl_->block));
+        return Result::Fail(static_cast<long>(E_ACCESSDENIED), attachBlockText(impl_->block));
+    }
+
+    const std::wstring dll = hookDllPath();
+    Result inj = injectDll(inject, dll);
+    CloseHandle(inject);
+    if (!inj) {
+        WA_LOG(wa::log::Level::Info, "Attach", "inject", inj.message, "fail");
+        return inj;
+    }
+
+    wchar_t mapNm[64] = {};
+    hook_ipc::mapName(pid, mapNm, 64);
+    HANDLE map = nullptr;
+    DWORD mapErr = ERROR_SUCCESS;
+    for (int i = 0; i < 40 && !map; ++i) {
+        map = OpenFileMappingW(FILE_MAP_READ, FALSE, mapNm);
+        mapErr = map ? ERROR_SUCCESS : GetLastError();
+        if (!map) Sleep(50);
+    }
+    WA_LOG(wa::log::Level::Debug, "Attach", "OpenFileMapping", wa::narrowAscii(mapNm),
+           wa::log::hrName(HRESULT_FROM_WIN32(mapErr)));
+    if (!map) {
+        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(mapErr)),
+                            "Attach: hook mapping not ready");
+    }
+    auto* ring = static_cast<hook_ipc::Ring*>(
+        MapViewOfFile(map, FILE_MAP_READ, 0, 0, sizeof(hook_ipc::Ring)));
+    WA_LOG(wa::log::Level::Debug, "Attach", "MapViewOfFile", wa::narrowAscii(mapNm),
+           ring ? "S_OK" : wa::log::hrName(HRESULT_FROM_WIN32(GetLastError())));
+    if (!ring || ring->magic != hook_ipc::kMagic) {
+        if (ring) UnmapViewOfFile(ring);
+        CloseHandle(map);
+        return Result::Fail(static_cast<long>(E_FAIL), "Attach: hook mapping invalid");
+    }
+    impl_->map = map;
+    impl_->ring = ring;
+    impl_->pid = pid;
+    impl_->readIndex = ring->writeIndex;
+    impl_->block = AttachBlock::None;
+    WA_LOG(wa::log::Level::Info, "Attach", "start",
+           "pid=" + std::to_string(pid) + " " + name, "attached");
+    return Result::Ok();
+}
+
+std::vector<HookedCall> OnDemandAttach::drain() {
+    std::vector<HookedCall> out;
+    if (!attached()) return out;
+    const uint32_t write = impl_->ring->writeIndex;
+    uint32_t read = impl_->readIndex;
+    if (write < read) return out;
+    uint32_t count = write - read;
+    if (count > hook_ipc::kCap) {
+        read = write - hook_ipc::kCap;
+        count = hook_ipc::kCap;
+    }
+    out.reserve(count);
+    for (uint32_t i = read; i < write; ++i) {
+        const auto& pod = impl_->ring->slots[i % hook_ipc::kCap];
+        out.push_back(fromPod(pod));
+    }
+    impl_->readIndex = write;
+    return out;
+}
+
+}  // namespace wa

--- a/src/core/OnDemandAttach.h
+++ b/src/core/OnDemandAttach.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "HookedCall.h"
+#include "Result.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace wa {
+
+inline constexpr bool kAttachLaunchSuspended = false;
+inline constexpr bool kAttachAutoInject = false;
+
+enum class AttachBlock : uint8_t {
+    None,
+    PidZero,
+    SelfProcess,
+    Audiodg,
+    CrossBitness,
+    NoDebugRights,
+};
+
+const char* attachBlockText(AttachBlock block);
+
+// Pure policy. Tests use this seam; they do not inject.
+AttachBlock evaluateAttach(uint32_t pid, uint32_t ourPid, bool sameBitness, bool hasDebugRights,
+                           const std::string& processName);
+
+class OnDemandAttach {
+public:
+    OnDemandAttach();
+    ~OnDemandAttach();
+    OnDemandAttach(const OnDemandAttach&) = delete;
+    OnDemandAttach& operator=(const OnDemandAttach&) = delete;
+
+    Result start(uint32_t pid);
+    void stop();
+    bool attached() const;
+    uint32_t pid() const;
+    AttachBlock lastBlock() const;
+    std::vector<HookedCall> drain();
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace wa

--- a/src/core/PipelineGraph.cpp
+++ b/src/core/PipelineGraph.cpp
@@ -1,4 +1,5 @@
 #include "PipelineGraph.h"
+#include "HookedCall.h"
 #include <algorithm>
 #include <cstring>
 
@@ -220,33 +221,36 @@ std::vector<PipelineNode> assemblePipeline(
     const LiveSessionView& session,
     const EndpointSnapshot& endpoint,
     const EtwInitializeHint& etw,
-    const std::vector<ProbeSlice>& probes) {
+    const std::vector<ProbeSlice>& probes,
+    const std::vector<HookedCall>& hooked) {
+    const EtwInitializeHint hint = mergeInitializeHint(etw, extractHookedInitialize(hooked));
     std::vector<PipelineNode> out;
     const bool capture = session.flow == PipelineFlow::Capture;
 
     if (capture) {
         out.push_back(hardwareNode(endpoint));
         out.push_back(driverNode());
-        appendEngine(out, endpoint, etw, probes, true);
+        appendEngine(out, endpoint, hint, probes, true);
         out.push_back(sessionNode(session));
         out.push_back(appNode(session));
     } else {
         out.push_back(appNode(session));
         out.push_back(sessionNode(session));
-        appendEngine(out, endpoint, etw, probes, false);
+        appendEngine(out, endpoint, hint, probes, false);
         out.push_back(driverNode());
         out.push_back(hardwareNode(endpoint));
     }
 
-    if (etw.present && etw.hresult) {
-        // Attach HRESULT to the session node so Initialize result is visible even on Exclusive.
-        for (auto& n : out) {
-            if (n.id == "session") {
-                n.params.push_back(param("Initialize HRESULT", std::to_string(*etw.hresult),
-                                         ObservationKind::Observed));
-                break;
-            }
+    for (auto& n : out) {
+        if (n.id != "session") continue;
+        if (hint.present && hint.hresult) {
+            n.params.push_back(param("Initialize HRESULT", std::to_string(*hint.hresult),
+                                     ObservationKind::Observed));
         }
+        if (hint.present && hint.format) {
+            n.params.push_back(param("app stream format", *hint.format, ObservationKind::Observed));
+        }
+        break;
     }
     return out;
 }

--- a/src/core/PipelineGraph.h
+++ b/src/core/PipelineGraph.h
@@ -71,6 +71,22 @@ struct EtwInitializeHint {
     std::optional<bool> matchFormat;
     std::optional<bool> exclusive;
     std::optional<int32_t> hresult;
+    std::optional<std::string> format;
+};
+
+struct HookedCall {
+    uint32_t streamId = 0;
+    int64_t timeMs = 0;
+    std::string iface;
+    std::string method;
+    std::string args;
+    int32_t hresult = 0;
+    bool pump = false;
+    std::optional<std::string> category;
+    std::optional<bool> raw;
+    std::optional<bool> matchFormat;
+    std::optional<bool> exclusive;
+    std::optional<std::string> format;
 };
 
 struct AdvertisedEffect {
@@ -88,11 +104,14 @@ struct ProbeSlice {
 
 const char* observationKindName(ObservationKind kind);
 
-// Pure join of session + endpoint + optional ETW + probes. No COM, no devices.
+// Pure join of session + endpoint + optional ETW + probes + hooked calls.
+// Hooked Initialize fields override matching ETW fields and stay Observed.
+// No COM, no devices.
 std::vector<PipelineNode> assemblePipeline(
     const LiveSessionView& session,
     const EndpointSnapshot& endpoint,
     const EtwInitializeHint& etw,
-    const std::vector<ProbeSlice>& probes);
+    const std::vector<ProbeSlice>& probes,
+    const std::vector<HookedCall>& hooked = {});
 
 }  // namespace wa

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -134,6 +134,7 @@ void AppUi::stopAll() {
     loopbackTracks_.destroyAll();
     appLoopbackTracks_.destroyAll();
     pipelineEtw_.stop();
+    pipelineAttach_.stop();
 }
 
 void AppUi::refreshApplicationLoopbackSessions() {
@@ -210,7 +211,8 @@ void AppUi::applyPipelineJoin() {
     if (pipelineEtw_.status() == wa::EtwWatchStatus::Listening)
         etw = wa::matchEtwInitialize(session, pipelineEtw_.snapshot(), wa::etwNowMs());
     pipelineEtwHint_ = etw;
-    pipelineNodes_ = wa::assemblePipeline(session, pipelineEndpoint_, etw, pipelineProbes_);
+    const auto hooked = wa::shapeCallLog(pipelineCalls_, false);
+    pipelineNodes_ = wa::assemblePipeline(session, pipelineEndpoint_, etw, pipelineProbes_, hooked);
 }
 
 void AppUi::runPipelineProbe() {
@@ -246,6 +248,23 @@ void AppUi::runPipelineProbe() {
                                   " recipe error(s)")
                                : "pipeline probe completed");
     rebuildPipelineGraph();
+}
+
+void AppUi::runPipelineAttach() {
+    if (pipelineSelected_ < 0 || pipelineSelected_ >= (int)pipelineSessions_.size())
+        return;
+    const uint32_t pid = pipelineSessions_[(size_t)pipelineSelected_].processId;
+    pipelineCalls_.clear();
+    wa::Result r = pipelineAttach_.start(pid);
+    if (!r) {
+        pipelineAttachBanner_ = r.message;
+        logLines_.push_back("pipeline attach failed: " + r.message);
+        applyPipelineJoin();
+        return;
+    }
+    pipelineAttachBanner_.clear();
+    logLines_.push_back("pipeline attached pid=" + std::to_string(pid));
+    applyPipelineJoin();
 }
 
 void AppUi::pushLog(int /*level*/, const std::string& line) {
@@ -753,7 +772,7 @@ namespace {
 bool etwHintEqual(const wa::EtwInitializeHint& a, const wa::EtwInitializeHint& b) {
     return a.present == b.present && a.category == b.category && a.raw == b.raw &&
            a.matchFormat == b.matchFormat && a.exclusive == b.exclusive &&
-           a.hresult == b.hresult;
+           a.hresult == b.hresult && a.format == b.format;
 }
 
 ImVec4 kindColor(wa::ObservationKind kind) {
@@ -784,6 +803,13 @@ void AppUi::drawPipelinePage() {
         if (!etwHintEqual(hint, pipelineEtwHint_))
             applyPipelineJoin();
     }
+    if (pipelineAttach_.attached()) {
+        auto more = pipelineAttach_.drain();
+        if (!more.empty()) {
+            pipelineCalls_.insert(pipelineCalls_.end(), more.begin(), more.end());
+            applyPipelineJoin();
+        }
+    }
 
     constexpr float kLogHeight = 200.0f;
     const float availY = ImGui::GetContentRegionAvail().y;
@@ -801,6 +827,12 @@ void AppUi::drawPipelinePage() {
         runPipelineProbe();
     if (!canProbe) ImGui::EndDisabled();
     ImGui::SameLine();
+    const bool canAttach = pipelineSelected_ >= 0;
+    if (!canAttach) ImGui::BeginDisabled();
+    if (ImGui::Button(wa::ui_text::kPipelineAttach))
+        runPipelineAttach();
+    if (!canAttach) ImGui::EndDisabled();
+    ImGui::SameLine();
     if (ImGui::Checkbox(wa::ui_text::kPipelineShowSelf, &pipelineShowSelf_))
         refreshPipelineSessions();
     const wa::EtwWatchStatus etwStatus = pipelineEtw_.status();
@@ -810,6 +842,13 @@ void AppUi::drawPipelinePage() {
         ImGui::PopStyleColor();
     } else if (etwStatus == wa::EtwWatchStatus::Listening) {
         ImGui::TextUnformatted(wa::ui_text::kPipelineEtwListening);
+    }
+    if (pipelineAttach_.attached()) {
+        ImGui::TextUnformatted(wa::ui_text::kPipelineAttached);
+    } else if (!pipelineAttachBanner_.empty()) {
+        ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.90f, 0.55f, 0.55f, 1.f));
+        ImGui::TextWrapped("%s", pipelineAttachBanner_.c_str());
+        ImGui::PopStyleColor();
     }
 
     if (pipelineSessions_.empty()) {
@@ -834,8 +873,14 @@ void AppUi::drawPipelinePage() {
             std::snprintf(label, sizeof(label), "%s##ps%d",
                           s.flow == wa::PipelineFlow::Capture ? "capture" : "render", i);
             if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns)) {
-                if (pipelineSelected_ != i)
+                if (pipelineSelected_ != i) {
                     pipelineProbes_.clear();
+                    if (pipelineAttach_.pid() != 0 && pipelineAttach_.pid() != s.processId) {
+                        pipelineAttach_.stop();
+                        pipelineCalls_.clear();
+                        pipelineAttachBanner_.clear();
+                    }
+                }
                 pipelineSelected_ = i;
                 rebuildPipelineGraph();
             }
@@ -857,7 +902,9 @@ void AppUi::drawPipelinePage() {
     ImGui::EndChild();
 
     ImGui::SameLine();
-    ImGui::BeginChild("pipelineGraph", ImVec2(0, 0), true);
+    const float rest = ImGui::GetContentRegionAvail().x;
+    const float graphW = std::max(240.0f, rest * 0.55f);
+    ImGui::BeginChild("pipelineGraph", ImVec2(graphW, 0), true);
     ImGui::SeparatorText(wa::ui_text::kPipelineGraph);
     if (pipelineSelected_ < 0) {
         ImGui::TextWrapped("%s", wa::ui_text::kPipelineSelectHint);
@@ -874,6 +921,39 @@ void AppUi::drawPipelinePage() {
             }
             ImGui::Spacing();
         }
+    }
+    ImGui::EndChild();
+
+    ImGui::SameLine();
+    ImGui::BeginChild("pipelineCallLog", ImVec2(0, 0), true);
+    ImGui::SeparatorText(wa::ui_text::kPipelineCallLog);
+    const auto callLog = wa::shapeCallLog(pipelineCalls_, false);
+    if (callLog.empty()) {
+        ImGui::TextWrapped("%s", wa::ui_text::kPipelineCallLogEmpty);
+    } else if (ImGui::BeginTable("pipelineCalls", 5,
+                                 ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                     ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp)) {
+        ImGui::TableSetupColumn(wa::ui_text::kPipelineCallColIface);
+        ImGui::TableSetupColumn(wa::ui_text::kPipelineCallColMethod);
+        ImGui::TableSetupColumn(wa::ui_text::kPipelineCallColArgs);
+        ImGui::TableSetupColumn(wa::ui_text::kPipelineCallColHr, ImGuiTableColumnFlags_WidthFixed, 70.f);
+        ImGui::TableSetupColumn(wa::ui_text::kPipelineCallColStream,
+                                ImGuiTableColumnFlags_WidthFixed, 70.f);
+        ImGui::TableHeadersRow();
+        for (const auto& c : callLog) {
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::TextUnformatted(c.iface.c_str());
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TextUnformatted(c.method.c_str());
+            ImGui::TableSetColumnIndex(2);
+            ImGui::TextUnformatted(c.args.c_str());
+            ImGui::TableSetColumnIndex(3);
+            ImGui::Text("%ld", static_cast<long>(c.hresult));
+            ImGui::TableSetColumnIndex(4);
+            ImGui::Text("%u", c.streamId);
+        }
+        ImGui::EndTable();
     }
     ImGui::EndChild();
     ImGui::EndChild();

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -14,6 +14,7 @@
 #include "EtwInitialize.h"
 #include "LiveSessionEnumerator.h"
 #include "MonitorEngine.h"
+#include "OnDemandAttach.h"
 #include "PipelineGraph.h"
 #include "SharedProbe.h"
 #include "Spectrogram.h"
@@ -57,6 +58,7 @@ private:
     void rebuildPipelineGraph();
     void applyPipelineJoin();
     void runPipelineProbe();
+    void runPipelineAttach();
     void drawMonitorPage();
     void drawPipelinePage();
     void drawLoopbackPage();
@@ -148,6 +150,9 @@ private:
     bool pipelineEtwStarted_ = false;
     wa::EndpointSnapshot pipelineEndpoint_;
     wa::EtwInitializeHint pipelineEtwHint_{};
+    wa::OnDemandAttach pipelineAttach_;
+    std::vector<wa::HookedCall> pipelineCalls_;
+    std::string pipelineAttachBanner_;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -65,5 +65,17 @@ inline constexpr const char* kPipelineGraph = "Processing graph";
 inline constexpr const char* kPipelineProbe = "Probe this device";
 inline constexpr const char* kPipelineEtwUnavailable = "ETW unavailable";
 inline constexpr const char* kPipelineEtwListening = "ETW listening";
+inline constexpr const char* kPipelineAttach = "Attach";
+inline constexpr const char* kPipelineCallLog = "Call log";
+inline constexpr const char* kPipelineAttached = "Attached";
+inline constexpr const char* kPipelineCallLogEmpty =
+    "No control-path calls yet. Attach to intercept Core Audio COM.";
+inline constexpr const char* kPipelineCrossBitness = "Attach failed: cross-bitness";
+inline constexpr const char* kPipelineNoDebug = "Attach failed: missing debug rights";
+inline constexpr const char* kPipelineCallColIface = "Iface";
+inline constexpr const char* kPipelineCallColMethod = "Method";
+inline constexpr const char* kPipelineCallColArgs = "Args";
+inline constexpr const char* kPipelineCallColHr = "HR";
+inline constexpr const char* kPipelineCallColStream = "Stream";
 
 } // namespace wa::ui_text

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -11,4 +11,5 @@ target_compile_definitions(WinAudioGui PRIVATE NOMINMAX _CRT_SECURE_NO_WARNINGS)
 # Windows-subsystem exe, but the code has main() (not WinMain): keep the CRT main entry.
 set_target_properties(WinAudioGui PROPERTIES WIN32_EXECUTABLE TRUE)
 target_link_options(WinAudioGui PRIVATE /ENTRY:mainCRTStartup)
+add_dependencies(WinAudioGui WinAudioHook)
 wa_set_project_warnings(WinAudioGui)

--- a/src/hook/CMakeLists.txt
+++ b/src/hook/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(WinAudioHook SHARED WinAudioHook.cpp)
+target_include_directories(WinAudioHook PRIVATE ${CMAKE_SOURCE_DIR}/src/core)
+target_link_libraries(WinAudioHook PRIVATE ole32 oleaut32 mmdevapi uuid)
+wa_set_project_warnings(WinAudioHook)

--- a/src/hook/WinAudioHook.cpp
+++ b/src/hook/WinAudioHook.cpp
@@ -1,0 +1,426 @@
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <audiopolicy.h>
+#include <objbase.h>
+#include <cstring>
+#include <cstdint>
+#include "HookedCallPod.h"
+
+using wa::hook_ipc::CallPod;
+using wa::hook_ipc::Ring;
+using wa::hook_ipc::kCap;
+using wa::hook_ipc::kMagic;
+
+namespace {
+
+Ring* g_ring = nullptr;
+HANDLE g_map = nullptr;
+volatile LONG g_quiet = 0;
+
+using ActivateFn = HRESULT(STDMETHODCALLTYPE*)(IMMDevice*, REFIID, DWORD, PROPVARIANT*, void**);
+using GetDeviceFn = HRESULT(STDMETHODCALLTYPE*)(IMMDeviceEnumerator*, LPCWSTR, IMMDevice**);
+using GetDefaultFn = HRESULT(STDMETHODCALLTYPE*)(IMMDeviceEnumerator*, EDataFlow, ERole, IMMDevice**);
+using InitializeFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*, AUDCLNT_SHAREMODE, DWORD,
+                                                 REFERENCE_TIME, REFERENCE_TIME, const WAVEFORMATEX*,
+                                                 LPCGUID);
+using SimpleHrFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*);
+using SetEventFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*, HANDLE);
+using GetServiceFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*, REFIID, void**);
+using SetPropsFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient2*, const AudioClientProperties*);
+using VolGetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, float*);
+using VolSetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, float, LPCGUID);
+using MuteGetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, BOOL*);
+using MuteSetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, BOOL, LPCGUID);
+using SessStateFn = HRESULT(STDMETHODCALLTYPE*)(IAudioSessionControl*, AudioSessionState*);
+using ClockFreqFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClock*, UINT64*);
+
+ActivateFn g_activate = nullptr;
+GetDeviceFn g_getDevice = nullptr;
+GetDefaultFn g_getDefault = nullptr;
+InitializeFn g_initialize = nullptr;
+SimpleHrFn g_start = nullptr;
+SimpleHrFn g_stop = nullptr;
+SimpleHrFn g_reset = nullptr;
+SetEventFn g_setEvent = nullptr;
+GetServiceFn g_getService = nullptr;
+SetPropsFn g_setProps = nullptr;
+VolGetFn g_volGet = nullptr;
+VolSetFn g_volSet = nullptr;
+MuteGetFn g_muteGet = nullptr;
+MuteSetFn g_muteSet = nullptr;
+SessStateFn g_sessState = nullptr;
+ClockFreqFn g_clockFreq = nullptr;
+
+void copyStr(char* dst, size_t n, const char* src) {
+    if (!dst || n == 0) return;
+    if (!src) {
+        dst[0] = 0;
+        return;
+    }
+    strncpy_s(dst, n, src, _TRUNCATE);
+}
+
+int64_t nowMs() {
+    FILETIME ft{};
+    GetSystemTimeAsFileTime(&ft);
+    ULARGE_INTEGER u;
+    u.LowPart = ft.dwLowDateTime;
+    u.HighPart = ft.dwHighDateTime;
+    return static_cast<int64_t>(u.QuadPart / 10000ULL) - 11644473600000LL;
+}
+
+void emit(CallPod pod) {
+    if (!g_ring || g_quiet) return;
+    pod.timeMs = nowMs();
+    const LONG idx = InterlockedIncrement(reinterpret_cast<volatile LONG*>(&g_ring->writeIndex));
+    const uint32_t slot = static_cast<uint32_t>(idx - 1) % kCap;
+    g_ring->slots[slot] = pod;
+}
+
+void emitSimple(uint32_t streamId, const char* iface, const char* method, const char* args,
+                HRESULT hr) {
+    CallPod p{};
+    p.streamId = streamId;
+    copyStr(p.iface, sizeof(p.iface), iface);
+    copyStr(p.method, sizeof(p.method), method);
+    copyStr(p.args, sizeof(p.args), args);
+    p.hresult = static_cast<int32_t>(hr);
+    emit(p);
+}
+
+uint32_t sid(const void* p) { return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(p)); }
+
+const char* iidName(REFIID iid) {
+    if (iid == __uuidof(IAudioClient)) return "IAudioClient";
+    if (iid == __uuidof(IAudioClient2)) return "IAudioClient2";
+    if (iid == __uuidof(IAudioClient3)) return "IAudioClient3";
+    if (iid == __uuidof(IAudioCaptureClient)) return "IAudioCaptureClient";
+    if (iid == __uuidof(IAudioRenderClient)) return "IAudioRenderClient";
+    if (iid == __uuidof(IAudioClock)) return "IAudioClock";
+    if (iid == __uuidof(ISimpleAudioVolume)) return "ISimpleAudioVolume";
+    if (iid == __uuidof(IAudioSessionControl)) return "IAudioSessionControl";
+    if (iid == __uuidof(IAudioSessionControl2)) return "IAudioSessionControl2";
+    if (iid == __uuidof(IAudioStreamVolume)) return "IAudioStreamVolume";
+#ifdef __IAudioEffectsManager_INTERFACE_DEFINED__
+    if (iid == __uuidof(IAudioEffectsManager)) return "IAudioEffectsManager";
+#endif
+    return "unknown";
+}
+
+const char* categoryName(int v) {
+    switch (v) {
+        case 0: return "Other";
+        case 3: return "Communications";
+        case 5: return "SoundEffects";
+        case 7: return "GameMedia";
+        case 8: return "GameChat";
+        case 9: return "Speech";
+        case 10: return "Movie";
+        case 11: return "Media";
+        default: return "Other";
+    }
+}
+
+void formatWave(const WAVEFORMATEX* fmt, char* out, size_t n) {
+    if (!fmt) {
+        copyStr(out, n, "null");
+        return;
+    }
+    const char* fl = (fmt->wFormatTag == 3) ? "f" : "";
+    sprintf_s(out, n, "%u/%u%s/%u", fmt->nSamplesPerSec, fmt->wBitsPerSample, fl, fmt->nChannels);
+}
+
+bool patchSlot(void* obj, int slot, void* hook, void** orig) {
+    if (!obj || !hook || !orig) return false;
+    void** vt = *reinterpret_cast<void***>(obj);
+    void** cell = vt + slot;
+    if (*orig == nullptr) *orig = *cell;
+    if (*cell == hook) return true;
+    DWORD old = 0;
+    if (!VirtualProtect(cell, sizeof(void*), PAGE_EXECUTE_READWRITE, &old)) return false;
+    *cell = hook;
+    DWORD tmp = 0;
+    VirtualProtect(cell, sizeof(void*), old, &tmp);
+    FlushInstructionCache(GetCurrentProcess(), cell, sizeof(void*));
+    return true;
+}
+
+HRESULT STDMETHODCALLTYPE HookInitialize(IAudioClient* self, AUDCLNT_SHAREMODE share, DWORD flags,
+                                         REFERENCE_TIME dur, REFERENCE_TIME per,
+                                         const WAVEFORMATEX* fmt, LPCGUID session) {
+    const HRESULT hr = g_initialize ? g_initialize(self, share, flags, dur, per, fmt, session)
+                                    : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    copyStr(p.iface, sizeof(p.iface), "IAudioClient");
+    copyStr(p.method, sizeof(p.method), "Initialize");
+    char wave[64] = {};
+    formatWave(fmt, wave, sizeof(wave));
+    sprintf_s(p.args, "share=%s flags=0x%lX fmt=%s",
+              share == AUDCLNT_SHAREMODE_EXCLUSIVE ? "exclusive" : "shared",
+              static_cast<unsigned long>(flags), wave);
+    p.hresult = static_cast<int32_t>(hr);
+    p.hasExclusive = 1;
+    p.exclusive = share == AUDCLNT_SHAREMODE_EXCLUSIVE ? 1 : 0;
+    p.hasFormat = 1;
+    copyStr(p.format, sizeof(p.format), wave);
+    emit(p);
+    (void)per;
+    (void)dur;
+    (void)session;
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookStart(IAudioClient* self) {
+    const HRESULT hr = g_start ? g_start(self) : E_UNEXPECTED;
+    emitSimple(sid(self), "IAudioClient", "Start", "", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookStop(IAudioClient* self) {
+    const HRESULT hr = g_stop ? g_stop(self) : E_UNEXPECTED;
+    emitSimple(sid(self), "IAudioClient", "Stop", "", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookReset(IAudioClient* self) {
+    const HRESULT hr = g_reset ? g_reset(self) : E_UNEXPECTED;
+    emitSimple(sid(self), "IAudioClient", "Reset", "", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookSetEventHandle(IAudioClient* self, HANDLE ev) {
+    const HRESULT hr = g_setEvent ? g_setEvent(self, ev) : E_UNEXPECTED;
+    emitSimple(sid(self), "IAudioClient", "SetEventHandle", "", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookVolGet(ISimpleAudioVolume* self, float* level) {
+    const HRESULT hr = g_volGet ? g_volGet(self, level) : E_UNEXPECTED;
+    char args[48] = {};
+    if (SUCCEEDED(hr) && level) sprintf_s(args, "level=%.3f", static_cast<double>(*level));
+    emitSimple(sid(self), "ISimpleAudioVolume", "GetMasterVolume", args, hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookVolSet(ISimpleAudioVolume* self, float level, LPCGUID ctx) {
+    const HRESULT hr = g_volSet ? g_volSet(self, level, ctx) : E_UNEXPECTED;
+    char args[48] = {};
+    sprintf_s(args, "level=%.3f", static_cast<double>(level));
+    emitSimple(sid(self), "ISimpleAudioVolume", "SetMasterVolume", args, hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookMuteGet(ISimpleAudioVolume* self, BOOL* mute) {
+    const HRESULT hr = g_muteGet ? g_muteGet(self, mute) : E_UNEXPECTED;
+    emitSimple(sid(self), "ISimpleAudioVolume", "GetMute",
+               (SUCCEEDED(hr) && mute && *mute) ? "true" : "false", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookMuteSet(ISimpleAudioVolume* self, BOOL mute, LPCGUID ctx) {
+    const HRESULT hr = g_muteSet ? g_muteSet(self, mute, ctx) : E_UNEXPECTED;
+    emitSimple(sid(self), "ISimpleAudioVolume", "SetMute", mute ? "true" : "false", hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookSessState(IAudioSessionControl* self, AudioSessionState* st) {
+    const HRESULT hr = g_sessState ? g_sessState(self, st) : E_UNEXPECTED;
+    const char* name = "unknown";
+    if (SUCCEEDED(hr) && st) {
+        if (*st == AudioSessionStateActive) name = "Active";
+        else if (*st == AudioSessionStateInactive) name = "Inactive";
+        else if (*st == AudioSessionStateExpired) name = "Expired";
+    }
+    emitSimple(sid(self), "IAudioSessionControl", "GetState", name, hr);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookClockFreq(IAudioClock* self, UINT64* freq) {
+    const HRESULT hr = g_clockFreq ? g_clockFreq(self, freq) : E_UNEXPECTED;
+    char args[48] = {};
+    if (SUCCEEDED(hr) && freq) sprintf_s(args, "hz=%llu", static_cast<unsigned long long>(*freq));
+    emitSimple(sid(self), "IAudioClock", "GetFrequency", args, hr);
+    return hr;
+}
+
+void patchService(void* obj, REFIID iid) {
+    if (!obj) return;
+    if (iid == __uuidof(ISimpleAudioVolume)) {
+        patchSlot(obj, 3, reinterpret_cast<void*>(&HookVolGet), reinterpret_cast<void**>(&g_volGet));
+        patchSlot(obj, 4, reinterpret_cast<void*>(&HookVolSet), reinterpret_cast<void**>(&g_volSet));
+        patchSlot(obj, 5, reinterpret_cast<void*>(&HookMuteGet), reinterpret_cast<void**>(&g_muteGet));
+        patchSlot(obj, 6, reinterpret_cast<void*>(&HookMuteSet), reinterpret_cast<void**>(&g_muteSet));
+    } else if (iid == __uuidof(IAudioSessionControl) || iid == __uuidof(IAudioSessionControl2)) {
+        patchSlot(obj, 3, reinterpret_cast<void*>(&HookSessState),
+                  reinterpret_cast<void**>(&g_sessState));
+    } else if (iid == __uuidof(IAudioClock)) {
+        patchSlot(obj, 3, reinterpret_cast<void*>(&HookClockFreq),
+                  reinterpret_cast<void**>(&g_clockFreq));
+    }
+}
+
+HRESULT STDMETHODCALLTYPE HookGetService(IAudioClient* self, REFIID iid, void** pp) {
+    const HRESULT hr = g_getService ? g_getService(self, iid, pp) : E_UNEXPECTED;
+    char args[80] = {};
+    sprintf_s(args, "iid=%s", iidName(iid));
+    emitSimple(sid(self), "IAudioClient", "GetService", args, hr);
+    if (SUCCEEDED(hr) && pp && *pp) patchService(*pp, iid);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookSetClientProperties(IAudioClient2* self,
+                                                  const AudioClientProperties* props) {
+    const HRESULT hr = g_setProps ? g_setProps(self, props) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    copyStr(p.iface, sizeof(p.iface), "IAudioClient2");
+    copyStr(p.method, sizeof(p.method), "SetClientProperties");
+    p.hresult = static_cast<int32_t>(hr);
+    if (props) {
+        p.hasCategory = 1;
+        copyStr(p.category, sizeof(p.category), categoryName(static_cast<int>(props->eCategory)));
+        p.hasRaw = 1;
+        p.raw = (props->Options & AUDCLNT_STREAMOPTIONS_RAW) ? 1 : 0;
+        p.hasMatchFormat = 1;
+        p.matchFormat = (props->Options & AUDCLNT_STREAMOPTIONS_MATCH_FORMAT) ? 1 : 0;
+        sprintf_s(p.args, "category=%s raw=%u matchformat=%u", p.category, p.raw, p.matchFormat);
+    }
+    emit(p);
+    return hr;
+}
+
+void patchClient(void* obj) {
+    if (!obj) return;
+    patchSlot(obj, 3, reinterpret_cast<void*>(&HookInitialize), reinterpret_cast<void**>(&g_initialize));
+    patchSlot(obj, 10, reinterpret_cast<void*>(&HookStart), reinterpret_cast<void**>(&g_start));
+    patchSlot(obj, 11, reinterpret_cast<void*>(&HookStop), reinterpret_cast<void**>(&g_stop));
+    patchSlot(obj, 12, reinterpret_cast<void*>(&HookReset), reinterpret_cast<void**>(&g_reset));
+    patchSlot(obj, 13, reinterpret_cast<void*>(&HookSetEventHandle),
+              reinterpret_cast<void**>(&g_setEvent));
+    patchSlot(obj, 14, reinterpret_cast<void*>(&HookGetService),
+              reinterpret_cast<void**>(&g_getService));
+    IAudioClient2* c2 = nullptr;
+    if (SUCCEEDED(static_cast<IUnknown*>(obj)->QueryInterface(__uuidof(IAudioClient2),
+                                                              reinterpret_cast<void**>(&c2))) &&
+        c2) {
+        patchSlot(c2, 16, reinterpret_cast<void*>(&HookSetClientProperties),
+                  reinterpret_cast<void**>(&g_setProps));
+        c2->Release();
+    }
+}
+
+HRESULT STDMETHODCALLTYPE HookActivate(IMMDevice* self, REFIID iid, DWORD ctx, PROPVARIANT* params,
+                                       void** ppInterface) {
+    const HRESULT hr =
+        g_activate ? g_activate(self, iid, ctx, params, ppInterface) : E_UNEXPECTED;
+    char args[80] = {};
+    sprintf_s(args, "iid=%s", iidName(iid));
+    emitSimple(sid(self), "IMMDevice", "Activate", args, hr);
+    if (SUCCEEDED(hr) && ppInterface && *ppInterface) {
+        if (iid == __uuidof(IAudioClient) || iid == __uuidof(IAudioClient2) ||
+            iid == __uuidof(IAudioClient3)) {
+            patchClient(*ppInterface);
+        }
+    }
+    return hr;
+}
+
+void patchDevice(IMMDevice* dev) {
+    if (!dev) return;
+    patchSlot(dev, 3, reinterpret_cast<void*>(&HookActivate), reinterpret_cast<void**>(&g_activate));
+}
+
+HRESULT STDMETHODCALLTYPE HookGetDevice(IMMDeviceEnumerator* self, LPCWSTR id, IMMDevice** device) {
+    const HRESULT hr = g_getDevice ? g_getDevice(self, id, device) : E_UNEXPECTED;
+    if (SUCCEEDED(hr) && device && *device) patchDevice(*device);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookGetDefault(IMMDeviceEnumerator* self, EDataFlow flow, ERole role,
+                                         IMMDevice** device) {
+    const HRESULT hr = g_getDefault ? g_getDefault(self, flow, role, device) : E_UNEXPECTED;
+    if (SUCCEEDED(hr) && device && *device) patchDevice(*device);
+    return hr;
+}
+
+void tryActivate(IMMDevice* dev, REFIID iid) {
+    if (!dev) return;
+    patchDevice(dev);
+    void* client = nullptr;
+    HRESULT hr = dev->Activate(iid, CLSCTX_ALL, nullptr, &client);
+    if (SUCCEEDED(hr) && client) {
+        patchClient(client);
+        static_cast<IUnknown*>(client)->Release();
+    }
+    (void)hr;
+}
+
+void install() {
+    InterlockedExchange(&g_quiet, 1);
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+    const bool needUninit = (hr == S_OK);
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) return;
+
+    IMMDeviceEnumerator* enumer = nullptr;
+    hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
+                          __uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(&enumer));
+    if (SUCCEEDED(hr) && enumer) {
+        patchSlot(enumer, 4, reinterpret_cast<void*>(&HookGetDefault),
+                  reinterpret_cast<void**>(&g_getDefault));
+        patchSlot(enumer, 5, reinterpret_cast<void*>(&HookGetDevice),
+                  reinterpret_cast<void**>(&g_getDevice));
+        IMMDevice* cap = nullptr;
+        IMMDevice* ren = nullptr;
+        enumer->GetDefaultAudioEndpoint(eCapture, eConsole, &cap);
+        enumer->GetDefaultAudioEndpoint(eRender, eConsole, &ren);
+        if (cap) {
+            tryActivate(cap, __uuidof(IAudioClient));
+            tryActivate(cap, __uuidof(IAudioClient2));
+            cap->Release();
+        }
+        if (ren) {
+            tryActivate(ren, __uuidof(IAudioClient));
+            tryActivate(ren, __uuidof(IAudioClient2));
+            ren->Release();
+        }
+        enumer->Release();
+    }
+    if (needUninit) CoUninitialize();
+    InterlockedExchange(&g_quiet, 0);
+}
+
+DWORD WINAPI HookThread(LPVOID) {
+    wchar_t name[64] = {};
+    wa::hook_ipc::mapName(GetCurrentProcessId(), name, 64);
+    g_map = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0,
+                               sizeof(Ring), name);
+    if (!g_map) return 1;
+    g_ring = static_cast<Ring*>(MapViewOfFile(g_map, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(Ring)));
+    if (!g_ring) return 1;
+    if (g_ring->magic != kMagic) {
+        ZeroMemory(g_ring, sizeof(Ring));
+        g_ring->magic = kMagic;
+        g_ring->cap = kCap;
+        g_ring->writeIndex = 0;
+    }
+    install();
+    return 0;
+}
+
+}  // namespace
+
+BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID) {
+    if (reason == DLL_PROCESS_ATTACH) {
+        const HANDLE th = CreateThread(nullptr, 0, HookThread, nullptr, 0, nullptr);
+        if (th) CloseHandle(th);
+    }
+    return TRUE;
+}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ add_executable(WinAudioTests
     test_live_session_list.cpp
     test_shared_probe.cpp
     test_etw_initialize.cpp
+    test_hooked_call.cpp
+    test_on_demand_attach.cpp
 
     test_cli_options.cpp
     test_dump_ui.cpp

--- a/src/tests/test_hooked_call.cpp
+++ b/src/tests/test_hooked_call.cpp
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+#include "HookedCall.h"
+#include "PipelineGraph.h"
+
+using namespace wa;
+
+namespace {
+
+LiveSessionView chromeCap() {
+    LiveSessionView s;
+    s.processId = 4242;
+    s.processName = "chrome.exe";
+    s.deviceId = "{cap}";
+    s.deviceName = "Headset Mic";
+    s.flow = PipelineFlow::Capture;
+    return s;
+}
+
+const PipelineNode* findNode(const std::vector<PipelineNode>& nodes, const char* id) {
+    for (const auto& n : nodes) {
+        if (n.id == id) return &n;
+    }
+    return nullptr;
+}
+
+bool hasParam(const PipelineNode& n, const char* key, const char* value, ObservationKind kind) {
+    for (const auto& p : n.params) {
+        if (p.key == key && p.value == value && p.kind == kind) return true;
+    }
+    return false;
+}
+
+HookedCall initCall() {
+    HookedCall c;
+    c.streamId = 7;
+    c.timeMs = 1000;
+    c.iface = "IAudioClient";
+    c.method = "Initialize";
+    c.args = "share=shared flags=0x0 fmt=48000/32f/2";
+    c.hresult = 0;
+    c.exclusive = false;
+    c.format = std::string("48000/32f/2");
+    return c;
+}
+
+}  // namespace
+
+TEST(CallLog, DropsPumpWhenDisabled) {
+    HookedCall pump;
+    pump.iface = "IAudioCaptureClient";
+    pump.method = "GetBuffer";
+    pump.args = "frames=480";
+    pump.pump = true;
+    HookedCall init = initCall();
+    const auto log = shapeCallLog({pump, init}, false);
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_EQ(log[0].method, "Initialize");
+}
+
+TEST(CallLog, KeepsControlPathActivateAndInitialize) {
+    HookedCall act;
+    act.iface = "IMMDevice";
+    act.method = "Activate";
+    act.args = "iid=IAudioClient";
+    act.hresult = 0;
+    const auto log = shapeCallLog({act, initCall()}, false);
+    ASSERT_EQ(log.size(), 2u);
+    EXPECT_EQ(log[0].method, "Activate");
+    EXPECT_EQ(log[1].method, "Initialize");
+}
+
+TEST(CallLog, NeverLeavesPcmInArgs) {
+    HookedCall c = initCall();
+    c.args = "share=shared pcm=010203 frames=480";
+    const auto log = shapeCallLog({c}, false);
+    ASSERT_EQ(log.size(), 1u);
+    EXPECT_EQ(log[0].args.find("pcm="), std::string::npos);
+    EXPECT_NE(log[0].args.find("share=shared"), std::string::npos);
+}
+
+TEST(HookedJoin, InitializeOverridesEtwCategoryAndRaw) {
+    EtwInitializeHint etw;
+    etw.present = true;
+    etw.category = std::string("Media");
+    etw.raw = false;
+    etw.hresult = 1;
+
+    HookedCall hooked = initCall();
+    hooked.category = std::string("Communications");
+    hooked.raw = true;
+    hooked.hresult = 0;
+
+    const auto nodes = assemblePipeline(chromeCap(), {}, etw, {}, {hooked});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_EQ(sfx->kind, ObservationKind::Skipped);
+    EXPECT_TRUE(hasParam(*sfx, "RAW", "SFX not used", ObservationKind::Observed));
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "Communications", ObservationKind::Observed));
+    const auto* session = findNode(nodes, "session");
+    ASSERT_NE(session, nullptr);
+    EXPECT_TRUE(hasParam(*session, "Initialize HRESULT", "0", ObservationKind::Observed));
+    EXPECT_TRUE(hasParam(*session, "app stream format", "48000/32f/2", ObservationKind::Observed));
+}
+
+TEST(HookedJoin, ExclusiveHookedSkipsSharedEngine) {
+    HookedCall hooked = initCall();
+    hooked.exclusive = true;
+    hooked.args = "share=exclusive";
+    const auto nodes = assemblePipeline(chromeCap(), {}, {}, {}, {hooked});
+    EXPECT_NE(findNode(nodes, "engine"), nullptr);
+    EXPECT_EQ(findNode(nodes, "sfx"), nullptr);
+    EXPECT_EQ(findNode(nodes, "src"), nullptr);
+}
+
+TEST(HookedJoin, WithoutHookedCallsEtwStillApplies) {
+    EtwInitializeHint etw;
+    etw.present = true;
+    etw.category = std::string("Media");
+    const auto nodes = assemblePipeline(chromeCap(), {}, etw, {}, {});
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "Media", ObservationKind::Observed));
+}
+
+TEST(HookedJoin, PumpRecordsDoNotProduceInitializeHint) {
+    HookedCall pump;
+    pump.method = "GetBuffer";
+    pump.pump = true;
+    pump.raw = true;
+    pump.hresult = 0;
+    EtwInitializeHint etw;
+    etw.present = true;
+    etw.category = std::string("Media");
+    const auto nodes = assemblePipeline(chromeCap(), {}, etw, {}, {pump});
+    const auto* sfx = findNode(nodes, "sfx");
+    ASSERT_NE(sfx, nullptr);
+    EXPECT_NE(sfx->kind, ObservationKind::Skipped);
+    const auto* mfx = findNode(nodes, "mfx");
+    ASSERT_NE(mfx, nullptr);
+    EXPECT_TRUE(hasParam(*mfx, "category", "Media", ObservationKind::Observed));
+}

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "AppUiText.h"
 #include "EtwInitialize.h"
+#include "OnDemandAttach.h"
 #include "PipelineGraph.h"
 
 using namespace wa;
@@ -89,4 +90,19 @@ TEST(PipelineUiText, ExposesPipelineTabControls) {
                  wa::ui_text::kPipelineEtwUnavailable);
     EXPECT_STREQ(wa::etwWatchStatusText(wa::EtwWatchStatus::Listening),
                  wa::ui_text::kPipelineEtwListening);
+    EXPECT_STREQ(wa::ui_text::kPipelineAttach, "Attach");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallLog, "Call log");
+    EXPECT_STREQ(wa::ui_text::kPipelineAttached, "Attached");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallLogEmpty,
+                 "No control-path calls yet. Attach to intercept Core Audio COM.");
+    EXPECT_STREQ(wa::attachBlockText(wa::AttachBlock::CrossBitness),
+                 wa::ui_text::kPipelineCrossBitness);
+    EXPECT_STREQ(wa::attachBlockText(wa::AttachBlock::NoDebugRights),
+                 wa::ui_text::kPipelineNoDebug);
+    EXPECT_STREQ(wa::attachBlockText(wa::AttachBlock::None), wa::ui_text::kPipelineAttached);
+    EXPECT_STREQ(wa::ui_text::kPipelineCallColIface, "Iface");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallColMethod, "Method");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallColArgs, "Args");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallColHr, "HR");
+    EXPECT_STREQ(wa::ui_text::kPipelineCallColStream, "Stream");
 }

--- a/src/tests/test_on_demand_attach.cpp
+++ b/src/tests/test_on_demand_attach.cpp
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+#include "OnDemandAttach.h"
+
+using namespace wa;
+
+TEST(OnDemandAttach, PidZeroFailsClosed) {
+    EXPECT_EQ(evaluateAttach(0, 100, true, true, "chrome.exe"), AttachBlock::PidZero);
+}
+
+TEST(OnDemandAttach, SelfProcessFailsClosed) {
+    EXPECT_EQ(evaluateAttach(100, 100, true, true, "WinAudioGui.exe"), AttachBlock::SelfProcess);
+}
+
+TEST(OnDemandAttach, AudiodgFailsClosed) {
+    EXPECT_EQ(evaluateAttach(8, 100, true, true, "audiodg.exe"), AttachBlock::Audiodg);
+    EXPECT_EQ(evaluateAttach(8, 100, true, true, "AUDIODG.EXE"), AttachBlock::Audiodg);
+}
+
+TEST(OnDemandAttach, CrossBitnessFailsClosed) {
+    EXPECT_EQ(evaluateAttach(4242, 100, false, true, "chrome.exe"), AttachBlock::CrossBitness);
+    EXPECT_STREQ(attachBlockText(AttachBlock::CrossBitness), "Attach failed: cross-bitness");
+}
+
+TEST(OnDemandAttach, MissingDebugRightsFailsClosed) {
+    EXPECT_EQ(evaluateAttach(4242, 100, true, false, "chrome.exe"), AttachBlock::NoDebugRights);
+    EXPECT_STREQ(attachBlockText(AttachBlock::NoDebugRights),
+                 "Attach failed: missing debug rights");
+}
+
+TEST(OnDemandAttach, SameBitnessWithDebugIsAllowed) {
+    EXPECT_EQ(evaluateAttach(4242, 100, true, true, "chrome.exe"), AttachBlock::None);
+}
+
+TEST(OnDemandAttach, DoesNotLaunchSuspendedOrAutoInject) {
+    // Policy has no launch-suspended or broadcast-inject mode; start() is on-demand
+    // for one PID. This test locks the public flags.
+    EXPECT_FALSE(kAttachLaunchSuspended);
+    EXPECT_FALSE(kAttachAutoInject);
+}


### PR DESCRIPTION
## What / Why

The Pipeline tab could reconstruct a Live session from the endpoint graph, Shared probe, and ETW, but it could not see another process's Core Audio Initialize arguments. This PR adds **On-demand attach** into the selected Live session PID and a **Call log** of control-path COM beside the graph. Hooked Initialize fields override ETW and stay Observed.

Closes #67. Parent: #63. Design: `docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md` section 4.5. ADR-0002: intercept Core Audio in the app process, not audiodg.

## How

- `assemblePipeline` takes canned `HookedCall` records. Matching Initialize / SetClientProperties fields replace ETW. Call log keeps control-path methods; GetBuffer/ReleaseBuffer stay off; `pcm=` is stripped from args.
- Attach injects `WinAudioHook.dll` into one same-bitness PID (vtable patch of Activate / IAudioClient* / volume / session / clock). Cross-bitness, missing debug rights, audiodg, and self-attach fail closed; radar, graph, probe, and ETW keep running.
- GUI: Attach button, fail-closed banner, Call log pane. Tests use field records, not live inject. Pump ring is #68.

## Testing

- Local Debug: `WinAudioTests` **307/307 passed**.
- Targeted: `CallLog.*`, `HookedJoin.*`, `OnDemandAttach.*` (pump drop, no PCM, hooked overrides ETW, policy fail-closed).
- Release ctest was not re-run in this session; CI matrix covers Debug + Release.
- Device-free tests do not inject into live processes.
- GUI: no screenshot in this PR. Real-device smoke (same-bitness attach with debug rights) not recorded here.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug ctest passed locally; Release covered by CI
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
