### PR TITLE
fix(gui): recover Pipeline attach Call log and clipped rows

### DIFF
--- a/src/core/HookedCall.cpp
+++ b/src/core/HookedCall.cpp
@@ -51,13 +51,16 @@ EtwInitializeHint extractHookedInitialize(const std::vector<HookedCall>& calls) 
     EtwInitializeHint h;
     for (const auto& c : calls) {
         if (c.pump || isPumpMethod(c.method)) continue;
-        if (c.method != "Initialize" && c.method != "SetClientProperties") continue;
+        if (c.method != "Initialize" && c.method != "SetClientProperties" &&
+            c.method != "InitializeSharedAudioStream")
+            continue;
         h.present = true;
         if (c.category) h.category = c.category;
         if (c.raw) h.raw = c.raw;
         if (c.matchFormat) h.matchFormat = c.matchFormat;
         if (c.exclusive) h.exclusive = c.exclusive;
-        if (c.method == "Initialize") h.hresult = c.hresult;
+        if (c.method == "Initialize" || c.method == "InitializeSharedAudioStream")
+            h.hresult = c.hresult;
         if (c.format) h.format = c.format;
     }
     return h;

--- a/src/core/HookedCallPod.h
+++ b/src/core/HookedCallPod.h
@@ -1,4 +1,12 @@
 #pragma once
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <sddl.h>
 #include <cstdint>
 #include <cstdio>
 
@@ -8,6 +16,42 @@ namespace hook_ipc {
 constexpr uint32_t kMagic = 0x5741484Bu;
 constexpr uint32_t kCap = 2048;
 constexpr uint32_t kPumpCap = 64;
+
+constexpr uint32_t kInstallPending = 0;
+constexpr uint32_t kInstallOk = 1;
+constexpr uint32_t kInstallFailed = 2;
+constexpr uint32_t kRingLayout = 2;
+
+// IUnknown occupies slots 0-2. These match the Windows SDK vtables.
+constexpr int kSlotDeviceActivate = 3;
+constexpr int kSlotEnumeratorEnumEndpoints = 3;
+constexpr int kSlotEnumeratorGetDefault = 4;
+constexpr int kSlotEnumeratorGetDevice = 5;
+constexpr int kSlotClientInitialize = 3;
+constexpr int kSlotClientStart = 10;
+constexpr int kSlotClientStop = 11;
+constexpr int kSlotClientReset = 12;
+constexpr int kSlotClientSetEventHandle = 13;
+constexpr int kSlotClientGetService = 14;
+constexpr int kSlotClientSetProperties = 16;
+constexpr int kSlotClientInitializeShared = 20;
+constexpr int kSlotBufferGetBuffer = 3;
+constexpr int kSlotBufferReleaseBuffer = 4;
+
+inline bool patchVtableSlot(void* obj, int slot, void* hook, void** orig) {
+    if (!obj || !hook || !orig) return false;
+    void** vt = *reinterpret_cast<void***>(obj);
+    void** cell = vt + slot;
+    if (*orig == nullptr) *orig = *cell;
+    if (*cell == hook) return true;
+    DWORD old = 0;
+    if (!VirtualProtect(cell, sizeof(void*), PAGE_EXECUTE_READWRITE, &old)) return false;
+    *cell = hook;
+    DWORD tmp = 0;
+    VirtualProtect(cell, sizeof(void*), old, &tmp);
+    FlushInstructionCache(GetCurrentProcess(), cell, sizeof(void*));
+    return true;
+}
 
 struct CallPod {
     uint32_t streamId;
@@ -38,12 +82,36 @@ struct Ring {
     uint32_t pumpEnabled;
     uint32_t pumpWriteIndex;
     uint32_t pumpXruns;
+    uint32_t installed;
+    uint32_t flow;  // 0 = capture, 1 = render
+    wchar_t deviceId[256];
     CallPod slots[kCap];
     CallPod pumpSlots[kPumpCap];
 };
 
 inline void mapName(uint32_t pid, wchar_t* out, size_t n) {
-    swprintf_s(out, n, L"Local\\WinAudioHook-%u", pid);
+    swprintf_s(out, n, L"Local\\WinAudioHook-%u-%u", kRingLayout, pid);
+}
+
+// Everyone + Low mandatory label so an elevated GUI mapping is visible to a
+// medium-IL target (and the reverse). CreateFileMapping copies the SD.
+inline HANDLE createHookMapping(uint32_t pid, bool* sdApplied = nullptr) {
+    wchar_t name[64] = {};
+    mapName(pid, name, 64);
+    PSECURITY_DESCRIPTOR sd = nullptr;
+    SECURITY_ATTRIBUTES sa{};
+    sa.nLength = sizeof(sa);
+    const bool converted = ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                               L"D:(A;;GA;;;WD)S:(ML;;NW;;;LW)", SDDL_REVISION_1, &sd, nullptr) !=
+                           FALSE;
+    if (sdApplied) *sdApplied = converted;
+    if (converted) sa.lpSecurityDescriptor = sd;
+    HANDLE h = CreateFileMappingW(INVALID_HANDLE_VALUE, converted ? &sa : nullptr, PAGE_READWRITE, 0,
+                                  static_cast<DWORD>(sizeof(Ring)), name);
+    const DWORD err = GetLastError();
+    if (sd) LocalFree(sd);
+    SetLastError(err);
+    return h;
 }
 
 }  // namespace hook_ipc

--- a/src/core/OnDemandAttach.cpp
+++ b/src/core/OnDemandAttach.cpp
@@ -43,6 +43,15 @@ bool sameBitness(HANDLE proc) {
     return selfWow == targetWow;
 }
 
+std::wstring utf8ToWide(const std::string& s) {
+    if (s.empty()) return {};
+    int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), nullptr, 0);
+    if (n <= 0) return {};
+    std::wstring w(static_cast<size_t>(n), 0);
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), w.data(), n);
+    return w;
+}
+
 std::wstring hookDllPath() {
     wchar_t path[MAX_PATH] = {};
     GetModuleFileNameW(nullptr, path, MAX_PATH);
@@ -55,6 +64,46 @@ std::wstring hookDllPath() {
         wcscat_s(path, L"WinAudioHook.dll");
     }
     return path;
+}
+
+std::wstring stageHookDll() {
+    const std::wstring src = hookDllPath();
+    const auto slash = src.find_last_of(L"\\/");
+    if (slash == std::wstring::npos) return src;
+    std::wstring dst = src.substr(0, slash + 1) + stagedHookFileName();
+    if (!CopyFileW(src.c_str(), dst.c_str(), FALSE)) {
+        const DWORD err = GetLastError();
+        WA_LOG(wa::log::Level::Warn, "Attach", "CopyFile(stage hook)", wa::narrowAscii(dst),
+               wa::log::hrName(HRESULT_FROM_WIN32(err)));
+        if (GetFileAttributesW(dst.c_str()) == INVALID_FILE_ATTRIBUTES) return src;
+    }
+    return dst;
+}
+
+void enableDebugPrivilege() {
+    HANDLE tok = nullptr;
+    if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &tok)) {
+        WA_LOG(wa::log::Level::Debug, "Attach", "OpenProcessToken", "",
+               wa::log::hrName(HRESULT_FROM_WIN32(GetLastError())));
+        return;
+    }
+    LUID luid{};
+    if (!LookupPrivilegeValueW(nullptr, SE_DEBUG_NAME, &luid)) {
+        WA_LOG(wa::log::Level::Debug, "Attach", "LookupPrivilegeValueW(SeDebugPrivilege)", "",
+               wa::log::hrName(HRESULT_FROM_WIN32(GetLastError())));
+        CloseHandle(tok);
+        return;
+    }
+    TOKEN_PRIVILEGES tp{};
+    tp.PrivilegeCount = 1;
+    tp.Privileges[0].Luid = luid;
+    tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+    AdjustTokenPrivileges(tok, FALSE, &tp, 0, nullptr, nullptr);
+    const DWORD err = GetLastError();
+    WA_LOG(err == ERROR_SUCCESS ? wa::log::Level::Debug : wa::log::Level::Warn, "Attach",
+           "AdjustTokenPrivileges(SeDebugPrivilege)", "",
+           wa::log::hrName(HRESULT_FROM_WIN32(err)));
+    CloseHandle(tok);
 }
 
 HookedCall fromPod(const hook_ipc::CallPod& p) {
@@ -117,14 +166,20 @@ Result injectDll(HANDLE proc, const std::wstring& dll) {
         return win32Result(thrErr, "Attach: CreateRemoteThread");
     }
     const DWORD wait = WaitForSingleObject(thread, 10000);
+    DWORD exitCode = 0;
+    GetExitCodeThread(thread, &exitCode);
     WA_LOG(wait == WAIT_OBJECT_0 ? wa::log::Level::Debug : wa::log::Level::Warn, "Attach",
-           "WaitForSingleObject(inject)", "",
+           "WaitForSingleObject(inject)", "exit=" + std::to_string(exitCode),
            wait == WAIT_OBJECT_0 ? "S_OK" : wa::log::hrName(HRESULT_FROM_WIN32(wait)));
     CloseHandle(thread);
     VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
-    if (wait != WAIT_OBJECT_0)
-        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(ERROR_TIMEOUT)),
-                            "Attach: inject timed out");
+    if (!remoteLoadLibrarySucceeded(wait, exitCode)) {
+        if (wait != WAIT_OBJECT_0)
+            return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(ERROR_TIMEOUT)),
+                                "Attach: inject timed out");
+        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND)),
+                            "Attach: LoadLibraryW failed in target");
+    }
     return Result::Ok();
 }
 
@@ -140,6 +195,20 @@ const char* attachBlockText(AttachBlock block) {
         case AttachBlock::NoDebugRights: return "Attach failed: missing debug rights";
     }
     return "Attach failed";
+}
+
+bool remoteLoadLibrarySucceeded(uint32_t waitResult, uint32_t exitCode) {
+    return waitResult == WAIT_OBJECT_0 && exitCode != 0;
+}
+
+const char* attachInstallFailMessage(uint32_t installed) {
+    return installed == hook_ipc::kInstallFailed
+               ? "Attach: hook install failed in target"
+               : "Attach: hook install did not finish; restart the target app and retry";
+}
+
+std::wstring stagedHookFileName() {
+    return L"WinAudioHook-" + std::to_wstring(hook_ipc::kRingLayout) + L".dll";
 }
 
 AttachBlock evaluateAttach(uint32_t pid, uint32_t ourPid, bool sameBitnessFlag, bool hasDebugRights,
@@ -190,9 +259,10 @@ AttachBlock OnDemandAttach::lastBlock() const {
     return impl_ ? impl_->block : AttachBlock::PidZero;
 }
 
-Result OnDemandAttach::start(uint32_t pid) {
+Result OnDemandAttach::start(uint32_t pid, const std::string& deviceIdUtf8, PipelineFlow flow) {
     stop();
     impl_->block = AttachBlock::PidZero;
+    enableDebugPrivilege();
     const uint32_t ourPid = GetCurrentProcessId();
 
     HANDLE query = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
@@ -225,38 +295,71 @@ Result OnDemandAttach::start(uint32_t pid) {
         return Result::Fail(static_cast<long>(E_ACCESSDENIED), attachBlockText(impl_->block));
     }
 
-    const std::wstring dll = hookDllPath();
-    Result inj = injectDll(inject, dll);
-    CloseHandle(inject);
-    if (!inj) {
-        WA_LOG(wa::log::Level::Info, "Attach", "inject", inj.message, "fail");
-        return inj;
-    }
-
     wchar_t mapNm[64] = {};
     hook_ipc::mapName(pid, mapNm, 64);
-    HANDLE map = nullptr;
-    DWORD mapErr = ERROR_SUCCESS;
-    for (int i = 0; i < 40 && !map; ++i) {
-        map = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, mapNm);
-        mapErr = map ? ERROR_SUCCESS : GetLastError();
-        if (!map) Sleep(50);
+    SetLastError(ERROR_SUCCESS);
+    bool sdApplied = false;
+    HANDLE map = hook_ipc::createHookMapping(pid, &sdApplied);
+    const DWORD mapErr = GetLastError();
+    if (!sdApplied) {
+        WA_LOG(wa::log::Level::Warn, "Attach", "ConvertStringSecurityDescriptor",
+               wa::narrowAscii(mapNm), "ignored");
     }
-    WA_LOG(wa::log::Level::Debug, "Attach", "OpenFileMapping", wa::narrowAscii(mapNm),
-           wa::log::hrName(HRESULT_FROM_WIN32(mapErr)));
+    WA_LOG(wa::log::Level::Debug, "Attach", "CreateFileMapping", wa::narrowAscii(mapNm),
+           map ? (mapErr == ERROR_ALREADY_EXISTS ? "already-exists" : "S_OK")
+               : wa::log::hrName(HRESULT_FROM_WIN32(mapErr)));
     if (!map) {
-        return Result::Fail(static_cast<long>(HRESULT_FROM_WIN32(mapErr)),
-                            "Attach: hook mapping not ready");
+        CloseHandle(inject);
+        return win32Result(mapErr, "Attach: CreateFileMapping");
     }
     auto* ring = static_cast<hook_ipc::Ring*>(
         MapViewOfFile(map, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(hook_ipc::Ring)));
     WA_LOG(wa::log::Level::Debug, "Attach", "MapViewOfFile", wa::narrowAscii(mapNm),
            ring ? "S_OK" : wa::log::hrName(HRESULT_FROM_WIN32(GetLastError())));
-    if (!ring || ring->magic != hook_ipc::kMagic) {
-        if (ring) UnmapViewOfFile(ring);
+    if (!ring) {
+        const DWORD err = GetLastError();
         CloseHandle(map);
-        return Result::Fail(static_cast<long>(E_FAIL), "Attach: hook mapping invalid");
+        CloseHandle(inject);
+        return win32Result(err, "Attach: MapViewOfFile");
     }
+
+    const bool reuse = mapErr == ERROR_ALREADY_EXISTS && ring->magic == hook_ipc::kMagic &&
+                       ring->installed == hook_ipc::kInstallOk;
+    if (!reuse) {
+        ZeroMemory(ring, sizeof(*ring));
+        ring->magic = hook_ipc::kMagic;
+        ring->cap = hook_ipc::kCap;
+        ring->installed = hook_ipc::kInstallPending;
+        const std::wstring wid = utf8ToWide(deviceIdUtf8);
+        if (!wid.empty())
+            wcsncpy_s(ring->deviceId, wid.c_str(), _TRUNCATE);
+        ring->flow = flow == PipelineFlow::Render ? 1u : 0u;
+    }
+
+    const std::wstring dll = stageHookDll();
+    Result inj = injectDll(inject, dll);
+    CloseHandle(inject);
+    if (!inj) {
+        WA_LOG(wa::log::Level::Info, "Attach", "inject", inj.message, "fail");
+        UnmapViewOfFile(ring);
+        CloseHandle(map);
+        return inj;
+    }
+
+    if (!reuse) {
+        for (int i = 0; i < 80 && ring->installed == hook_ipc::kInstallPending; ++i)
+            Sleep(50);
+        const uint32_t installed = ring->installed;
+        WA_LOG(installed == hook_ipc::kInstallOk ? wa::log::Level::Debug : wa::log::Level::Info,
+               "Attach", "hook installed", "pid=" + std::to_string(pid),
+               installed == hook_ipc::kInstallOk ? "S_OK" : attachInstallFailMessage(installed));
+        if (installed != hook_ipc::kInstallOk) {
+            UnmapViewOfFile(ring);
+            CloseHandle(map);
+            return Result::Fail(static_cast<long>(E_FAIL), attachInstallFailMessage(installed));
+        }
+    }
+
     impl_->map = map;
     impl_->ring = ring;
     impl_->pid = pid;

--- a/src/core/OnDemandAttach.h
+++ b/src/core/OnDemandAttach.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "HookedCall.h"
+#include "PipelineGraph.h"
 #include "Result.h"
 #include <cstdint>
 #include <memory>
@@ -26,6 +27,15 @@ const char* attachBlockText(AttachBlock block);
 AttachBlock evaluateAttach(uint32_t pid, uint32_t ourPid, bool sameBitness, bool hasDebugRights,
                            const std::string& processName);
 
+// Remote LoadLibraryW thread must complete and return a non-zero HMODULE.
+bool remoteLoadLibrarySucceeded(uint32_t waitResult, uint32_t exitCode);
+
+// Message for a failed hook install. Callers must snapshot `installed` before
+// UnmapViewOfFile — the view is invalid afterwards.
+const char* attachInstallFailMessage(uint32_t installed);
+
+std::wstring stagedHookFileName();
+
 class OnDemandAttach {
 public:
     OnDemandAttach();
@@ -33,7 +43,8 @@ public:
     OnDemandAttach(const OnDemandAttach&) = delete;
     OnDemandAttach& operator=(const OnDemandAttach&) = delete;
 
-    Result start(uint32_t pid);
+    Result start(uint32_t pid, const std::string& deviceIdUtf8 = {},
+                 PipelineFlow flow = PipelineFlow::Capture);
     void stop();
     bool attached() const;
     uint32_t pid() const;

--- a/src/core/PipelineGraph.cpp
+++ b/src/core/PipelineGraph.cpp
@@ -1,7 +1,6 @@
 #include "PipelineGraph.h"
 #include "HookedCall.h"
 #include <algorithm>
-#include <cstring>
 
 namespace wa {
 namespace {

--- a/src/gui/AppUi.cpp
+++ b/src/gui/AppUi.cpp
@@ -254,9 +254,10 @@ void AppUi::runPipelineProbe() {
 void AppUi::runPipelineAttach() {
     if (pipelineSelected_ < 0 || pipelineSelected_ >= (int)pipelineSessions_.size())
         return;
-    const uint32_t pid = pipelineSessions_[(size_t)pipelineSelected_].processId;
+    const auto& session = pipelineSessions_[(size_t)pipelineSelected_];
+    const uint32_t pid = session.processId;
     pipelineCalls_.clear();
-    wa::Result r = pipelineAttach_.start(pid);
+    wa::Result r = pipelineAttach_.start(pid, session.deviceId, session.flow);
     if (!r) {
         pipelineAttachBanner_ = r.message;
         logLines_.push_back("pipeline attach failed: " + r.message);
@@ -818,7 +819,10 @@ void AppUi::drawPipelinePage() {
     const float topHeight = std::max(120.0f, availY - kLogHeight - ImGui::GetStyle().ItemSpacing.y);
 
     ImGui::BeginChild("pipelineTop", ImVec2(0, topHeight), false);
-    ImGui::BeginChild("pipelineLeft", ImVec2(420, 0), true);
+    const float availX = ImGui::GetContentRegionAvail().x;
+    float leftW = std::clamp(availX * 0.40f, 520.f, 720.f);
+    if (availX < 980.f) leftW = std::max(420.f, availX * 0.42f);
+    ImGui::BeginChild("pipelineLeft", ImVec2(leftW, 0), true);
     ImGui::SeparatorText(wa::ui_text::kPipelineSessions);
     if (ImGui::Button(wa::ui_text::kPipelineRefresh))
         refreshPipelineSessions();
@@ -861,23 +865,28 @@ void AppUi::drawPipelinePage() {
         ImGui::TextWrapped("%s", wa::ui_text::kPipelineEmpty);
     } else if (ImGui::BeginTable("pipelineSessions", 7,
                                  ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
-                                     ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp)) {
+                                     ImGuiTableFlags_ScrollY | ImGuiTableFlags_ScrollX |
+                                     ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingFixedFit,
+                                 ImVec2(0, ImGui::GetContentRegionAvail().y))) {
         ImGui::TableSetupColumn("Flow", ImGuiTableColumnFlags_WidthFixed, 70.f);
-        ImGui::TableSetupColumn("Process");
-        ImGui::TableSetupColumn("PID", ImGuiTableColumnFlags_WidthFixed, 60.f);
-        ImGui::TableSetupColumn("Device");
-        ImGui::TableSetupColumn("Vol", ImGuiTableColumnFlags_WidthFixed, 40.f);
-        ImGui::TableSetupColumn("Mute", ImGuiTableColumnFlags_WidthFixed, 40.f);
-        ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 70.f);
+        ImGui::TableSetupColumn("Process", ImGuiTableColumnFlags_WidthFixed, 180.f);
+        ImGui::TableSetupColumn("PID", ImGuiTableColumnFlags_WidthFixed, 64.f);
+        ImGui::TableSetupColumn("Device", ImGuiTableColumnFlags_WidthFixed, 240.f);
+        ImGui::TableSetupColumn("Vol", ImGuiTableColumnFlags_WidthFixed, 48.f);
+        ImGui::TableSetupColumn("Mute", ImGuiTableColumnFlags_WidthFixed, 48.f);
+        ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, 72.f);
         ImGui::TableHeadersRow();
         for (int i = 0; i < (int)pipelineSessions_.size(); ++i) {
             const auto& s = pipelineSessions_[(size_t)i];
+            const std::string tip = wa::ui_text::formatLiveSessionTooltip(s);
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
             const bool selected = (i == pipelineSelected_);
             char label[64];
             std::snprintf(label, sizeof(label), "%s##ps%d",
-                          s.flow == wa::PipelineFlow::Capture ? "capture" : "render", i);
+                          s.flow == wa::PipelineFlow::Capture ? wa::ui_text::kPipelineFlowCapture
+                                                             : wa::ui_text::kPipelineFlowRender,
+                          i);
             if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns)) {
                 if (pipelineSelected_ != i) {
                     pipelineProbes_.clear();
@@ -890,18 +899,26 @@ void AppUi::drawPipelinePage() {
                 pipelineSelected_ = i;
                 rebuildPipelineGraph();
             }
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(1);
             ImGui::TextUnformatted(s.processName.c_str());
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(2);
             ImGui::Text("%u", s.processId);
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(3);
             ImGui::TextUnformatted(s.deviceName.c_str());
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(4);
             ImGui::Text("%.2f", static_cast<double>(s.sessionVolume));
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(5);
-            ImGui::TextUnformatted(s.sessionMute ? "yes" : "no");
+            ImGui::TextUnformatted(s.sessionMute ? wa::ui_text::kPipelineMuteYes
+                                                 : wa::ui_text::kPipelineMuteNo);
+            ImGui::SetItemTooltip("%s", tip.c_str());
             ImGui::TableSetColumnIndex(6);
             ImGui::TextUnformatted(s.state.c_str());
+            ImGui::SetItemTooltip("%s", tip.c_str());
         }
         ImGui::EndTable();
     }
@@ -942,7 +959,8 @@ void AppUi::drawPipelinePage() {
     const auto callView = wa::shapeCallLog(callSrc, pipelinePump_);
     const auto& callLog = callView.entries;
     if (callLog.empty()) {
-        ImGui::TextWrapped("%s", wa::ui_text::kPipelineCallLogEmpty);
+        ImGui::TextWrapped("%s", wa::ui_text::pipelineCallLogEmptyText(pipelineAttach_.attached(),
+                                                                      pipelinePump_));
     } else if (ImGui::BeginTable("pipelineCalls", 5,
                                  ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                      ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp)) {

--- a/src/gui/AppUiText.h
+++ b/src/gui/AppUiText.h
@@ -1,4 +1,7 @@
 #pragma once
+#include "PipelineGraph.h"
+#include <cstdio>
+#include <string>
 
 namespace wa::ui_text {
 
@@ -70,6 +73,41 @@ inline constexpr const char* kPipelineCallLog = "Call log";
 inline constexpr const char* kPipelineAttached = "Attached";
 inline constexpr const char* kPipelineCallLogEmpty =
     "No control-path calls yet. Attach to intercept Core Audio COM.";
+inline constexpr const char* kPipelineCallLogWaiting =
+    "Attached. Call log waits for the next control-path call (Initialize, Start, Stop, "
+    "GetService). Enable Record pump metadata to see GetBuffer/ReleaseBuffer.";
+inline constexpr const char* kPipelineCallLogWaitingPump =
+    "Attached with pump metadata on. Waiting for GetBuffer/ReleaseBuffer. If this stays "
+    "empty, the process may not be using Core Audio COM on this device.";
+inline constexpr const char* kPipelineFlowCapture = "capture";
+inline constexpr const char* kPipelineFlowRender = "render";
+inline constexpr const char* kPipelineMuteYes = "yes";
+inline constexpr const char* kPipelineMuteNo = "no";
+
+inline std::string formatLiveSessionTooltip(const LiveSessionView& row) {
+    char vol[16];
+    std::snprintf(vol, sizeof(vol), "%.2f", static_cast<double>(row.sessionVolume));
+    std::string out;
+    out.reserve(128 + row.processName.size() + row.deviceName.size() + row.state.size());
+    out += (row.flow == PipelineFlow::Capture) ? kPipelineFlowCapture : kPipelineFlowRender;
+    out += "\nprocess: ";
+    out += row.processName;
+    out += "\npid: ";
+    out += std::to_string(row.processId);
+    out += "\ndevice: ";
+    out += row.deviceName;
+    out += "\nvolume: ";
+    out += vol;
+    out += "\nmute: ";
+    out += row.sessionMute ? kPipelineMuteYes : kPipelineMuteNo;
+    out += "\nstate: ";
+    out += row.state;
+    return out;
+}
+inline const char* pipelineCallLogEmptyText(bool attached, bool pumpEnabled) {
+    if (!attached) return kPipelineCallLogEmpty;
+    return pumpEnabled ? kPipelineCallLogWaitingPump : kPipelineCallLogWaiting;
+}
 inline constexpr const char* kPipelineCrossBitness = "Attach failed: cross-bitness";
 inline constexpr const char* kPipelineNoDebug = "Attach failed: missing debug rights";
 inline constexpr const char* kPipelineCallColIface = "Iface";

--- a/src/hook/CMakeLists.txt
+++ b/src/hook/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(WinAudioHook SHARED WinAudioHook.cpp)
 target_include_directories(WinAudioHook PRIVATE ${CMAKE_SOURCE_DIR}/src/core)
-target_link_libraries(WinAudioHook PRIVATE ole32 oleaut32 mmdevapi uuid)
+target_link_libraries(WinAudioHook PRIVATE ole32 oleaut32 mmdevapi uuid advapi32)
 wa_set_project_warnings(WinAudioHook)

--- a/src/hook/WinAudioHook.cpp
+++ b/src/hook/WinAudioHook.cpp
@@ -18,6 +18,9 @@ using wa::hook_ipc::Ring;
 using wa::hook_ipc::kCap;
 using wa::hook_ipc::kPumpCap;
 using wa::hook_ipc::kMagic;
+using wa::hook_ipc::kInstallPending;
+using wa::hook_ipc::kInstallOk;
+using wa::hook_ipc::kInstallFailed;
 
 namespace {
 
@@ -28,8 +31,11 @@ volatile LONG g_quiet = 0;
 using ActivateFn = HRESULT(STDMETHODCALLTYPE*)(IMMDevice*, REFIID, DWORD, PROPVARIANT*, void**);
 using GetDeviceFn = HRESULT(STDMETHODCALLTYPE*)(IMMDeviceEnumerator*, LPCWSTR, IMMDevice**);
 using GetDefaultFn = HRESULT(STDMETHODCALLTYPE*)(IMMDeviceEnumerator*, EDataFlow, ERole, IMMDevice**);
+using EnumFn = HRESULT(STDMETHODCALLTYPE*)(IMMDeviceEnumerator*, EDataFlow, DWORD, IMMDeviceCollection**);
 using InitializeFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*, AUDCLNT_SHAREMODE, DWORD,
                                                  REFERENCE_TIME, REFERENCE_TIME, const WAVEFORMATEX*,
+                                                 LPCGUID);
+using InitSharedFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient3*, DWORD, UINT32, const WAVEFORMATEX*,
                                                  LPCGUID);
 using SimpleHrFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*);
 using SetEventFn = HRESULT(STDMETHODCALLTYPE*)(IAudioClient*, HANDLE);
@@ -50,7 +56,9 @@ using RenRelBufFn = HRESULT(STDMETHODCALLTYPE*)(IAudioRenderClient*, UINT32, DWO
 ActivateFn g_activate = nullptr;
 GetDeviceFn g_getDevice = nullptr;
 GetDefaultFn g_getDefault = nullptr;
+EnumFn g_enum = nullptr;
 InitializeFn g_initialize = nullptr;
+InitSharedFn g_initShared = nullptr;
 SimpleHrFn g_start = nullptr;
 SimpleHrFn g_stop = nullptr;
 SimpleHrFn g_reset = nullptr;
@@ -157,18 +165,7 @@ void formatWave(const WAVEFORMATEX* fmt, char* out, size_t n) {
 }
 
 bool patchSlot(void* obj, int slot, void* hook, void** orig) {
-    if (!obj || !hook || !orig) return false;
-    void** vt = *reinterpret_cast<void***>(obj);
-    void** cell = vt + slot;
-    if (*orig == nullptr) *orig = *cell;
-    if (*cell == hook) return true;
-    DWORD old = 0;
-    if (!VirtualProtect(cell, sizeof(void*), PAGE_EXECUTE_READWRITE, &old)) return false;
-    *cell = hook;
-    DWORD tmp = 0;
-    VirtualProtect(cell, sizeof(void*), old, &tmp);
-    FlushInstructionCache(GetCurrentProcess(), cell, sizeof(void*));
-    return true;
+    return wa::hook_ipc::patchVtableSlot(obj, slot, hook, orig);
 }
 
 HRESULT STDMETHODCALLTYPE HookInitialize(IAudioClient* self, AUDCLNT_SHAREMODE share, DWORD flags,
@@ -333,15 +330,17 @@ HRESULT STDMETHODCALLTYPE HookRenReleaseBuffer(IAudioRenderClient* self, UINT32 
 
 void patchService(void* obj, REFIID iid) {
     if (!obj) return;
+    using wa::hook_ipc::kSlotBufferGetBuffer;
+    using wa::hook_ipc::kSlotBufferReleaseBuffer;
     if (iid == __uuidof(IAudioCaptureClient)) {
-        patchSlot(obj, 3, reinterpret_cast<void*>(&HookCapGetBuffer),
+        patchSlot(obj, kSlotBufferGetBuffer, reinterpret_cast<void*>(&HookCapGetBuffer),
                   reinterpret_cast<void**>(&g_capGet));
-        patchSlot(obj, 4, reinterpret_cast<void*>(&HookCapReleaseBuffer),
+        patchSlot(obj, kSlotBufferReleaseBuffer, reinterpret_cast<void*>(&HookCapReleaseBuffer),
                   reinterpret_cast<void**>(&g_capRel));
     } else if (iid == __uuidof(IAudioRenderClient)) {
-        patchSlot(obj, 3, reinterpret_cast<void*>(&HookRenGetBuffer),
+        patchSlot(obj, kSlotBufferGetBuffer, reinterpret_cast<void*>(&HookRenGetBuffer),
                   reinterpret_cast<void**>(&g_renGet));
-        patchSlot(obj, 4, reinterpret_cast<void*>(&HookRenReleaseBuffer),
+        patchSlot(obj, kSlotBufferReleaseBuffer, reinterpret_cast<void*>(&HookRenReleaseBuffer),
                   reinterpret_cast<void**>(&g_renRel));
     } else if (iid == __uuidof(ISimpleAudioVolume)) {
         patchSlot(obj, 3, reinterpret_cast<void*>(&HookVolGet), reinterpret_cast<void**>(&g_volGet));
@@ -387,23 +386,65 @@ HRESULT STDMETHODCALLTYPE HookSetClientProperties(IAudioClient2* self,
     return hr;
 }
 
+HRESULT STDMETHODCALLTYPE HookInitShared(IAudioClient3* self, DWORD flags, UINT32 period,
+                                         const WAVEFORMATEX* fmt, LPCGUID session) {
+    const HRESULT hr =
+        g_initShared ? g_initShared(self, flags, period, fmt, session) : E_UNEXPECTED;
+    CallPod p{};
+    p.streamId = sid(self);
+    copyStr(p.iface, sizeof(p.iface), "IAudioClient3");
+    copyStr(p.method, sizeof(p.method), "InitializeSharedAudioStream");
+    char wave[64] = {};
+    formatWave(fmt, wave, sizeof(wave));
+    sprintf_s(p.args, "flags=0x%lX period=%u fmt=%s", static_cast<unsigned long>(flags), period,
+              wave);
+    p.hresult = static_cast<int32_t>(hr);
+    p.hasExclusive = 1;
+    p.exclusive = 0;
+    p.hasFormat = 1;
+    copyStr(p.format, sizeof(p.format), wave);
+    emit(p);
+    (void)session;
+    return hr;
+}
+
 void patchClient(void* obj) {
     if (!obj) return;
-    patchSlot(obj, 3, reinterpret_cast<void*>(&HookInitialize), reinterpret_cast<void**>(&g_initialize));
-    patchSlot(obj, 10, reinterpret_cast<void*>(&HookStart), reinterpret_cast<void**>(&g_start));
-    patchSlot(obj, 11, reinterpret_cast<void*>(&HookStop), reinterpret_cast<void**>(&g_stop));
-    patchSlot(obj, 12, reinterpret_cast<void*>(&HookReset), reinterpret_cast<void**>(&g_reset));
-    patchSlot(obj, 13, reinterpret_cast<void*>(&HookSetEventHandle),
+    using wa::hook_ipc::kSlotClientInitialize;
+    using wa::hook_ipc::kSlotClientStart;
+    using wa::hook_ipc::kSlotClientStop;
+    using wa::hook_ipc::kSlotClientReset;
+    using wa::hook_ipc::kSlotClientSetEventHandle;
+    using wa::hook_ipc::kSlotClientGetService;
+    using wa::hook_ipc::kSlotClientSetProperties;
+    using wa::hook_ipc::kSlotClientInitializeShared;
+    patchSlot(obj, kSlotClientInitialize, reinterpret_cast<void*>(&HookInitialize),
+              reinterpret_cast<void**>(&g_initialize));
+    patchSlot(obj, kSlotClientStart, reinterpret_cast<void*>(&HookStart),
+              reinterpret_cast<void**>(&g_start));
+    patchSlot(obj, kSlotClientStop, reinterpret_cast<void*>(&HookStop),
+              reinterpret_cast<void**>(&g_stop));
+    patchSlot(obj, kSlotClientReset, reinterpret_cast<void*>(&HookReset),
+              reinterpret_cast<void**>(&g_reset));
+    patchSlot(obj, kSlotClientSetEventHandle, reinterpret_cast<void*>(&HookSetEventHandle),
               reinterpret_cast<void**>(&g_setEvent));
-    patchSlot(obj, 14, reinterpret_cast<void*>(&HookGetService),
+    patchSlot(obj, kSlotClientGetService, reinterpret_cast<void*>(&HookGetService),
               reinterpret_cast<void**>(&g_getService));
     IAudioClient2* c2 = nullptr;
     if (SUCCEEDED(static_cast<IUnknown*>(obj)->QueryInterface(__uuidof(IAudioClient2),
                                                               reinterpret_cast<void**>(&c2))) &&
         c2) {
-        patchSlot(c2, 16, reinterpret_cast<void*>(&HookSetClientProperties),
+        patchSlot(c2, kSlotClientSetProperties, reinterpret_cast<void*>(&HookSetClientProperties),
                   reinterpret_cast<void**>(&g_setProps));
         c2->Release();
+    }
+    IAudioClient3* c3 = nullptr;
+    if (SUCCEEDED(static_cast<IUnknown*>(obj)->QueryInterface(__uuidof(IAudioClient3),
+                                                              reinterpret_cast<void**>(&c3))) &&
+        c3) {
+        patchSlot(c3, kSlotClientInitializeShared, reinterpret_cast<void*>(&HookInitShared),
+                  reinterpret_cast<void**>(&g_initShared));
+        c3->Release();
     }
 }
 
@@ -425,7 +466,26 @@ HRESULT STDMETHODCALLTYPE HookActivate(IMMDevice* self, REFIID iid, DWORD ctx, P
 
 void patchDevice(IMMDevice* dev) {
     if (!dev) return;
-    patchSlot(dev, 3, reinterpret_cast<void*>(&HookActivate), reinterpret_cast<void**>(&g_activate));
+    patchSlot(dev, wa::hook_ipc::kSlotDeviceActivate, reinterpret_cast<void*>(&HookActivate),
+              reinterpret_cast<void**>(&g_activate));
+}
+
+HRESULT STDMETHODCALLTYPE HookEnum(IMMDeviceEnumerator* self, EDataFlow flow, DWORD mask,
+                                   IMMDeviceCollection** col) {
+    const HRESULT hr = g_enum ? g_enum(self, flow, mask, col) : E_UNEXPECTED;
+    if (SUCCEEDED(hr) && col && *col) {
+        UINT n = 0;
+        if (SUCCEEDED((*col)->GetCount(&n))) {
+            for (UINT i = 0; i < n; ++i) {
+                IMMDevice* d = nullptr;
+                if (SUCCEEDED((*col)->Item(i, &d)) && d) {
+                    patchDevice(d);
+                    d->Release();
+                }
+            }
+        }
+    }
+    return hr;
 }
 
 HRESULT STDMETHODCALLTYPE HookGetDevice(IMMDeviceEnumerator* self, LPCWSTR id, IMMDevice** device) {
@@ -441,67 +501,97 @@ HRESULT STDMETHODCALLTYPE HookGetDefault(IMMDeviceEnumerator* self, EDataFlow fl
     return hr;
 }
 
-void tryActivate(IMMDevice* dev, REFIID iid) {
+// Activate without Initialize so we patch the shared IAudioClient vtable
+// without opening a dummy stream in the target.
+void tryActivate(IMMDevice* dev) {
     if (!dev) return;
     patchDevice(dev);
-    void* client = nullptr;
-    HRESULT hr = dev->Activate(iid, CLSCTX_ALL, nullptr, &client);
-    if (SUCCEEDED(hr) && client) {
-        patchClient(client);
-        static_cast<IUnknown*>(client)->Release();
+    void* raw = nullptr;
+    if (SUCCEEDED(dev->Activate(__uuidof(IAudioClient), CLSCTX_ALL, nullptr, &raw)) && raw) {
+        patchClient(raw);
+        static_cast<IUnknown*>(raw)->Release();
     }
-    (void)hr;
 }
 
-void install() {
+void patchAllDevices(IMMDeviceEnumerator* enumer, EDataFlow flow) {
+    if (!enumer) return;
+    IMMDeviceCollection* col = nullptr;
+    if (FAILED(enumer->EnumAudioEndpoints(flow, DEVICE_STATE_ACTIVE, &col)) || !col) return;
+    UINT n = 0;
+    if (SUCCEEDED(col->GetCount(&n))) {
+        for (UINT i = 0; i < n; ++i) {
+            IMMDevice* d = nullptr;
+            if (SUCCEEDED(col->Item(i, &d)) && d) {
+                patchDevice(d);
+                d->Release();
+            }
+        }
+    }
+    col->Release();
+}
+
+bool install() {
     InterlockedExchange(&g_quiet, 1);
     HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
     const bool needUninit = (hr == S_OK);
-    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) return;
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+        InterlockedExchange(&g_quiet, 0);
+        return false;
+    }
 
+    bool ok = false;
     IMMDeviceEnumerator* enumer = nullptr;
     hr = CoCreateInstance(__uuidof(MMDeviceEnumerator), nullptr, CLSCTX_ALL,
                           __uuidof(IMMDeviceEnumerator), reinterpret_cast<void**>(&enumer));
     if (SUCCEEDED(hr) && enumer) {
-        patchSlot(enumer, 4, reinterpret_cast<void*>(&HookGetDefault),
-                  reinterpret_cast<void**>(&g_getDefault));
-        patchSlot(enumer, 5, reinterpret_cast<void*>(&HookGetDevice),
-                  reinterpret_cast<void**>(&g_getDevice));
-        IMMDevice* cap = nullptr;
-        IMMDevice* ren = nullptr;
-        enumer->GetDefaultAudioEndpoint(eCapture, eConsole, &cap);
-        enumer->GetDefaultAudioEndpoint(eRender, eConsole, &ren);
-        if (cap) {
-            tryActivate(cap, __uuidof(IAudioClient));
-            tryActivate(cap, __uuidof(IAudioClient2));
-            cap->Release();
+        const bool patchedEnum =
+            patchSlot(enumer, wa::hook_ipc::kSlotEnumeratorEnumEndpoints,
+                      reinterpret_cast<void*>(&HookEnum), reinterpret_cast<void**>(&g_enum)) &&
+            patchSlot(enumer, wa::hook_ipc::kSlotEnumeratorGetDefault,
+                      reinterpret_cast<void*>(&HookGetDefault),
+                      reinterpret_cast<void**>(&g_getDefault)) &&
+            patchSlot(enumer, wa::hook_ipc::kSlotEnumeratorGetDevice,
+                      reinterpret_cast<void*>(&HookGetDevice),
+                      reinterpret_cast<void**>(&g_getDevice));
+        patchAllDevices(enumer, eCapture);
+        patchAllDevices(enumer, eRender);
+
+        const bool capture = !g_ring || g_ring->flow == 0;
+        IMMDevice* chosen = nullptr;
+        if (g_ring && g_ring->deviceId[0])
+            enumer->GetDevice(g_ring->deviceId, &chosen);
+        if (!chosen) {
+            enumer->GetDefaultAudioEndpoint(capture ? eCapture : eRender, eConsole, &chosen);
         }
-        if (ren) {
-            tryActivate(ren, __uuidof(IAudioClient));
-            tryActivate(ren, __uuidof(IAudioClient2));
-            ren->Release();
+        if (chosen) {
+            tryActivate(chosen);
+            chosen->Release();
         }
         enumer->Release();
+        ok = patchedEnum;
     }
     if (needUninit) CoUninitialize();
     InterlockedExchange(&g_quiet, 0);
+    return ok;
 }
 
 DWORD WINAPI HookThread(LPVOID) {
-    wchar_t name[64] = {};
-    wa::hook_ipc::mapName(GetCurrentProcessId(), name, 64);
-    g_map = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0,
-                               sizeof(Ring), name);
+    g_map = wa::hook_ipc::createHookMapping(GetCurrentProcessId());
     if (!g_map) return 1;
     g_ring = static_cast<Ring*>(MapViewOfFile(g_map, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(Ring)));
-    if (!g_ring) return 1;
+    if (!g_ring) {
+        CloseHandle(g_map);
+        g_map = nullptr;
+        return 1;
+    }
     if (g_ring->magic != kMagic) {
         ZeroMemory(g_ring, sizeof(Ring));
         g_ring->magic = kMagic;
         g_ring->cap = kCap;
         g_ring->writeIndex = 0;
+        g_ring->installed = kInstallPending;
     }
-    install();
+    g_ring->installed = install() ? kInstallOk : kInstallFailed;
     return 0;
 }
 

--- a/src/tests/test_hooked_call.cpp
+++ b/src/tests/test_hooked_call.cpp
@@ -79,6 +79,22 @@ TEST(CallLog, NeverLeavesPcmInArgs) {
     EXPECT_NE(log.entries[0].args.find("share=shared"), std::string::npos);
 }
 
+TEST(CallLog, InitializeSharedAudioStreamOverridesEtwFormat) {
+    HookedCall c;
+    c.iface = "IAudioClient3";
+    c.method = "InitializeSharedAudioStream";
+    c.args = "flags=0x0 period=480 fmt=48000/32f/2";
+    c.hresult = 0;
+    c.exclusive = false;
+    c.format = std::string("48000/32f/2");
+    const auto hint = extractHookedInitialize({c});
+    EXPECT_TRUE(hint.present);
+    ASSERT_TRUE(hint.format.has_value());
+    EXPECT_EQ(*hint.format, "48000/32f/2");
+    ASSERT_TRUE(hint.hresult.has_value());
+    EXPECT_EQ(*hint.hresult, 0);
+}
+
 TEST(HookedJoin, InitializeOverridesEtwCategoryAndRaw) {
     EtwInitializeHint etw;
     etw.present = true;

--- a/src/tests/test_live_session_list.cpp
+++ b/src/tests/test_live_session_list.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <string>
 #include "AppUiText.h"
 #include "EtwInitialize.h"
 #include "OnDemandAttach.h"
@@ -57,6 +58,22 @@ TEST(LiveSessionList, KeepsSamePidOnDifferentDevices) {
     ASSERT_EQ(rows.size(), 2u);
 }
 
+TEST(LiveSessionList, TooltipKeepsProcessAndDeviceWhenCellsClip) {
+    LiveSessionView s = row(25060, "chrome.exe", "Headset Microphone (Realtek(R) Audio)",
+                            PipelineFlow::Capture);
+    s.sessionVolume = 0.75f;
+    s.sessionMute = true;
+    s.state = "Active";
+    const std::string tip = wa::ui_text::formatLiveSessionTooltip(s);
+    EXPECT_NE(tip.find("chrome.exe"), std::string::npos);
+    EXPECT_NE(tip.find("25060"), std::string::npos);
+    EXPECT_NE(tip.find("Headset Microphone (Realtek(R) Audio)"), std::string::npos);
+    EXPECT_NE(tip.find(wa::ui_text::kPipelineFlowCapture), std::string::npos);
+    EXPECT_NE(tip.find("0.75"), std::string::npos);
+    EXPECT_NE(tip.find(wa::ui_text::kPipelineMuteYes), std::string::npos);
+    EXPECT_NE(tip.find("Active"), std::string::npos);
+}
+
 TEST(LiveSessionList, SortsByNameThenPidThenFlowThenDevice) {
     std::vector<LiveSessionView> rows = {
         row(20, "zoom.exe", "mic", PipelineFlow::Capture),
@@ -95,6 +112,20 @@ TEST(PipelineUiText, ExposesPipelineTabControls) {
     EXPECT_STREQ(wa::ui_text::kPipelineAttached, "Attached");
     EXPECT_STREQ(wa::ui_text::kPipelineCallLogEmpty,
                  "No control-path calls yet. Attach to intercept Core Audio COM.");
+    EXPECT_STREQ(wa::ui_text::pipelineCallLogEmptyText(false, false),
+                 wa::ui_text::kPipelineCallLogEmpty);
+    EXPECT_STREQ(wa::ui_text::pipelineCallLogEmptyText(false, true),
+                 wa::ui_text::kPipelineCallLogEmpty);
+    EXPECT_STREQ(wa::ui_text::pipelineCallLogEmptyText(true, false),
+                 wa::ui_text::kPipelineCallLogWaiting);
+    EXPECT_STREQ(wa::ui_text::pipelineCallLogEmptyText(true, true),
+                 wa::ui_text::kPipelineCallLogWaitingPump);
+    EXPECT_NE(std::string(wa::ui_text::kPipelineCallLogWaiting).find("Initialize"),
+              std::string::npos);
+    EXPECT_NE(std::string(wa::ui_text::kPipelineCallLogWaiting).find("Record pump metadata"),
+              std::string::npos);
+    EXPECT_NE(std::string(wa::ui_text::kPipelineCallLogWaitingPump).find("Core Audio COM"),
+              std::string::npos);
     EXPECT_STREQ(wa::attachBlockText(wa::AttachBlock::CrossBitness),
                  wa::ui_text::kPipelineCrossBitness);
     EXPECT_STREQ(wa::attachBlockText(wa::AttachBlock::NoDebugRights),

--- a/src/tests/test_on_demand_attach.cpp
+++ b/src/tests/test_on_demand_attach.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "HookedCallPod.h"
 #include "OnDemandAttach.h"
 
 using namespace wa;
@@ -36,4 +37,80 @@ TEST(OnDemandAttach, DoesNotLaunchSuspendedOrAutoInject) {
     // for one PID. This test locks the public flags.
     EXPECT_FALSE(kAttachLaunchSuspended);
     EXPECT_FALSE(kAttachAutoInject);
+}
+
+TEST(OnDemandAttach, RemoteLoadLibraryNullModuleFailsClosed) {
+    EXPECT_FALSE(remoteLoadLibrarySucceeded(0, 0));
+}
+
+TEST(OnDemandAttach, RemoteLoadLibraryTimeoutFailsClosed) {
+    EXPECT_FALSE(remoteLoadLibrarySucceeded(258, 0x1000));
+}
+
+TEST(OnDemandAttach, RemoteLoadLibraryNonZeroModuleSucceeds) {
+    EXPECT_TRUE(remoteLoadLibrarySucceeded(0, 0x00007FFC));
+}
+
+TEST(VtablePatch, ReplacesSlotAndKeepsOriginal) {
+    void* origFn = reinterpret_cast<void*>(static_cast<uintptr_t>(0x1));
+    void* hookFn = reinterpret_cast<void*>(static_cast<uintptr_t>(0x2));
+    void* vt[4] = {nullptr, nullptr, nullptr, origFn};
+    struct Obj {
+        void** vtable;
+    } obj{vt};
+    void* saved = nullptr;
+    ASSERT_TRUE(hook_ipc::patchVtableSlot(&obj, 3, hookFn, &saved));
+    EXPECT_EQ(saved, origFn);
+    EXPECT_EQ(vt[3], hookFn);
+}
+
+TEST(VtablePatch, IAudioClient3InitializeSharedSlotIs20) {
+    EXPECT_EQ(hook_ipc::kSlotClientInitializeShared, 20);
+    EXPECT_EQ(hook_ipc::kSlotClientGetService, 14);
+    EXPECT_EQ(hook_ipc::kSlotBufferGetBuffer, 3);
+}
+
+TEST(OnDemandAttach, InstallFailMessageUsesSnapshotNotMappedRing) {
+    EXPECT_STREQ(attachInstallFailMessage(hook_ipc::kInstallFailed),
+                 "Attach: hook install failed in target");
+    EXPECT_STREQ(attachInstallFailMessage(hook_ipc::kInstallPending),
+                 "Attach: hook install did not finish; restart the target app and retry");
+}
+
+TEST(OnDemandAttach, SnapshotSurvivesUnmap) {
+    HANDLE map = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, 4096, nullptr);
+    ASSERT_TRUE(map);
+    auto* view = static_cast<uint32_t*>(MapViewOfFile(map, FILE_MAP_ALL_ACCESS, 0, 0, 4096));
+    ASSERT_TRUE(view);
+    *view = hook_ipc::kInstallFailed;
+    const uint32_t installed = *view;
+    UnmapViewOfFile(view);
+    CloseHandle(map);
+    EXPECT_STREQ(attachInstallFailMessage(installed), "Attach: hook install failed in target");
+}
+
+TEST(OnDemandAttach, MapNameIncludesLayoutVersion) {
+    wchar_t name[64] = {};
+    hook_ipc::mapName(25060, name, 64);
+    EXPECT_STREQ(name, L"Local\\WinAudioHook-2-25060");
+}
+
+TEST(OnDemandAttach, StagedHookFileNameFollowsLayout) {
+    EXPECT_EQ(stagedHookFileName(), L"WinAudioHook-2.dll");
+}
+
+TEST(OnDemandAttach, CreateHookMappingIsVisibleInSameProcess) {
+    const uint32_t pid = 424242u;
+    HANDLE a = hook_ipc::createHookMapping(pid);
+    ASSERT_TRUE(a);
+    HANDLE b = hook_ipc::createHookMapping(pid);
+    ASSERT_TRUE(b);
+    EXPECT_EQ(GetLastError(), static_cast<DWORD>(ERROR_ALREADY_EXISTS));
+    auto* ring = static_cast<hook_ipc::Ring*>(
+        MapViewOfFile(b, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(hook_ipc::Ring)));
+    ASSERT_TRUE(ring);
+    ring->magic = hook_ipc::kMagic;
+    UnmapViewOfFile(ring);
+    CloseHandle(b);
+    CloseHandle(a);
 }


### PR DESCRIPTION
## What / Why

Pipeline Attach could report success while the Call log stayed empty: the GUI's hook mapping was invisible across integrity levels, a null `LoadLibraryW` module was treated as success, and there was no handshake that vtables had been installed. Live session Process/Device cells also clipped with no way to read the full row.

This PR makes Attach fail closed when inject or hook install fails, shares the mapping with a Low mandatory label so an elevated GUI can still talk to a medium-IL target (and the reverse), and adds a full-row hover on the Live session list.

Refs #63. Design: `docs/superpowers/specs/2026-08-25-pipeline-inspector-prd.md` (stories 3, 25–34, 41–43) and ADR-0002.

## How

- The GUI creates the inject mapping first (`Local\WinAudioHook-<layout>-<pid>`) with Everyone + Low mandatory label, then injects a layout-versioned staged hook DLL (`WinAudioHook-2.dll`) so a rebuilt hook can load while an old copy is still mapped in the target.
- Attach waits for an install handshake. `LoadLibraryW` returning a null module, a timed-out inject, or `installed != ok` fail closed with a banner; radar / graph / probe / ETW still run.
- The hook patches enumerator + device Activate and `Activate`s the selected endpoint only to patch the shared `IAudioClient` vtable. It does **not** `Initialize` a dummy stream in the target. `IAudioClient3::InitializeSharedAudioStream` is intercepted and overrides ETW format like `Initialize`.
- Call log empty copy distinguishes not-attached / attached-waiting-control-path / attached-with-pump. Pump metadata stays default-off and never stores PCM.
- Known limit: if the hook DLL is already loaded in the target, a failed install needs a target restart (DllMain will not run again). Pump `GetBuffer`/`ReleaseBuffer` on a stream that already called `GetService` before attach appear only after a later `GetService`.

## Testing

- Local Debug: `test.bat Debug` — **322/322 passed**.
- Local Release: `test.bat Release` — **322/322 passed**.
- Targeted: `OnDemandAttach.*`, `VtablePatch.*`, `LiveSessionList.*`, `PipelineUiText.*`, `CallLog.*`, `HookedJoin.*`.
- Device-free tests cover mapping name/layout, LoadLibrary fail-closed, install-message snapshot after unmap, tooltip copy, and `InitializeSharedAudioStream` join. They do not inject into live processes.
- GUI: no screenshot. Real-device Attach smoke not recorded in this session.

## Checklist

- [x] Commits follow Conventional Commits and are atomic (each builds and passes tests)
- [x] `test.bat Debug` and `test.bat Release` pass locally
- [x] New core logic has gtest coverage that runs without real audio devices
- [ ] GUI changes: screenshots attached
- [ ] Real-device behavior touched: manual smoke done (CLI `monitor` or GUI), result stated above
