### PR TITLE
feat(gui): add optional pump metadata on Call log

### DIFF
--- a/src/core/HookedCall.cpp
+++ b/src/core/HookedCall.cpp
@@ -1,5 +1,6 @@
 #include "HookedCall.h"
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 
 namespace wa {
@@ -18,17 +19,32 @@ std::string sanitizeHookedArgs(std::string args) {
     return args;
 }
 
-std::vector<HookedCall> shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled) {
-    std::vector<HookedCall> out;
-    out.reserve(in.size());
+CallLogView shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled, size_t pumpCap) {
+    CallLogView view;
+    std::vector<HookedCall> pump;
+    view.entries.reserve(in.size());
+    pump.reserve(pumpEnabled ? std::min(in.size(), pumpCap + 8) : 0);
     for (HookedCall c : in) {
-        const bool pump = c.pump || isPumpMethod(c.method);
-        c.pump = pump;
-        if (pump && !pumpEnabled) continue;
+        const bool isPump = c.pump || isPumpMethod(c.method);
+        c.pump = isPump;
         c.args = sanitizeHookedArgs(std::move(c.args));
-        out.push_back(std::move(c));
+        if (isPump) {
+            if (pumpEnabled) {
+                if (c.xrun) ++view.pumpXruns;
+                pump.push_back(std::move(c));
+            }
+            continue;
+        }
+        view.entries.push_back(std::move(c));
     }
-    return out;
+    if (pumpCap > 0 && pump.size() > pumpCap) {
+        pump.erase(pump.begin(),
+                   pump.begin() + static_cast<std::ptrdiff_t>(pump.size() - pumpCap));
+    }
+    view.entries.insert(view.entries.end(), pump.begin(), pump.end());
+    std::stable_sort(view.entries.begin(), view.entries.end(),
+                     [](const HookedCall& a, const HookedCall& b) { return a.timeMs < b.timeMs; });
+    return view;
 }
 
 EtwInitializeHint extractHookedInitialize(const std::vector<HookedCall>& calls) {

--- a/src/core/HookedCall.h
+++ b/src/core/HookedCall.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "PipelineGraph.h"
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -9,9 +11,18 @@ bool isPumpMethod(const std::string& method);
 
 std::string sanitizeHookedArgs(std::string args);
 
-// Control-path records are kept. Pump GetBuffer/ReleaseBuffer are omitted
-// unless pumpEnabled (later ticket). Args never keep a pcm= payload.
-std::vector<HookedCall> shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled);
+inline constexpr size_t kDefaultPumpRingCap = 64;
+
+struct CallLogView {
+    std::vector<HookedCall> entries;
+    uint32_t pumpXruns = 0;
+};
+
+// Control-path records are kept in full. Pump GetBuffer/ReleaseBuffer are
+// omitted unless pumpEnabled; when on, only the last pumpCap pump rows remain.
+// xrun counts include dropped pump records. Args never keep a pcm= payload.
+CallLogView shapeCallLog(const std::vector<HookedCall>& in, bool pumpEnabled,
+                         size_t pumpCap = kDefaultPumpRingCap);
 
 EtwInitializeHint extractHookedInitialize(const std::vector<HookedCall>& calls);
 

--- a/src/core/HookedCallPod.h
+++ b/src/core/HookedCallPod.h
@@ -7,6 +7,7 @@ namespace hook_ipc {
 
 constexpr uint32_t kMagic = 0x5741484Bu;
 constexpr uint32_t kCap = 2048;
+constexpr uint32_t kPumpCap = 64;
 
 struct CallPod {
     uint32_t streamId;
@@ -16,6 +17,7 @@ struct CallPod {
     char args[192];
     int32_t hresult;
     uint8_t pump;
+    uint8_t xrun;
     uint8_t hasCategory;
     uint8_t hasRaw;
     uint8_t hasMatchFormat;
@@ -33,7 +35,11 @@ struct Ring {
     uint32_t writeIndex;
     uint32_t cap;
     uint32_t dropped;
+    uint32_t pumpEnabled;
+    uint32_t pumpWriteIndex;
+    uint32_t pumpXruns;
     CallPod slots[kCap];
+    CallPod pumpSlots[kPumpCap];
 };
 
 inline void mapName(uint32_t pid, wchar_t* out, size_t n) {

--- a/src/core/OnDemandAttach.cpp
+++ b/src/core/OnDemandAttach.cpp
@@ -66,6 +66,7 @@ HookedCall fromPod(const hook_ipc::CallPod& p) {
     c.args = p.args;
     c.hresult = p.hresult;
     c.pump = p.pump != 0;
+    c.xrun = p.xrun != 0;
     if (p.hasCategory) c.category = std::string(p.category);
     if (p.hasRaw) c.raw = p.raw != 0;
     if (p.hasMatchFormat) c.matchFormat = p.matchFormat != 0;
@@ -237,7 +238,7 @@ Result OnDemandAttach::start(uint32_t pid) {
     HANDLE map = nullptr;
     DWORD mapErr = ERROR_SUCCESS;
     for (int i = 0; i < 40 && !map; ++i) {
-        map = OpenFileMappingW(FILE_MAP_READ, FALSE, mapNm);
+        map = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, mapNm);
         mapErr = map ? ERROR_SUCCESS : GetLastError();
         if (!map) Sleep(50);
     }
@@ -248,7 +249,7 @@ Result OnDemandAttach::start(uint32_t pid) {
                             "Attach: hook mapping not ready");
     }
     auto* ring = static_cast<hook_ipc::Ring*>(
-        MapViewOfFile(map, FILE_MAP_READ, 0, 0, sizeof(hook_ipc::Ring)));
+        MapViewOfFile(map, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(hook_ipc::Ring)));
     WA_LOG(wa::log::Level::Debug, "Attach", "MapViewOfFile", wa::narrowAscii(mapNm),
            ring ? "S_OK" : wa::log::hrName(HRESULT_FROM_WIN32(GetLastError())));
     if (!ring || ring->magic != hook_ipc::kMagic) {
@@ -284,6 +285,29 @@ std::vector<HookedCall> OnDemandAttach::drain() {
     }
     impl_->readIndex = write;
     return out;
+}
+
+std::vector<HookedCall> OnDemandAttach::pumpRing() const {
+    std::vector<HookedCall> out;
+    if (!attached() || !impl_->ring->pumpEnabled) return out;
+    const uint32_t write = impl_->ring->pumpWriteIndex;
+    const uint32_t n = write < hook_ipc::kPumpCap ? write : hook_ipc::kPumpCap;
+    out.reserve(n);
+    for (uint32_t i = write - n; i < write; ++i)
+        out.push_back(fromPod(impl_->ring->pumpSlots[i % hook_ipc::kPumpCap]));
+    return out;
+}
+
+uint32_t OnDemandAttach::pumpXruns() const {
+    if (!attached()) return 0;
+    return impl_->ring->pumpXruns;
+}
+
+void OnDemandAttach::setPumpEnabled(bool on) {
+    if (!impl_ || !impl_->ring) return;
+    impl_->ring->pumpEnabled = on ? 1u : 0u;
+    WA_LOG(wa::log::Level::Debug, "Attach", "setPumpEnabled",
+           on ? "on" : "off", "S_OK");
 }
 
 }  // namespace wa

--- a/src/core/OnDemandAttach.h
+++ b/src/core/OnDemandAttach.h
@@ -39,6 +39,9 @@ public:
     uint32_t pid() const;
     AttachBlock lastBlock() const;
     std::vector<HookedCall> drain();
+    std::vector<HookedCall> pumpRing() const;
+    uint32_t pumpXruns() const;
+    void setPumpEnabled(bool on);
 
 private:
     struct Impl;

--- a/src/core/PipelineGraph.h
+++ b/src/core/PipelineGraph.h
@@ -82,6 +82,7 @@ struct HookedCall {
     std::string args;
     int32_t hresult = 0;
     bool pump = false;
+    bool xrun = false;
     std::optional<std::string> category;
     std::optional<bool> raw;
     std::optional<bool> matchFormat;

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -212,7 +212,8 @@ void AppUi::applyPipelineJoin() {
         etw = wa::matchEtwInitialize(session, pipelineEtw_.snapshot(), wa::etwNowMs());
     pipelineEtwHint_ = etw;
     const auto hooked = wa::shapeCallLog(pipelineCalls_, false);
-    pipelineNodes_ = wa::assemblePipeline(session, pipelineEndpoint_, etw, pipelineProbes_, hooked);
+    pipelineNodes_ = wa::assemblePipeline(session, pipelineEndpoint_, etw, pipelineProbes_,
+                                          hooked.entries);
 }
 
 void AppUi::runPipelineProbe() {
@@ -263,6 +264,7 @@ void AppUi::runPipelineAttach() {
         return;
     }
     pipelineAttachBanner_.clear();
+    pipelineAttach_.setPumpEnabled(pipelinePump_);
     logLines_.push_back("pipeline attached pid=" + std::to_string(pid));
     applyPipelineJoin();
 }
@@ -843,6 +845,10 @@ void AppUi::drawPipelinePage() {
     } else if (etwStatus == wa::EtwWatchStatus::Listening) {
         ImGui::TextUnformatted(wa::ui_text::kPipelineEtwListening);
     }
+    if (ImGui::Checkbox(wa::ui_text::kPipelinePump, &pipelinePump_)) {
+        if (pipelineAttach_.attached())
+            pipelineAttach_.setPumpEnabled(pipelinePump_);
+    }
     if (pipelineAttach_.attached()) {
         ImGui::TextUnformatted(wa::ui_text::kPipelineAttached);
     } else if (!pipelineAttachBanner_.empty()) {
@@ -927,7 +933,14 @@ void AppUi::drawPipelinePage() {
     ImGui::SameLine();
     ImGui::BeginChild("pipelineCallLog", ImVec2(0, 0), true);
     ImGui::SeparatorText(wa::ui_text::kPipelineCallLog);
-    const auto callLog = wa::shapeCallLog(pipelineCalls_, false);
+    std::vector<wa::HookedCall> callSrc = pipelineCalls_;
+    if (pipelinePump_ && pipelineAttach_.attached()) {
+        auto pump = pipelineAttach_.pumpRing();
+        callSrc.insert(callSrc.end(), pump.begin(), pump.end());
+        ImGui::Text("%s: %u", wa::ui_text::kPipelineXruns, pipelineAttach_.pumpXruns());
+    }
+    const auto callView = wa::shapeCallLog(callSrc, pipelinePump_);
+    const auto& callLog = callView.entries;
     if (callLog.empty()) {
         ImGui::TextWrapped("%s", wa::ui_text::kPipelineCallLogEmpty);
     } else if (ImGui::BeginTable("pipelineCalls", 5,

--- a/src/gui/AppUi.h
+++ b/src/gui/AppUi.h
@@ -153,6 +153,7 @@ private:
     wa::OnDemandAttach pipelineAttach_;
     std::vector<wa::HookedCall> pipelineCalls_;
     std::string pipelineAttachBanner_;
+    bool pipelinePump_ = false;
 
     wa::StreamParams capParams_{};    // Advanced 弹窗编辑;Start 时传入(运行中只读)
     wa::StreamParams renParams_{};

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -77,5 +77,7 @@ inline constexpr const char* kPipelineCallColMethod = "Method";
 inline constexpr const char* kPipelineCallColArgs = "Args";
 inline constexpr const char* kPipelineCallColHr = "HR";
 inline constexpr const char* kPipelineCallColStream = "Stream";
+inline constexpr const char* kPipelinePump = "Record pump metadata";
+inline constexpr const char* kPipelineXruns = "xruns";
 
 } // namespace wa::ui_text

--- a/src/hook/WinAudioHook.cpp
+++ b/src/hook/WinAudioHook.cpp
@@ -16,6 +16,7 @@
 using wa::hook_ipc::CallPod;
 using wa::hook_ipc::Ring;
 using wa::hook_ipc::kCap;
+using wa::hook_ipc::kPumpCap;
 using wa::hook_ipc::kMagic;
 
 namespace {
@@ -40,6 +41,11 @@ using MuteGetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, BOOL*);
 using MuteSetFn = HRESULT(STDMETHODCALLTYPE*)(ISimpleAudioVolume*, BOOL, LPCGUID);
 using SessStateFn = HRESULT(STDMETHODCALLTYPE*)(IAudioSessionControl*, AudioSessionState*);
 using ClockFreqFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClock*, UINT64*);
+using CapGetBufFn = HRESULT(STDMETHODCALLTYPE*)(IAudioCaptureClient*, BYTE**, UINT32*, DWORD*,
+                                                UINT64*, UINT64*);
+using CapRelBufFn = HRESULT(STDMETHODCALLTYPE*)(IAudioCaptureClient*, UINT32);
+using RenGetBufFn = HRESULT(STDMETHODCALLTYPE*)(IAudioRenderClient*, UINT32, BYTE**);
+using RenRelBufFn = HRESULT(STDMETHODCALLTYPE*)(IAudioRenderClient*, UINT32, DWORD);
 
 ActivateFn g_activate = nullptr;
 GetDeviceFn g_getDevice = nullptr;
@@ -57,6 +63,10 @@ MuteGetFn g_muteGet = nullptr;
 MuteSetFn g_muteSet = nullptr;
 SessStateFn g_sessState = nullptr;
 ClockFreqFn g_clockFreq = nullptr;
+CapGetBufFn g_capGet = nullptr;
+CapRelBufFn g_capRel = nullptr;
+RenGetBufFn g_renGet = nullptr;
+RenRelBufFn g_renRel = nullptr;
 
 void copyStr(char* dst, size_t n, const char* src) {
     if (!dst || n == 0) return;
@@ -79,6 +89,15 @@ int64_t nowMs() {
 void emit(CallPod pod) {
     if (!g_ring || g_quiet) return;
     pod.timeMs = nowMs();
+    if (pod.pump) {
+        if (!g_ring->pumpEnabled) return;
+        if (pod.xrun)
+            InterlockedIncrement(reinterpret_cast<volatile LONG*>(&g_ring->pumpXruns));
+        const LONG idx =
+            InterlockedIncrement(reinterpret_cast<volatile LONG*>(&g_ring->pumpWriteIndex));
+        g_ring->pumpSlots[static_cast<uint32_t>(idx - 1) % kPumpCap] = pod;
+        return;
+    }
     const LONG idx = InterlockedIncrement(reinterpret_cast<volatile LONG*>(&g_ring->writeIndex));
     const uint32_t slot = static_cast<uint32_t>(idx - 1) % kCap;
     g_ring->slots[slot] = pod;
@@ -251,9 +270,80 @@ HRESULT STDMETHODCALLTYPE HookClockFreq(IAudioClock* self, UINT64* freq) {
     return hr;
 }
 
+HRESULT STDMETHODCALLTYPE HookCapGetBuffer(IAudioCaptureClient* self, BYTE** data, UINT32* frames,
+                                           DWORD* flags, UINT64* pos, UINT64* qpc) {
+    const HRESULT hr =
+        g_capGet ? g_capGet(self, data, frames, flags, pos, qpc) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    p.pump = 1;
+    copyStr(p.iface, sizeof(p.iface), "IAudioCaptureClient");
+    copyStr(p.method, sizeof(p.method), "GetBuffer");
+    const UINT32 n = (SUCCEEDED(hr) && frames) ? *frames : 0;
+    const DWORD fl = flags ? *flags : 0;
+    sprintf_s(p.args, "frames=%u flags=0x%lX", n, static_cast<unsigned long>(fl));
+    p.hresult = static_cast<int32_t>(hr);
+    p.xrun = (FAILED(hr) || (fl & AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY)) ? 1 : 0;
+    emit(p);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookCapReleaseBuffer(IAudioCaptureClient* self, UINT32 frames) {
+    const HRESULT hr = g_capRel ? g_capRel(self, frames) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    p.pump = 1;
+    copyStr(p.iface, sizeof(p.iface), "IAudioCaptureClient");
+    copyStr(p.method, sizeof(p.method), "ReleaseBuffer");
+    sprintf_s(p.args, "frames=%u", frames);
+    p.hresult = static_cast<int32_t>(hr);
+    p.xrun = FAILED(hr) ? 1 : 0;
+    emit(p);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookRenGetBuffer(IAudioRenderClient* self, UINT32 frames, BYTE** data) {
+    const HRESULT hr = g_renGet ? g_renGet(self, frames, data) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    p.pump = 1;
+    copyStr(p.iface, sizeof(p.iface), "IAudioRenderClient");
+    copyStr(p.method, sizeof(p.method), "GetBuffer");
+    sprintf_s(p.args, "frames=%u", frames);
+    p.hresult = static_cast<int32_t>(hr);
+    p.xrun = FAILED(hr) ? 1 : 0;
+    emit(p);
+    return hr;
+}
+
+HRESULT STDMETHODCALLTYPE HookRenReleaseBuffer(IAudioRenderClient* self, UINT32 frames,
+                                               DWORD flags) {
+    const HRESULT hr = g_renRel ? g_renRel(self, frames, flags) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    p.pump = 1;
+    copyStr(p.iface, sizeof(p.iface), "IAudioRenderClient");
+    copyStr(p.method, sizeof(p.method), "ReleaseBuffer");
+    sprintf_s(p.args, "frames=%u flags=0x%lX", frames, static_cast<unsigned long>(flags));
+    p.hresult = static_cast<int32_t>(hr);
+    p.xrun = FAILED(hr) ? 1 : 0;
+    emit(p);
+    return hr;
+}
+
 void patchService(void* obj, REFIID iid) {
     if (!obj) return;
-    if (iid == __uuidof(ISimpleAudioVolume)) {
+    if (iid == __uuidof(IAudioCaptureClient)) {
+        patchSlot(obj, 3, reinterpret_cast<void*>(&HookCapGetBuffer),
+                  reinterpret_cast<void**>(&g_capGet));
+        patchSlot(obj, 4, reinterpret_cast<void*>(&HookCapReleaseBuffer),
+                  reinterpret_cast<void**>(&g_capRel));
+    } else if (iid == __uuidof(IAudioRenderClient)) {
+        patchSlot(obj, 3, reinterpret_cast<void*>(&HookRenGetBuffer),
+                  reinterpret_cast<void**>(&g_renGet));
+        patchSlot(obj, 4, reinterpret_cast<void*>(&HookRenReleaseBuffer),
+                  reinterpret_cast<void**>(&g_renRel));
+    } else if (iid == __uuidof(ISimpleAudioVolume)) {
         patchSlot(obj, 3, reinterpret_cast<void*>(&HookVolGet), reinterpret_cast<void**>(&g_volGet));
         patchSlot(obj, 4, reinterpret_cast<void*>(&HookVolSet), reinterpret_cast<void**>(&g_volSet));
         patchSlot(obj, 5, reinterpret_cast<void*>(&HookMuteGet), reinterpret_cast<void**>(&g_muteGet));

--- a/src/tests/test_hooked_call.cpp
+++ b/src/tests/test_hooked_call.cpp
@@ -53,8 +53,9 @@ TEST(CallLog, DropsPumpWhenDisabled) {
     pump.pump = true;
     HookedCall init = initCall();
     const auto log = shapeCallLog({pump, init}, false);
-    ASSERT_EQ(log.size(), 1u);
-    EXPECT_EQ(log[0].method, "Initialize");
+    ASSERT_EQ(log.entries.size(), 1u);
+    EXPECT_EQ(log.entries[0].method, "Initialize");
+    EXPECT_EQ(log.pumpXruns, 0u);
 }
 
 TEST(CallLog, KeepsControlPathActivateAndInitialize) {
@@ -64,18 +65,18 @@ TEST(CallLog, KeepsControlPathActivateAndInitialize) {
     act.args = "iid=IAudioClient";
     act.hresult = 0;
     const auto log = shapeCallLog({act, initCall()}, false);
-    ASSERT_EQ(log.size(), 2u);
-    EXPECT_EQ(log[0].method, "Activate");
-    EXPECT_EQ(log[1].method, "Initialize");
+    ASSERT_EQ(log.entries.size(), 2u);
+    EXPECT_EQ(log.entries[0].method, "Activate");
+    EXPECT_EQ(log.entries[1].method, "Initialize");
 }
 
 TEST(CallLog, NeverLeavesPcmInArgs) {
     HookedCall c = initCall();
     c.args = "share=shared pcm=010203 frames=480";
     const auto log = shapeCallLog({c}, false);
-    ASSERT_EQ(log.size(), 1u);
-    EXPECT_EQ(log[0].args.find("pcm="), std::string::npos);
-    EXPECT_NE(log[0].args.find("share=shared"), std::string::npos);
+    ASSERT_EQ(log.entries.size(), 1u);
+    EXPECT_EQ(log.entries[0].args.find("pcm="), std::string::npos);
+    EXPECT_NE(log.entries[0].args.find("share=shared"), std::string::npos);
 }
 
 TEST(HookedJoin, InitializeOverridesEtwCategoryAndRaw) {
@@ -140,4 +141,80 @@ TEST(HookedJoin, PumpRecordsDoNotProduceInitializeHint) {
     const auto* mfx = findNode(nodes, "mfx");
     ASSERT_NE(mfx, nullptr);
     EXPECT_TRUE(hasParam(*mfx, "category", "Media", ObservationKind::Observed));
+}
+
+TEST(CallLog, PumpRingDropsOldestAndKeepsControlPath) {
+    std::vector<HookedCall> in;
+    HookedCall init = initCall();
+    init.timeMs = 1;
+    in.push_back(init);
+    for (int i = 0; i < 20; ++i) {
+        HookedCall p;
+        p.iface = "IAudioCaptureClient";
+        p.method = "GetBuffer";
+        p.args = "frames=480";
+        p.pump = true;
+        p.timeMs = 10 + i;
+        p.hresult = 0;
+        in.push_back(p);
+    }
+    HookedCall stop;
+    stop.iface = "IAudioClient";
+    stop.method = "Stop";
+    stop.timeMs = 1000;
+    in.push_back(stop);
+
+    const auto log = shapeCallLog(in, true, 8);
+    size_t control = 0, pump = 0;
+    bool sawInit = false, sawStop = false;
+    int firstPumpTime = -1, lastPumpTime = -1;
+    for (const auto& c : log.entries) {
+        if (c.pump || isPumpMethod(c.method)) {
+            ++pump;
+            if (firstPumpTime < 0) firstPumpTime = static_cast<int>(c.timeMs);
+            lastPumpTime = static_cast<int>(c.timeMs);
+        } else {
+            ++control;
+            if (c.method == "Initialize") sawInit = true;
+            if (c.method == "Stop") sawStop = true;
+        }
+    }
+    EXPECT_EQ(control, 2u);
+    EXPECT_TRUE(sawInit);
+    EXPECT_TRUE(sawStop);
+    EXPECT_EQ(pump, 8u);
+    EXPECT_EQ(firstPumpTime, 22);
+    EXPECT_EQ(lastPumpTime, 29);
+}
+
+TEST(CallLog, XrunAggregationCountsDroppedPumpRecords) {
+    std::vector<HookedCall> in;
+    in.push_back(initCall());
+    for (int i = 0; i < 12; ++i) {
+        HookedCall p;
+        p.method = "GetBuffer";
+        p.pump = true;
+        p.xrun = (i % 3 == 0);
+        p.hresult = 0;
+        p.args = "frames=480";
+        in.push_back(p);
+    }
+    const auto log = shapeCallLog(in, true, 4);
+    EXPECT_EQ(log.pumpXruns, 4u);
+    size_t pump = 0;
+    for (const auto& c : log.entries)
+        if (c.pump) ++pump;
+    EXPECT_EQ(pump, 4u);
+}
+
+TEST(CallLog, EnabledPumpStillStripsPcm) {
+    HookedCall p;
+    p.method = "GetBuffer";
+    p.pump = true;
+    p.args = "frames=480 pcm=DEADBEEF";
+    const auto log = shapeCallLog({initCall(), p}, true, 8);
+    ASSERT_EQ(log.entries.size(), 2u);
+    for (const auto& c : log.entries) {
+        EXPECT_EQ(c.args.find("pcm="), std::string::npos);
+    }
 }

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -105,4 +105,6 @@ TEST(PipelineUiText, ExposesPipelineTabControls) {
     EXPECT_STREQ(wa::ui_text::kPipelineCallColArgs, "Args");
     EXPECT_STREQ(wa::ui_text::kPipelineCallColHr, "HR");
     EXPECT_STREQ(wa::ui_text::kPipelineCallColStream, "Stream");
+    EXPECT_STREQ(wa::ui_text::kPipelinePump, "Record pump metadata");
+    EXPECT_STREQ(wa::ui_text::kPipelineXruns, "xruns");
 }


### PR DESCRIPTION
## What / Why

The Call log kept control-path Core Audio calls and omitted GetBuffer/ReleaseBuffer so Initialize was not drowned in 10 ms noise. Testers still need a way to prove a Hooked stream is pumping. This PR adds an optional **pump metadata** ring with xrun counts. Default remains off. PCM is never stored.

Closes #68. Parent: #63. Design: `docs/superpowers/specs/2026-08-21-winaudio-pipeline-inspector-design.md` section 4.5.

## How

- `shapeCallLog` keeps every control-path record. When pump is enabled, only the last 64 GetBuffer/ReleaseBuffer rows remain; oldest pump rows drop; xrun counts include dropped pump records. `pcm=` is stripped from args. Entries stay time-ordered.
- The inject mapping has a separate pump ring so control-path slots are not overwritten. The hook logs frames/flags/HRESULT only (never the buffer pointer) and counts xruns when pump is on (failed HRESULT or capture `DATA_DISCONTINUITY`).
- GUI: **Record pump metadata** is off by default; when on, the Call log shows the ring and an xrun count.

## Testing

- Local Debug: `WinAudioTests` **310/310 passed**.
- Targeted: `CallLog.*` (default-off, ring eviction, xrun aggregation, no PCM).
- Release ctest was not re-run in this session; CI matrix covers Debug + Release.
- Device-free tests use canned pump records, not live inject.
- GUI: no screenshot in this PR. Real-device smoke (attach then enable pump) not recorded here.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] Debug ctest passed locally; Release covered by CI
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
